### PR TITLE
fix: clear extension storage when disconnecting the wallet

### DIFF
--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -12,10 +12,10 @@ const defaultStorage = {
   connected: false,
   enabled: true,
   exceptionList: {},
-  walletAddress: undefined,
-  amount: undefined,
-  token: undefined,
-  grant: undefined
+  walletAddress: null,
+  amount: null,
+  token: null,
+  grant: null,
 } satisfies Omit<Storage, 'publicKey' | 'privateKey' | 'keyId'>
 
 export class StorageService {

--- a/src/popup/lib/context.tsx
+++ b/src/popup/lib/context.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { getContextData } from '@/popup/lib/messages'
-import { PopupStore } from '@/shared/types'
+import { DeepNonNullable, PopupStore } from '@/shared/types'
 
 export enum ReducerActionType {
   SET_DATA = 'SET_DATA',
   TOGGLE_WM = 'TOGGLE_WM'
 }
 
-export type PopupState = Required<NonNullable<PopupStore>>
+export type PopupState = Required<DeepNonNullable<PopupStore>>
 
 export interface PopupContext {
   state: Required<NonNullable<PopupState>>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,3 +58,8 @@ export type PopupStore = Omit<
 > & {
   website: WebsiteData
 }
+
+export type DeepNonNullable<T> = {
+        [P in keyof T]?: NonNullable<T[P]>;
+}
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,13 +34,13 @@ export interface Storage {
   /** If a wallet is connected or not */
   connected: boolean
   /** User wallet address information */
-  walletAddress?: WalletAddress | undefined
+  walletAddress?: WalletAddress | undefined | null
   /** Overall amount */
-  amount?: WalletAmount | undefined
+  amount?: WalletAmount | undefined | null
   /** Access token for quoting & outgoing payments  */
-  token?: AccessToken | undefined
+  token?: AccessToken | undefined | null
   /** Grant details - continue access token & uri for canceling the grant */
-  grant?: GrantDetails | undefined
+  grant?: GrantDetails | undefined | null
   /** Exception list with websites and each specific amount */
   exceptionList: {
     [website: string]: Amount


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes #173, #108.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
Initially, we attempted to reset the values by changing them back to `undefined` when clearing the storage, but this approach didn't actually change their values. We need to set them as `null` to properly clear the storage.