### PR TITLE
feat(popup): allow short form for wallet addresses in popup

### DIFF
--- a/src/popup/components/ConnectWalletForm.tsx
+++ b/src/popup/components/ConnectWalletForm.tsx
@@ -10,7 +10,8 @@ import { debounceSync, getWalletInformation } from '@/shared/helpers'
 import {
   charIsNumber,
   formatNumber,
-  getCurrencySymbol
+  getCurrencySymbol,
+  toWalletAddressUrl
 } from '@/popup/lib/utils'
 import { useForm } from 'react-hook-form'
 
@@ -52,7 +53,8 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
       clearErrors('walletAddressUrl')
       if (!walletAddressUrl) return
       try {
-        const url = new URL(walletAddressUrl)
+        const httpUrl = toWalletAddressUrl(walletAddressUrl)
+        const url = new URL(httpUrl)
         const walletAddress = await getWalletInformation(url.toString())
         setCurrencySymbol({
           symbol: getCurrencySymbol(walletAddress.assetCode),
@@ -61,7 +63,7 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
       } catch (e) {
         setError('walletAddressUrl', {
           type: 'validate',
-          message: 'Invalid wallet address URL.'
+          message: 'Invalid wallet address.'
         })
       }
     },
@@ -107,7 +109,10 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        const response = await connectWallet(data)
+        const response = await connectWallet({
+          ...data,
+          walletAddressUrl: toWalletAddressUrl(data.walletAddressUrl)
+        })
         if (!response.success) {
           setError('walletAddressUrl', {
             type: 'validate',
@@ -137,7 +142,7 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
         <Code className="text-xs" value={publicKey} />
       </div>
       <Input
-        type="url"
+        type="text"
         label="Wallet address"
         disabled={connected}
         placeholder="https://ilp.rafiki.money/johndoe"

--- a/src/popup/components/ConnectWalletForm.tsx
+++ b/src/popup/components/ConnectWalletForm.tsx
@@ -53,8 +53,7 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
       clearErrors('walletAddressUrl')
       if (!walletAddressUrl) return
       try {
-        const httpUrl = toWalletAddressUrl(walletAddressUrl)
-        const url = new URL(httpUrl)
+        const url = new URL(toWalletAddressUrl(walletAddressUrl))
         const walletAddress = await getWalletInformation(url.toString())
         setCurrencySymbol({
           symbol: getCurrencySymbol(walletAddress.assetCode),
@@ -143,7 +142,7 @@ export const ConnectWalletForm = ({ publicKey }: ConnectWalletFormProps) => {
       </div>
       <Input
         type="text"
-        label="Wallet address"
+        label="Wallet address or payment pointer"
         disabled={connected}
         placeholder="https://ilp.rafiki.money/johndoe"
         errorMessage={errors.walletAddressUrl?.message}

--- a/src/popup/lib/utils.test.ts
+++ b/src/popup/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatNumber } from './utils'
+import { formatNumber, toWalletAddressUrl } from './utils'
 
 describe('formatNumber', () => {
   it('should display right format for integers', () => {
@@ -41,5 +41,13 @@ describe('formatNumber', () => {
     expect(formatNumber(0.000010009, 9, true)).toEqual('1.0009e-5')
 
     expect(formatNumber(0.000100009, 9)).toEqual('0.000100009')
+  })
+})
+
+describe('toWalletAddressUrl', () => {
+  it('converts from short form to long form', () => {
+    expect(toWalletAddressUrl('$wallet.com/bob')).toEqual(
+      'https://wallet.com/bob'
+    )
   })
 })

--- a/src/popup/lib/utils.ts
+++ b/src/popup/lib/utils.ts
@@ -62,3 +62,7 @@ export function formatNumber(
     } else return value.toExponential()
   }
 }
+
+export function toWalletAddressUrl(s: string): string {
+  return s.startsWith('$') ? s.replace(/^\$/, 'https://') : s
+}

--- a/src/popup/lib/utils.ts
+++ b/src/popup/lib/utils.ts
@@ -64,5 +64,5 @@ export function formatNumber(
 }
 
 export function toWalletAddressUrl(s: string): string {
-  return s.startsWith('$') ? s.replace(/^\$/, 'https://') : s
+  return s.startsWith('$') ? s.replace('$', 'https://') : s
 }


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes #411.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Discussed during WM Work Week. ASEs can decide what term they want to use - wallet address or payment pointer. This PR allows the use of the short form ($ notation) in the popup.