### PR TITLE
fix(background): ensure default storage is populated; fix popup crash

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -168,7 +168,7 @@ export class Background {
         await this.storage.populate()
         await this.openPaymentsService.genererateKeys()
       }
-      this.checkPermissions()
+      await this.checkPermissions()
     })
   }
 

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -153,19 +153,8 @@ export class Background {
   }
 
   bindPermissionsHandler() {
-    const permissions = this.browser.permissions
-    const checkPermissions = async () => {
-      try {
-        const status = await permissions.contains(PERMISSION_HOSTS)
-        this.storage.setHostPermissionStatus(status)
-      } catch (error) {
-        this.logger.error(error)
-      }
-    }
-
-    void checkPermissions()
-    permissions.onAdded.addListener(checkPermissions)
-    permissions.onRemoved.addListener(checkPermissions)
+    this.browser.permissions.onAdded.addListener(this.checkPermissions)
+    this.browser.permissions.onRemoved.addListener(this.checkPermissions)
     this.events.on('storage.host_permissions_update', async ({ status }) => {
       this.logger.info('permission changed', { status })
       // TODO: change icon here in future
@@ -179,6 +168,17 @@ export class Background {
         await this.storage.populate()
         await this.openPaymentsService.genererateKeys()
       }
+      this.checkPermissions()
     })
+  }
+
+  checkPermissions = async () => {
+    try {
+      this.logger.debug('checking hosts permission')
+      const status = await this.browser.permissions.contains(PERMISSION_HOSTS)
+      this.storage.setHostPermissionStatus(status)
+    } catch (error) {
+      this.logger.error(error)
+    }
   }
 }

--- a/src/popup/components/ProtectedRoute.tsx
+++ b/src/popup/components/ProtectedRoute.tsx
@@ -9,7 +9,7 @@ export const ProtectedRoute = () => {
   if (!state.hasHostPermissions) {
     return <Navigate to={ROUTES_PATH.MISSING_HOST_PERMISSION} />
   }
-  if (state.connected === false) {
+  if (!state.connected) {
     return <Navigate to={ROUTES_PATH.SETTINGS} />
   }
 

--- a/src/popup/components/ProtectedRoute.tsx
+++ b/src/popup/components/ProtectedRoute.tsx
@@ -9,7 +9,7 @@ export const ProtectedRoute = () => {
   if (!state.hasHostPermissions) {
     return <Navigate to={ROUTES_PATH.MISSING_HOST_PERMISSION} />
   }
-  if (!state.connected) {
+  if (state.connected === false) {
     return <Navigate to={ROUTES_PATH.SETTINGS} />
   }
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Fixes https://github.com/interledger/web-monetization-extension/issues/330

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Race condition and an unseen check on the conditions for when we populate storage.
Now, we call `storage.setHostPermissionStatus` only after `storage.populate` is called.