### PR TITLE
perf(popup/Home): debounce setting rate of pay

### DIFF
--- a/src/popup/pages/Home.tsx
+++ b/src/popup/pages/Home.tsx
@@ -2,10 +2,13 @@ import React from 'react'
 import { PopupStateContext, ReducerActionType } from '@/popup/lib/context'
 import { WarningSign } from '@/popup/components/Icons'
 import { Slider } from '../components/ui/Slider'
-import { updateRateOfPay } from '../lib/messages'
+import { updateRateOfPay as updateRateOfPay_ } from '../lib/messages'
 import { Label } from '../components/ui/Label'
 import { getCurrencySymbol, roundWithPrecision } from '../lib/utils'
+import { debounceAsync } from '@/shared/helpers'
 import { PayWebsiteForm } from '../components/PayWebsiteForm'
+
+const updateRateOfPay = debounceAsync(updateRateOfPay_, 500);
 
 export const Component = () => {
   const {
@@ -29,19 +32,18 @@ export const Component = () => {
     return r.toExponential()
   }, [rateOfPay, walletAddress.assetScale])
 
-  // TODO: Use a debounce
   const onRateChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const rateOfPay = event.currentTarget.value
-    const response = await updateRateOfPay({
-      rateOfPay
-    })
-    if (!response.success) return
     dispatch({
       type: ReducerActionType.UPDATE_RATE_OF_PAY,
       data: {
         rateOfPay
       }
     })
+    const response = await updateRateOfPay({ rateOfPay })
+    if (!response.success) {
+      // TODO: Maybe reset to old state, but not while user is active (avoid jank)
+    }
   }
 
   return (

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -71,3 +71,19 @@ export const notNullOrUndef = <T>(
     return t
   }
 }
+
+export function debounceAsync<T extends unknown[], R extends Promise<unknown>>(
+  func: (...args: T) => R,
+  wait: number
+) {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  return function (...args: T) {
+    return new Promise<Awaited<R>>((resolve) => {
+      if (timeout != null) clearTimeout(timeout)
+      timeout = setTimeout(() => {
+        timeout = null
+        void Promise.resolve(func(...args)).then(resolve)
+      }, wait)
+    })
+  }
+}


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Saw a TODO in code, decided to clear it.

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->


## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Adds a `debounceAsync` helper and use it. Doesn't debounce `onRateChange` as we want UI to be updated smoothly. Can probably add a 30ms debounce on it, but I think not needed.

[Screencast from 16-05-24 07:31:07 PM IST.webm](https://github.com/interledger/web-monetization-extension/assets/8426945/8afc4d7e-a404-4f43-9fc9-cdbe17056b75)

Demo has timeout set to 1500ms