### PR TITLE
feat(background): store spent amount on payment to retrieve balance

### DIFF
--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -8,8 +8,7 @@ import {
   isFinalizedGrant,
   isPendingGrant,
   type IncomingPayment,
-  type OutgoingPayment,
-  type OutgoingPaymentWithSpentAmounts,
+  type OutgoingPaymentWithSpentAmounts as OutgoingPayment,
   type WalletAddress
 } from '@interledger/open-payments/dist/types'
 import * as ed from '@noble/ed25519'
@@ -537,7 +536,7 @@ export class OpenPaymentsService {
           source: 'Web Monetization'
         }
       }
-    )) as OutgoingPaymentWithSpentAmounts
+    )) as OutgoingPayment
 
     if (outgoingPayment.grantSpentDebitAmount) {
       this.storage.updateSpentAmount(

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -540,7 +540,7 @@ export class OpenPaymentsService {
     )) as OutgoingPaymentWithSpentAmounts
 
     if (outgoingPayment.grantSpentDebitAmount) {
-      this.storage.setSpentAmount(
+      this.storage.updateSpentAmount(
         this.grant!.type,
         outgoingPayment.grantSpentDebitAmount.value
       )

--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/shared/types'
 import { type Browser } from 'webextension-polyfill'
 import { EventsService } from './events'
-import { ThrottleBatch } from '@/shared/helpers'
+import { bigIntMax, ThrottleBatch } from '@/shared/helpers'
 import { computeBalance } from '../utils'
 
 const defaultStorage = {
@@ -41,7 +41,6 @@ export class StorageService {
     private browser: Browser,
     private events: EventsService
   ) {
-    const bigIntMax = (a: string, b: string) => (BigInt(a) > BigInt(b) ? a : b)
     this.setSpentAmountRecurring = new ThrottleBatch(
       (amount) => this.setSpentAmount('recurring', amount),
       (args) => [args.reduce((max, [v]) => bigIntMax(max, v), '0')],

--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/shared/types'
 import { type Browser } from 'webextension-polyfill'
 import { EventsService } from './events'
+import { ThrottleBatch } from '@/shared/helpers'
 import { computeBalance } from '../utils'
 
 const defaultStorage = {
@@ -33,10 +34,25 @@ const defaultStorage = {
 } satisfies Omit<Storage, 'publicKey' | 'privateKey' | 'keyId'>
 
 export class StorageService {
+  private setSpentAmountRecurring: ThrottleBatch<[amount: string]>
+  private setSpentAmountOneTime: ThrottleBatch<[amount: string]>
+
   constructor(
     private browser: Browser,
     private events: EventsService
-  ) {}
+  ) {
+    const bigIntMax = (a: string, b: string) => (BigInt(a) > BigInt(b) ? a : b)
+    this.setSpentAmountRecurring = new ThrottleBatch(
+      (amount) => this.set({ recurringGrantSpentAmount: amount }),
+      (args) => [args.reduce((max, [v]) => bigIntMax(max, v), '0')],
+      1000
+    )
+    this.setSpentAmountOneTime = new ThrottleBatch(
+      (amount) => this.set({ oneTimeGrantSpentAmount: amount }),
+      (args) => [args.reduce((max, [v]) => bigIntMax(max, v), '0')],
+      1000
+    )
+  }
 
   async get<TKey extends StorageKey>(
     keys?: TKey[]
@@ -137,6 +153,14 @@ export class StorageService {
       prevState: prevState
     })
     return true
+  }
+
+  setSpentAmount(grant: GrantDetails['type'], amount: string) {
+    if (grant === 'recurring') {
+      this.setSpentAmountRecurring.enqueue(amount)
+    } else if (grant === 'one-time') {
+      this.setSpentAmountOneTime.enqueue(amount)
+    }
   }
 
   async getBalance(): Promise<

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -188,3 +188,7 @@ export function convert(value: bigint, source: number, target: number) {
   }
   return value / BigInt(Math.pow(10, -scaleDiff))
 }
+
+export function bigIntMax(a: string, b: string) {
+  return BigInt(a) > BigInt(b) ? a : b
+}

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -88,6 +88,83 @@ export function debounceAsync<T extends unknown[], R extends Promise<unknown>>(
   }
 }
 
+// Based on https://stackoverflow.com/a/27078401
+export function throttle<T extends unknown[], R>(
+  func: (...args: T) => R,
+  wait: number,
+  options: Partial<{ leading: boolean; trailing: boolean }> = {
+    leading: false,
+    trailing: false
+  }
+) {
+  let result: R
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  let previous = 0
+  const later = (...args: T) => {
+    previous = options.leading === false ? 0 : Date.now()
+    timeout = null
+    result = func(...args)
+  }
+  return (...args: T) => {
+    const now = Date.now()
+    if (!previous && options.leading === false) previous = now
+    const remaining = wait - (now - previous)
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      previous = now
+      result = func(...args)
+    } else if (!timeout && options.trailing !== false) {
+      timeout = setTimeout(later, remaining, ...args)
+    }
+    return result
+  }
+}
+
+/**
+ * Throttle a function, while allowing the queued arguments to be reduced before
+ * the function is called. With args reducer, we can call the throttled function
+ * with first/last/merged arguments etc.
+ *
+ * @example
+ * ```ts
+ * const throttled = new ThrottleBatch(
+ *   (total: number) => saveToStorage(total),
+ *   (collectedArgs) => collectedArgs.reduce(total, [val] => total + val, 0),
+ *   wait
+ * )
+ * throttled.enqueue(10)
+ * throttled.enqueue(15)
+ * // results in saveToStorage(25)
+ * ```
+ */
+export class ThrottleBatch<Args extends unknown[], R = unknown> {
+  private argsList: Args[] = []
+  private throttled: () => void
+
+  constructor(
+    private func: (...arg: Args) => R,
+    private argsReducer: (args: Args[]) => [...Args],
+    wait: number
+  ) {
+    this.throttled = throttle(() => this.flush(), wait, { leading: true })
+  }
+
+  enqueue(...data: Args) {
+    this.argsList.push(data)
+    void this.throttled()
+  }
+
+  flush() {
+    if (!this.argsList.length) return
+    const args = this.argsReducer(this.argsList.slice())
+    this.argsList = []
+    return this.func(...args)
+  }
+}
+
 export function debounceSync<T extends unknown[], R>(
   func: (...args: T) => R,
   wait: number

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -131,8 +131,8 @@ export function throttle<T extends unknown[], R>(
  * @example
  * ```ts
  * const throttled = new ThrottleBatch(
- *   (total: number) => saveToStorage(total),
- *   (collectedArgs) => collectedArgs.reduce(total, [val] => total + val, 0),
+ *   (total: number) => saveToStorage({ total: total.toString() }),
+ *   (collectedArgs) => [collectedArgs.reduce(total, [val] => total + val, 0)],
  *   wait
  * )
  * throttled.enqueue(10)


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes #272.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Saves `grantSpentDebitAmount` as "amountSpent" in storage, which we can later use to retrieve balance. To handle race conditions, we store the max of amount spent in the batch of multiple (possibly parallel) calls.

Extracted from https://github.com/interledger/web-monetization-extension/pull/379, but using throttling instead of debouncing.
