### PR TITLE
fix(content): reduce amount of `IS_TAB_MONETIZED` messages/events

### DIFF
--- a/src/content/services/frameManager.ts
+++ b/src/content/services/frameManager.ts
@@ -188,14 +188,11 @@ export class FrameManager {
           if (message === ContentToContentAction.IS_FRAME_MONETIZED) {
             event.stopPropagation()
 
-            let isMonetized = false
-
             this.isFrameMonetized = payload.isMonetized
-            this.frames.forEach((value) => {
-              if (value.isFrameMonetized) isMonetized = true
-            })
-
-            isTabMonetized({ value: isMonetized || this.isFrameMonetized })
+            const isMonetized =
+              this.isFrameMonetized ||
+              [...this.frames.values()].some((e) => e.isFrameMonetized)
+            isTabMonetized({ value: isMonetized })
           }
           return
         }

--- a/src/content/services/monetizationTagManager.ts
+++ b/src/content/services/monetizationTagManager.ts
@@ -425,6 +425,7 @@ export class MonetizationTagManager extends EventEmitter {
   }
 
   private sendStartMonetization(tags: StartMonetizationPayload[]) {
+    if (!tags.length) return
     const isFrameMonetizedMessage = {
       message: ContentToContentAction.IS_FRAME_MONETIZED,
       id: this.id,
@@ -451,6 +452,7 @@ export class MonetizationTagManager extends EventEmitter {
   }
 
   private async sendStopMonetization(tags: StopMonetizationPayload[]) {
+    if (!tags.length) return
     await stopMonetization(tags)
 
     // Check if tab still monetized


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Prevents slow-down due to too many `IS_TAB_MONETIZED` events.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Adds back some of optimizations removed in https://github.com/interledger/web-monetization-extension/pull/355. Turns out, we we can use them correctly with start/end; just resume one was buggy.
Adds a little optimization in how we compute payload for `isTabMonetized` (more short-circuiting).