### PR TITLE
fix(ci/test-e2e): don't cancel in-progress jobs

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -3,9 +3,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: ${{ github.event.pull_request.number }}
-
 jobs:
   test-e2e:
     if: ${{

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -5,7 +5,6 @@ on:
 
 concurrency:
   group: ${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   test-e2e:


### PR DESCRIPTION
If someone added any unrelated review, existing test run got cancelled. Not anymore.
Context: https://github.com/interledger/web-monetization-extension/actions/runs/10885243656