### PR TITLE
chore(package.json): reduce strictness of `engines.node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "pnpm": "^9.4.0",
     "npm": "pnpm",
     "yarn": "pnpm",
-    "node": "20.14.0"
+    "node": "^20.14"
   },
   "packageManager": "pnpm@9.4.0"
 }


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Builds failing with bad Node.js version.

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->
## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

`.nvmrc` simply says lts. No need to be overly strict in engines, as it's a dev only thing for us.
