### PR TITLE
perf(background/tabEvents): memoize `setIcon` call

### DIFF
--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -131,13 +131,15 @@ export class TabEvents {
     await this.setIconAndTooltip(path, title, tabId);
   };
 
-  // TODO: memoize this call
   private setIconAndTooltip = async (
     path: (typeof ICONS)[keyof typeof ICONS],
     title: string,
-    tabId?: TabId,
+    tabId: TabId,
   ) => {
-    await this.browser.action.setIcon({ path, tabId });
+    if (this.tabState.getIcon(tabId) !== path) {
+      this.tabState.setIcon(tabId, path);
+      await this.browser.action.setIcon({ path, tabId });
+    }
     await this.browser.action.setTitle({ title, tabId });
   };
 

--- a/src/background/services/tabState.ts
+++ b/src/background/services/tabState.ts
@@ -22,6 +22,7 @@ export class TabState {
 
   private state = new Map<TabId, Map<string, State>>();
   private sessions = new Map<TabId, Map<SessionId, PaymentSession>>();
+  private currentIcon = new Map<TabId, Record<number, string>>();
 
   constructor({ logger }: Cradle) {
     Object.assign(this, {
@@ -118,6 +119,14 @@ export class TabState {
     return [...this.sessions.values()].flatMap((s) => [...s.values()]);
   }
 
+  getIcon(tabId: TabId) {
+    return this.currentIcon.get(tabId);
+  }
+
+  setIcon(tabId: TabId, icon: Record<number, string>) {
+    this.currentIcon.set(tabId, icon);
+  }
+
   getAllTabs(): TabId[] {
     return [...this.sessions.keys()];
   }
@@ -128,6 +137,8 @@ export class TabState {
   }
 
   clearSessionsByTabId(tabId: TabId) {
+    this.currentIcon.delete(tabId);
+
     const sessions = this.getSessions(tabId);
     if (!sessions.size) return;
 


### PR DESCRIPTION
In Chrome, we get 3 fetch requests on each `setIcon` calls even if setting same icon. Each request takes 5-25ms, which is unnecessary and noisy as well.