### PR TITLE
chore: default project name for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,6 +2,7 @@ name: Bug report
 description: File a bug report
 title: '[BUG] '
 labels: ['bug', 'triage']
+projects: ['https://github.com/interledger/web-monetization-extension']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Set the default project name for the WM extension when reporting a bug.

## Context

When a user reports a bug, the template already sets the default labels to "triage" and "bug", however the project name was left as blank. 

## Changes proposed in this pull request

Update the bug report template to default the project name to WM extension, when a bug is reported.