### PR TITLE
refactor: add `t`, `useTranslation` helpers to use translations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,13 @@
     "react-hooks/exhaustive-deps": "error",
     "react/react-in-jsx-scope": "off",
     "react/jsx-uses-react": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/no-explicit-any": "off"
   },
   "overrides": [

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "temp",
     "*.svg",
     "pnpm-lock.yaml",
+    ".eslintrc.json",
     "cspell-dictionary.txt"
   ]
 }

--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -13,9 +13,9 @@ import {
 } from './services'
 import { createLogger, Logger } from '@/shared/logger'
 import { LOG_LEVEL } from '@/shared/defines'
-import { tFactory } from '@/shared/helpers'
+import { tFactory, type Translation } from '@/shared/helpers'
 
-export interface Cradle {
+interface Cradle {
   logger: Logger
   browser: Browser
   events: EventsService
@@ -26,7 +26,7 @@ export interface Cradle {
   sendToPopup: SendToPopup
   tabEvents: TabEvents
   background: Background
-  t: ReturnType<typeof tFactory>
+  t: Translation
   tabState: TabState
 }
 

--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -13,8 +13,9 @@ import {
 } from './services'
 import { createLogger, Logger } from '@/shared/logger'
 import { LOG_LEVEL } from '@/shared/defines'
+import { tFactory } from '@/shared/helpers'
 
-interface Cradle {
+export interface Cradle {
   logger: Logger
   browser: Browser
   events: EventsService
@@ -25,6 +26,7 @@ interface Cradle {
   sendToPopup: SendToPopup
   tabEvents: TabEvents
   background: Background
+  t: ReturnType<typeof tFactory>
   tabState: TabState
 }
 
@@ -38,6 +40,7 @@ export const configureContainer = () => {
   container.register({
     logger: asValue(logger),
     browser: asValue(browser),
+    t: asValue(tFactory(browser)),
     events: asClass(EventsService).singleton(),
     deduplicator: asClass(Deduplicator)
       .singleton()

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -4,7 +4,7 @@ import { MonetizationService } from './monetization'
 import { StorageService } from './storage'
 import { IsTabMonetizedPayload } from '@/shared/messages'
 import { getTabId } from '../utils'
-import type { Cradle } from '@/background/container'
+import type { Translation } from '@/shared/helpers'
 
 const runtime = browser.runtime
 const ICONS = {
@@ -30,7 +30,7 @@ export class TabEvents {
   constructor(
     private monetizationService: MonetizationService,
     private storage: StorageService,
-    private t: Cradle['t'],
+    private t: Translation,
     private browser: Browser
   ) {}
   clearTabSessions = (

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -4,6 +4,7 @@ import { MonetizationService } from './monetization'
 import { StorageService } from './storage'
 import { IsTabMonetizedPayload } from '@/shared/messages'
 import { getTabId } from '../utils'
+import { tFactory } from '@/shared/helpers'
 
 const runtime = browser.runtime
 const ICONS = {
@@ -62,15 +63,16 @@ export class TabEvents {
     sender?: Runtime.MessageSender
   ) => {
     const { enabled } = await this.storage.get(['enabled'])
+    const t = tFactory(this.browser)
 
-    let title = this.browser.i18n.getMessage('appName')
+    let title = t('appName')
     let iconData = enabled ? ICONS.default : ICONS.warning
     if (enabled && payload) {
       const { value: isTabMonetized } = payload
       iconData = isTabMonetized ? ICONS.active : ICONS.inactive
       const tabStateText = isTabMonetized
-        ? this.browser.i18n.getMessage('monetizationActiveShort')
-        : this.browser.i18n.getMessage('monetizationInactiveShort')
+        ? t('monetizationActiveShort')
+        : t('monetizationInactiveShort')
       title = `${title} - ${tabStateText}`
     }
     const tabId = sender && getTabId(sender)

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -4,7 +4,7 @@ import { MonetizationService } from './monetization'
 import { StorageService } from './storage'
 import { IsTabMonetizedPayload } from '@/shared/messages'
 import { getTabId } from '../utils'
-import { tFactory } from '@/shared/helpers'
+import type { Cradle } from '@/background/container'
 
 const runtime = browser.runtime
 const ICONS = {
@@ -30,6 +30,7 @@ export class TabEvents {
   constructor(
     private monetizationService: MonetizationService,
     private storage: StorageService,
+    private t: Cradle['t'],
     private browser: Browser
   ) {}
   clearTabSessions = (
@@ -63,16 +64,15 @@ export class TabEvents {
     sender?: Runtime.MessageSender
   ) => {
     const { enabled } = await this.storage.get(['enabled'])
-    const t = tFactory(this.browser)
 
-    let title = t('appName')
+    let title = this.t('appName')
     let iconData = enabled ? ICONS.default : ICONS.warning
     if (enabled && payload) {
       const { value: isTabMonetized } = payload
       iconData = isTabMonetized ? ICONS.active : ICONS.inactive
       const tabStateText = isTabMonetized
-        ? t('monetizationActiveShort')
-        : t('monetizationInactiveShort')
+        ? this.t('monetizationActiveShort')
+        : this.t('monetizationInactiveShort')
       title = `${title} - ${tabStateText}`
     }
     const tabId = sender && getTabId(sender)

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,7 +1,8 @@
 import { MainLayout } from '@/popup/components/layout/MainLayout'
-import { PopupContextProvider } from './lib/context'
+import { PopupContextProvider, TranslationContextProvider } from './lib/context'
 import { LazyMotion, domAnimation } from 'framer-motion'
 import React from 'react'
+import browser from 'webextension-polyfill'
 import { ProtectedRoute } from '@/popup/components/ProtectedRoute'
 import {
   RouteObject,
@@ -49,9 +50,11 @@ const router = createMemoryRouter(routes)
 export const Popup = () => {
   return (
     <LazyMotion features={domAnimation} strict>
-      <PopupContextProvider>
-        <RouterProvider router={router} />
-      </PopupContextProvider>
+      <TranslationContextProvider browser={browser}>
+        <PopupContextProvider>
+          <RouterProvider router={router} />
+        </PopupContextProvider>
+      </TranslationContextProvider>
     </LazyMotion>
   )
 }

--- a/src/popup/components/SiteNotMonetized.tsx
+++ b/src/popup/components/SiteNotMonetized.tsx
@@ -1,16 +1,15 @@
 import React from 'react'
-import browser from 'webextension-polyfill'
 import { WarningSign } from '@/popup/components/Icons'
+import { useTranslation } from '@/popup/lib/context'
 
 export const SiteNotMonetized = () => {
+  const t = useTranslation()
   return (
     <div className="flex h-full items-center justify-center gap-2 p-4 text-lg">
       <div className="flex-shrink-0">
         <WarningSign className="size-6 text-medium" />
       </div>
-      <h3 className="text-medium">
-        {browser.i18n.getMessage('siteNotMonetized')}
-      </h3>
+      <h3 className="text-medium">{t('siteNotMonetized')}</h3>
     </div>
   )
 }

--- a/src/popup/lib/context.tsx
+++ b/src/popup/lib/context.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import browser, { type Browser } from 'webextension-polyfill'
 import { getContextData } from '@/popup/lib/messages'
-import { tFactory } from '@/shared/helpers'
+import { tFactory, type Translation } from '@/shared/helpers'
 import type { DeepNonNullable, PopupStore } from '@/shared/types'
 import {
   ContentToBackgroundAction,
@@ -163,9 +163,7 @@ export function PopupContextProvider({ children }: PopupContextProviderProps) {
   )
 }
 
-const TranslationContext = React.createContext<ReturnType<typeof tFactory>>(
-  (v: string) => v
-)
+const TranslationContext = React.createContext<Translation>((v: string) => v)
 
 export const TranslationContextProvider = ({
   browser,

--- a/src/popup/lib/context.tsx
+++ b/src/popup/lib/context.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import browser from 'webextension-polyfill'
+import browser, { type Browser } from 'webextension-polyfill'
 import { getContextData } from '@/popup/lib/messages'
-import { DeepNonNullable, PopupStore } from '@/shared/types'
+import { tFactory } from '@/shared/helpers'
+import type { DeepNonNullable, PopupStore } from '@/shared/types'
 import {
   ContentToBackgroundAction,
   type ContentToBackgroundMessage
@@ -161,3 +162,25 @@ export function PopupContextProvider({ children }: PopupContextProviderProps) {
     </PopupStateContext.Provider>
   )
 }
+
+const TranslationContext = React.createContext<ReturnType<typeof tFactory>>(
+  (v: string) => v
+)
+
+export const TranslationContextProvider = ({
+  browser,
+  children
+}: {
+  browser: Browser
+  children: React.ReactNode
+}) => {
+  const t = tFactory(browser)
+
+  return (
+    <TranslationContext.Provider value={t}>
+      {children}
+    </TranslationContext.Provider>
+  )
+}
+
+export const useTranslation = () => React.useContext(TranslationContext)

--- a/src/popup/pages/MissingHostPermission.tsx
+++ b/src/popup/pages/MissingHostPermission.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import browser from 'webextension-polyfill'
 import { PERMISSION_HOSTS } from '@/shared/defines'
 import { WarningSign } from '@/popup/components/Icons'
+import { useTranslation } from '@/popup/lib/context'
 
 export const Component = () => {
+  const t = useTranslation()
   return (
     <div className="rounded-md bg-orange-50 p-4 text-sm">
       <div className="flex">
@@ -13,7 +15,7 @@ export const Component = () => {
         <div className="ml-3 flex flex-col gap-2">
           <h3 className="font-medium text-orange-800">Permission needed</h3>
           <div className="text-orange-700">
-            <p>{browser.i18n.getMessage('hostsPermissionsNeeded')}</p>
+            <p>{t('hostsPermissionsNeeded')}</p>
           </div>
         </div>
       </div>

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -194,8 +194,9 @@ export function bigIntMax(a: string, b: string) {
   return BigInt(a) > BigInt(b) ? a : b
 }
 
-export function tFactory(browser: Pick<Browser, 'i18n'>) {
-  type TranslationKeys = keyof typeof import('../_locales/en/messages.json')
+export type Translation = ReturnType<typeof tFactory>
+
+type TranslationKeys = keyof typeof import('../_locales/en/messages.json')export function tFactory(browser: Pick<Browser, 'i18n'>) {
   /**
    * Helper over calling cumbersome `this.browser.i18n.getMessage(key)` with
    * added benefit that it type-checks if key exists in message.json

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -3,7 +3,6 @@ import { WalletAddress } from '@interledger/open-payments/dist/types'
 import { cx, CxOptions } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
 import type { Browser } from 'webextension-polyfill'
-import type { ExcludeFirst } from './types'
 
 export const cn = (...inputs: CxOptions) => {
   return twMerge(cx(inputs))

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -2,6 +2,8 @@ import { SuccessResponse } from '@/shared/messages'
 import { WalletAddress } from '@interledger/open-payments/dist/types'
 import { cx, CxOptions } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
+import type { Browser } from 'webextension-polyfill'
+import type { ExcludeFirst } from './types'
 
 export const cn = (...inputs: CxOptions) => {
   return twMerge(cx(inputs))
@@ -191,4 +193,17 @@ export function convert(value: bigint, source: number, target: number) {
 
 export function bigIntMax(a: string, b: string) {
   return BigInt(a) > BigInt(b) ? a : b
+}
+
+/**
+ * Helper over calling cumbersome `this.browser.i18n.getMessage(key)` with added
+ * benefit that it type-checks if key exists in message.json
+ */
+export function t<
+  T extends keyof typeof import('../_locales/en/messages.json')
+>(browser: Pick<Browser, 'i18n'>, key: T, substitutions?: string | string[]) {
+  return browser.i18n.getMessage(key, substitutions)
+}
+export function tFactory(browser: Pick<Browser, 'i18n'>) {
+  return (...args: ExcludeFirst<Parameters<typeof t>>) => t(browser, ...args)
 }

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -194,9 +194,10 @@ export function bigIntMax(a: string, b: string) {
   return BigInt(a) > BigInt(b) ? a : b
 }
 
-export type Translation = ReturnType<typeof tFactory>
+type TranslationKeys = keyof typeof import('../_locales/en/messages.json')
 
-type TranslationKeys = keyof typeof import('../_locales/en/messages.json')export function tFactory(browser: Pick<Browser, 'i18n'>) {
+export type Translation = ReturnType<typeof tFactory>
+export function tFactory(browser: Pick<Browser, 'i18n'>) {
   /**
    * Helper over calling cumbersome `this.browser.i18n.getMessage(key)` with
    * added benefit that it type-checks if key exists in message.json

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -195,15 +195,14 @@ export function bigIntMax(a: string, b: string) {
   return BigInt(a) > BigInt(b) ? a : b
 }
 
-/**
- * Helper over calling cumbersome `this.browser.i18n.getMessage(key)` with added
- * benefit that it type-checks if key exists in message.json
- */
-export function t<
-  T extends keyof typeof import('../_locales/en/messages.json')
->(browser: Pick<Browser, 'i18n'>, key: T, substitutions?: string | string[]) {
-  return browser.i18n.getMessage(key, substitutions)
-}
 export function tFactory(browser: Pick<Browser, 'i18n'>) {
-  return (...args: ExcludeFirst<Parameters<typeof t>>) => t(browser, ...args)
+  type TranslationKeys = keyof typeof import('../_locales/en/messages.json')
+  /**
+   * Helper over calling cumbersome `this.browser.i18n.getMessage(key)` with
+   * added benefit that it type-checks if key exists in message.json
+   */
+  return <T extends TranslationKeys>(
+    key: T,
+    substitutions?: string | string[]
+  ) => browser.i18n.getMessage(key, substitutions)
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -95,6 +95,3 @@ export type PopupStore = Omit<
 export type DeepNonNullable<T> = {
   [P in keyof T]?: NonNullable<T[P]>
 }
-
-export type ExcludeFirst<T extends [f: unknown, ...rest: unknown[]]> =
-  T extends [infer _F, ...infer Rest] ? Rest : never

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -95,3 +95,6 @@ export type PopupStore = Omit<
 export type DeepNonNullable<T> = {
   [P in keyof T]?: NonNullable<T[P]>
 }
+
+export type ExcludeFirst<T extends [f: unknown, ...rest: unknown[]]> =
+  T extends [infer _F, ...infer Rest] ? Rest : never


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Making translations easier to use.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
Adds following helpers: 
- `t(key, optionalSubsitutions)` added to background container
   - as a shorter call over `this.browser.i18n.getMessage(key, optionalSubsitutions)`,
   - where TypeScript ensures `key` exists in _locales
- For popup, a `const t = useTranslation()` helper.
- In popup, reduces place where we need to `import browser from 'webextension-polyfill'`, make it easier to test. The context default just returns passed key as is.