### PR TITLE
test(e2e): retain traces for failed runs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       { open: 'never', outputFolder: path.join(testDir, 'playwright-report') },
     ],
   ],
-  use: { trace: 'on-first-retry' },
+  use: { trace: 'retain-on-failure' },
 
   projects: [
     {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->
With the current setup, if the first run fails we are not saving the trace for it, only for the first retry.
## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
Retain traces only for failed runs.