### PR TITLE
feat(background): resend last monetization event on reload when overpaying

### DIFF
--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -193,8 +193,11 @@ export class PaymentSession {
             this.tabState.saveOverpaying(
               this.tab,
               this.url,
-              this.receiver.id,
-              this.intervalInMs
+              {
+                  walletAddressId: this.receiver.id,
+                  monetizationEvent: monetizationEventPayload,
+                  intervalInMs: this.intervalInMs
+              }
             )
           }
 

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -128,7 +128,7 @@ export class PaymentSession {
 
     let outgoingPayment: OutgoingPayment | undefined
 
-    const { waitTime, monetizationEvent } = this.tabState.getOverpayingWaitTime(
+    const { waitTime, monetizationEvent } = this.tabState.getOverpayingDetails(
       this.tab,
       this.url,
       this.receiver.id

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -11,6 +11,7 @@ import { convert, sleep } from '@/shared/helpers'
 import { transformBalance } from '@/popup/lib/utils'
 import { TabState } from './tabState'
 import type { Tabs } from 'webextension-polyfill'
+import { MonetizationEventPayload } from '@/shared/messages'
 
 const DEFAULT_INTERVAL_MS = 1000
 const HOUR_MS = 3600 * 1000
@@ -166,12 +167,9 @@ export class PaymentSession {
 
           outgoingPayment = undefined
 
-          sendMonetizationEvent({
-            tabId: this.tabId,
-            frameId: this.frameId,
-            payload: {
+          const monetizationEventPayload: MonetizationEventPayload = {
               requestId: this.requestId,
-              detail: {
+              details: {
                 amountSent: {
                   currency: receiveAmount.assetCode,
                   value: transformBalance(
@@ -183,6 +181,11 @@ export class PaymentSession {
                 paymentPointer: this.receiver.id
               }
             }
+
+          sendMonetizationEvent({
+            tabId: this.tabId,
+            frameId: this.frameId,
+            payload: monetizationEventPayload
           })
 
           // TO DO: find a better source of truth for deciding if overpaying is applicable
@@ -283,7 +286,7 @@ export class PaymentSession {
           frameId: this.frameId,
           payload: {
             requestId: this.requestId,
-            detail: {
+            details: {
               amountSent: {
                 currency: receiveAmount.assetCode,
                 value: transformBalance(

--- a/src/background/services/tabState.ts
+++ b/src/background/services/tabState.ts
@@ -1,8 +1,15 @@
 import { Tabs } from 'webextension-polyfill'
 
 type State = {
+  monetizationEvent: MonetizationEventPayload
   lastPaymentTimestamp: number
   expiresAtTimestamp: number
+}
+
+interface SaveOverpayingDetails {
+    walletAddressId: string,
+    monetizationEvent: MonetizationEventPayload,
+    intervalInMs: number
 }
 
 export class TabState {
@@ -33,9 +40,9 @@ export class TabState {
   saveOverpaying(
     tab: Tabs.Tab,
     url: string,
-    walletAddressId: string,
-    intervalInMs: number
+    details: SaveOverpayingDetails
   ): void {
+      const {intervalInMs, walletAddressId, monetizationEvent } = details
     if (!intervalInMs) return
 
     const now = Date.now()
@@ -45,8 +52,9 @@ export class TabState {
     const state = this.state.get(tab)?.get(key)
 
     if (!state) {
-      const tabState = this.state.get(tab) || new Map()
+      const tabState = this.state.get(tab) || new Map<string, State>()
       tabState.set(key, {
+        monetizationEvent,
         expiresAtTimestamp: expiresAtTimestamp,
         lastPaymentTimestamp: now
       })

--- a/src/background/services/tabState.ts
+++ b/src/background/services/tabState.ts
@@ -22,7 +22,7 @@ export class TabState {
     return `${url}:${walletAddressId}`
   }
 
-  getOverpayingWaitTime(
+  getOverpayingDetails(
     tab: Tabs.Tab,
     url: string,
     walletAddressId: string

--- a/src/content/polyfill.ts
+++ b/src/content/polyfill.ts
@@ -67,7 +67,7 @@ import type { MonetizationEventPayload } from '@/shared/messages'
 
     constructor(
       type: 'monetization',
-      eventInitDict: MonetizationEventPayload['detail']
+      eventInitDict: MonetizationEventPayload['details']
     ) {
       super(type, { bubbles: true })
       const { amountSent, incomingPayment, paymentPointer } = eventInitDict
@@ -97,7 +97,7 @@ import type { MonetizationEventPayload } from '@/shared/messages'
 
   window.addEventListener(
     '__wm_ext_monetization',
-    (event: CustomEvent<MonetizationEventPayload['detail']>) => {
+    (event: CustomEvent<MonetizationEventPayload['details']>) => {
       if (!(event.target instanceof HTMLLinkElement)) return
       if (!event.target.isConnected) return
 

--- a/src/content/services/monetizationTagManager.ts
+++ b/src/content/services/monetizationTagManager.ts
@@ -73,13 +73,13 @@ export class MonetizationTagManager extends EventEmitter {
     tag.dispatchEvent(new Event('error'))
   }
 
-  dispatchMonetizationEvent({ requestId, detail }: MonetizationEventPayload) {
+  dispatchMonetizationEvent({ requestId, details }: MonetizationEventPayload) {
     this.monetizationTags.forEach((tagDetails, tag) => {
       if (tagDetails.requestId !== requestId) return
 
       tag.dispatchEvent(
         new CustomEvent('__wm_ext_monetization', {
-          detail: mozClone(detail, this.document),
+          detail: mozClone(details, this.document),
           bubbles: true
         })
       )

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -135,13 +135,15 @@ export enum BackgroundToContentAction {
   EMIT_TOGGLE_WM = 'EMIT_TOGGLE_WM'
 }
 
+export interface MonetizationEventDetails {
+  amountSent: PaymentCurrencyAmount
+  incomingPayment: OutgoingPayment['receiver']
+  paymentPointer: WalletAddress['id']
+}
+
 export interface MonetizationEventPayload {
   requestId: string
-  details: {
-    amountSent: PaymentCurrencyAmount
-    incomingPayment: OutgoingPayment['receiver']
-    paymentPointer: WalletAddress['id']
-  }
+  details: MonetizationEventDetails
 }
 
 export interface EmitToggleWMPayload {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -137,7 +137,7 @@ export enum BackgroundToContentAction {
 
 export interface MonetizationEventPayload {
   requestId: string
-  detail: {
+  details: {
     amountSent: PaymentCurrencyAmount
     incomingPayment: OutgoingPayment['receiver']
     paymentPointer: WalletAddress['id']


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes #422.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- Changed `MonetizationEventPayload`: `detail` -> `details`
- Updated `tabState` methods to store the monetization event as well.
- Session now sends the last monetization event when starting an overpaying payment session