### PR TITLE
fix(background/events): don't throw on calling `once()`

### DIFF
--- a/src/background/services/events.ts
+++ b/src/background/services/events.ts
@@ -46,6 +46,8 @@ export class EventsService extends EventEmitter {
    * @deprecated
    */
   removeListener(): this {
-    throw new Error('Use `off` instead of `removeListener`.')
+    // eslint-disable-next-line prefer-rest-params
+    super.removeListener.apply(this, arguments)
+    return this
   }
 }

--- a/src/background/services/events.ts
+++ b/src/background/services/events.ts
@@ -47,7 +47,6 @@ export class EventsService extends EventEmitter {
    */
   removeListener(): this {
     // eslint-disable-next-line prefer-rest-params
-    super.removeListener.apply(this, arguments)
-    return this
+    return super.removeListener.apply(this, arguments)
   }
 }


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

`super.once()` ends up using our deprecated panic-inducing `removeListener()`

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Let `once()` work like it should. Keep the deprecation message in TypeScript only.
`addEventListener` still can throw.