### PR TITLE
fix: ensure correct icon is reflected for monetization state

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -90,7 +90,7 @@ export class Background {
 
             case PopupToBackgroundAction.TOGGLE_WM:
               await this.monetizationService.toggleWM()
-              await this.tabEvents.onUpdatedTab(null, sender)
+              await this.tabEvents.onUpdatedTab()
               return
 
             case PopupToBackgroundAction.PAY_WEBSITE:

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -90,8 +90,7 @@ export class Background {
 
             case PopupToBackgroundAction.TOGGLE_WM:
               await this.monetizationService.toggleWM()
-
-              this.tabEvents.onUpdatedTab()
+              await this.tabEvents.onUpdatedTab()
               return
 
             case PopupToBackgroundAction.PAY_WEBSITE:
@@ -112,7 +111,7 @@ export class Background {
               return
 
             case ContentToBackgroundAction.STOP_MONETIZATION:
-              this.monetizationService.stopPaymentSession(
+              await this.monetizationService.stopPaymentSession(
                 message.payload,
                 sender
               )
@@ -131,7 +130,10 @@ export class Background {
               )
 
             case ContentToBackgroundAction.IS_TAB_MONETIZED:
-              this.tabEvents.onUpdatedTab(message.payload)
+              await this.tabEvents.onUpdatedTab({
+                ...message.payload,
+                tabId: sender.tab!.id!
+              })
               return
 
             case ContentToBackgroundAction.IS_WM_ENABLED:

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -90,7 +90,7 @@ export class Background {
 
             case PopupToBackgroundAction.TOGGLE_WM:
               await this.monetizationService.toggleWM()
-              await this.tabEvents.onUpdatedTab()
+              await this.tabEvents.onUpdatedTab(null, sender)
               return
 
             case PopupToBackgroundAction.PAY_WEBSITE:
@@ -130,10 +130,7 @@ export class Background {
               )
 
             case ContentToBackgroundAction.IS_TAB_MONETIZED:
-              await this.tabEvents.onUpdatedTab({
-                ...message.payload,
-                tabId: sender.tab!.id!
-              })
+              await this.tabEvents.onUpdatedTab(message.payload, sender)
               return
 
             case ContentToBackgroundAction.IS_WM_ENABLED:

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -59,17 +59,20 @@ export class TabEvents {
   ) => {
     const { enabled } = await this.storage.get(['enabled'])
 
-    let iconData = enabled
-      ? { '34': icon34, '128': icon128 }
-      : { '34': iconWarning34, '128': iconWarning128 }
-
+    let iconData = {
+      '34': enabled ? icon34 : iconWarning34,
+      '128': enabled ? icon34 : iconWarning128
+    }
     let tabId
-    if (enabled && payload) {
-      const { value: isTabMonetized } = payload
-      tabId = payload.tabId
-      iconData = isTabMonetized
-        ? { '34': iconActive34, '128': iconActive128 }
-        : { '34': iconInactive34, '128': iconInactive128 }
+    if (enabled) {
+      if (payload) {
+        const { value } = payload
+        tabId = payload.tabId
+        iconData = {
+          '34': value ? iconActive34 : iconInactive34,
+          '128': value ? iconActive128 : iconInactive128
+        }
+      }
     }
 
     await this.browser.action.setIcon({ path: iconData, tabId })

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -54,29 +54,24 @@ export class TabEvents {
     await this.changeIcon()
   }
 
-  onUpdatedTab = async (payload?: IsTabMonetizedPayload) => {
+  onUpdatedTab = async (
+    payload?: IsTabMonetizedPayload & { tabId: number }
+  ) => {
     const { enabled } = await this.storage.get(['enabled'])
 
-    let iconData = {
-      '34': enabled ? icon34 : iconWarning34,
-      '128': enabled ? icon34 : iconWarning128
+    let iconData = enabled
+      ? { '34': icon34, '128': icon128 }
+      : { '34': iconWarning34, '128': iconWarning128 }
+
+    let tabId
+    if (enabled && payload) {
+      const { value: isTabMonetized } = payload
+      tabId = payload.tabId
+      iconData = isTabMonetized
+        ? { '34': iconActive34, '128': iconActive128 }
+        : { '34': iconInactive34, '128': iconInactive128 }
     }
 
-    if (enabled) {
-      if (payload) {
-        const { value } = payload
-
-        iconData = {
-          '34': value ? iconActive34 : iconInactive34,
-          '128': value ? iconActive128 : iconInactive128
-        }
-      }
-    }
-
-    if (this.browser.action) {
-      await this.browser.action.setIcon({ path: iconData })
-    } else if (chrome.browserAction) {
-      chrome.browserAction.setIcon({ path: iconData })
-    }
+    await this.browser.action.setIcon({ path: iconData, tabId })
   }
 }

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -4,14 +4,24 @@ import { StorageService } from './storage'
 import { IsTabMonetizedPayload } from '@/shared/messages'
 
 const runtime = browser.runtime
-const icon34 = runtime.getURL('assets/icons/icon-34.png')
-const icon128 = runtime.getURL('assets/icons/icon-128.png')
-const iconActive34 = runtime.getURL('assets/icons/icon-active-34.png')
-const iconActive128 = runtime.getURL('assets/icons/icon-active-128.png')
-const iconInactive34 = runtime.getURL('assets/icons/icon-inactive-34.png')
-const iconInactive128 = runtime.getURL('assets/icons/icon-inactive-128.png')
-const iconWarning34 = runtime.getURL('assets/icons/icon-warning-34.png')
-const iconWarning128 = runtime.getURL('assets/icons/icon-warning-128.png')
+const ICONS = {
+  default: {
+    34: runtime.getURL('assets/icons/icon-34.png'),
+    128: runtime.getURL('assets/icons/icon-128.png')
+  },
+  active: {
+    34: runtime.getURL('assets/icons/icon-active-34.png'),
+    128: runtime.getURL('assets/icons/icon-active-128.png')
+  },
+  inactive: {
+    34: runtime.getURL('assets/icons/icon-inactive-34.png'),
+    128: runtime.getURL('assets/icons/icon-inactive-128.png')
+  },
+  warning: {
+    34: runtime.getURL('assets/icons/icon-warning-34.png'),
+    128: runtime.getURL('assets/icons/icon-warning-128.png')
+  }
+}
 
 export class TabEvents {
   constructor(
@@ -33,17 +43,8 @@ export class TabEvents {
 
   private changeIcon = async () => {
     const { enabled } = await this.storage.get(['enabled'])
-
-    const iconData = {
-      '34': enabled ? icon34 : iconWarning34,
-      '128': enabled ? icon128 : iconWarning128
-    }
-
-    if (this.browser.action) {
-      await this.browser.action.setIcon({ path: iconData })
-    } else if (chrome.browserAction) {
-      chrome.browserAction.setIcon({ path: iconData })
-    }
+    const iconData = enabled ? ICONS.default : ICONS.warning
+    await this.browser.action.setIcon({ path: iconData })
   }
 
   onActivatedTab = async () => {
@@ -59,19 +60,13 @@ export class TabEvents {
   ) => {
     const { enabled } = await this.storage.get(['enabled'])
 
-    let iconData = {
-      '34': enabled ? icon34 : iconWarning34,
-      '128': enabled ? icon34 : iconWarning128
-    }
+    let iconData = enabled ? ICONS.default : ICONS.warning
     let tabId
     if (enabled) {
       if (payload) {
         const { value } = payload
         tabId = payload.tabId
-        iconData = {
-          '34': value ? iconActive34 : iconInactive34,
-          '128': value ? iconActive128 : iconInactive128
-        }
+        iconData = value ? ICONS.active : ICONS.inactive
       }
     }
 

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -58,8 +58,8 @@ export class TabEvents {
   }
 
   onUpdatedTab = async (
-    payload: IsTabMonetizedPayload | null,
-    sender: Runtime.MessageSender
+    payload?: IsTabMonetizedPayload | null,
+    sender?: Runtime.MessageSender
   ) => {
     const { enabled } = await this.storage.get(['enabled'])
 
@@ -68,7 +68,7 @@ export class TabEvents {
       const { value: isTabMonetized } = payload
       iconData = isTabMonetized ? ICONS.active : ICONS.inactive
     }
-    const tabId = getTabId(sender)
+    const tabId = sender && getTabId(sender)
 
     await this.browser.action.setIcon({ path: iconData, tabId })
   }

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -64,9 +64,9 @@ export class TabEvents {
     let tabId
     if (enabled) {
       if (payload) {
-        const { value } = payload
+        const { value: isTabMonetized } = payload
         tabId = payload.tabId
-        iconData = value ? ICONS.active : ICONS.inactive
+        iconData = isTabMonetized ? ICONS.active : ICONS.inactive
       }
     }
 

--- a/src/content/lib/messages.ts
+++ b/src/content/lib/messages.ts
@@ -21,6 +21,7 @@ export const checkWalletAddressUrlCall = async (
 export const startMonetization = async (
   payload: ContentToBackgroundActionPayload[ContentToBackgroundAction.START_MONETIZATION]
 ) => {
+  if (!payload.length) return
   return await message.send({
     action: ContentToBackgroundAction.START_MONETIZATION,
     payload
@@ -30,6 +31,7 @@ export const startMonetization = async (
 export const stopMonetization = async (
   payload: ContentToBackgroundActionPayload[ContentToBackgroundAction.STOP_MONETIZATION]
 ) => {
+  if (!payload.length) return
   return await message.send({
     action: ContentToBackgroundAction.STOP_MONETIZATION,
     payload
@@ -39,6 +41,7 @@ export const stopMonetization = async (
 export const resumeMonetization = async (
   payload: ContentToBackgroundActionPayload[ContentToBackgroundAction.RESUME_MONETIZATION]
 ) => {
+  if (!payload.length) return
   return await message.send({
     action: ContentToBackgroundAction.RESUME_MONETIZATION,
     payload

--- a/src/content/services/monetizationTagManager.ts
+++ b/src/content/services/monetizationTagManager.ts
@@ -415,12 +415,10 @@ export class MonetizationTagManager extends EventEmitter {
   }
 
   private sendStartMonetization(tags: StartMonetizationPayload[]) {
-    if (!tags.length) return
-
     const isFrameMonetizedMessage = {
       message: ContentToContentAction.IS_FRAME_MONETIZED,
       id: this.id,
-      payload: { isMonetized: true }
+      payload: { isMonetized: tags.length > 0 }
     }
 
     if (this.isTopFrame) {
@@ -443,8 +441,6 @@ export class MonetizationTagManager extends EventEmitter {
   }
 
   private async sendStopMonetization(tags: StopMonetizationPayload[]) {
-    if (!tags.length) return
-
     await stopMonetization(tags)
 
     // Check if tab still monetized
@@ -467,8 +463,6 @@ export class MonetizationTagManager extends EventEmitter {
   }
 
   private sendResumeMonetization(tags: ResumeMonetizationPayload[]) {
-    if (!tags.length) return
-
     const isFrameMonetizedMessage = {
       message: ContentToContentAction.IS_FRAME_MONETIZED,
       id: this.id,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes https://github.com/interledger/web-monetization-extension/issues/329.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

- We were not sending `IS_FRAME_MONETIZED` due to a premature optimization (not sending it when no tags), so we weren't updating the state when required.
- Also had some timing issues with not `await`-ing.
- We now use `sender.tab.id` to ensure we set the icon for the right tab, and not override it from a stale message from a different tab (race condition).


As discussed in call today, in future we'll try to make use of a `TabStateService` and use that as source of truth, and reduce reliance on message passing.
