### PR TITLE
fix(background/storage): set default `hasHostPermissions` to true

### DIFF
--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -6,7 +6,7 @@ import { EventsService } from './events'
 const defaultStorage = {
   connected: false,
   enabled: true,
-  hasHostPermissions: false,
+  hasHostPermissions: true,
   exceptionList: {},
   walletAddress: null,
   amount: null,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

On clicking disconnect, as we clear the storage, the popup shows the permission prompt again, even if we have the permissions.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Set default state to `true`, so popup doesn't show permission prompt. We'll ask again if we don't have permissions after popup opens again.