### PR TITLE
fix(background): increase request timeout for the OP SDK

### DIFF
--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -219,6 +219,7 @@ export class OpenPaymentsService {
 
     this.client = await createAuthenticatedClient({
       validateResponses: false,
+      requestTimeoutMs: 10000,
       walletAddressUrl,
       authenticatedRequestInterceptor: async (request) => {
         if (!request.method || !request.url) {


### PR DESCRIPTION
## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Since quoting was removed in https://github.com/interledger/web-monetization-extension/pull/371, I constantly see timed out requests. The reason: under the hood, Rafiki still performs a quote, but we do not make the HTTP call. Since the quoting is still performed, some of the requests are timing out if it takes them more than 5 seconds to complete.