### PR TITLE
feat: support split-view in Edge, tab-tiling in Vivaldi

### DIFF
--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -7,6 +7,7 @@ import {
   Background,
   TabEvents,
   TabState,
+  WindowState,
   SendToPopup,
   EventsService,
   Heartbeat,
@@ -14,7 +15,12 @@ import {
 } from './services';
 import { createLogger, Logger } from '@/shared/logger';
 import { LOG_LEVEL } from '@/shared/defines';
-import { tFactory, type Translation } from '@/shared/helpers';
+import {
+  getBrowserName,
+  tFactory,
+  type BrowserName,
+  type Translation,
+} from '@/shared/helpers';
 import {
   MessageManager,
   type BackgroundToContentMessage,
@@ -23,6 +29,7 @@ import {
 export interface Cradle {
   logger: Logger;
   browser: Browser;
+  browserName: BrowserName;
   events: EventsService;
   deduplicator: Deduplicator;
   storage: StorageService;
@@ -34,6 +41,7 @@ export interface Cradle {
   background: Background;
   t: Translation;
   tabState: TabState;
+  windowState: WindowState;
   heartbeat: Heartbeat;
 }
 
@@ -47,6 +55,7 @@ export const configureContainer = () => {
   container.register({
     logger: asValue(logger),
     browser: asValue(browser),
+    browserName: asValue(getBrowserName(browser, navigator.userAgent)),
     t: asValue(tFactory(browser)),
     events: asClass(EventsService).singleton(),
     deduplicator: asClass(Deduplicator)
@@ -81,6 +90,11 @@ export const configureContainer = () => {
       .singleton()
       .inject(() => ({
         logger: logger.getLogger('tab-state'),
+      })),
+    windowState: asClass(WindowState)
+      .singleton()
+      .inject(() => ({
+        logger: logger.getLogger('window-state'),
       })),
     heartbeat: asClass(Heartbeat).singleton(),
   });

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -139,7 +139,7 @@ export class Background {
       });
       const popupWasOpen = popupOpen;
       popupOpen = this.sendToPopup.isPopupOpen;
-      if (popupWasOpen || this.sendToPopup.isPopupOpen) {
+      if (popupWasOpen || popupOpen) {
         // This is intentionally called after windows.getAll, to add a little
         // delay for popup port to open
         this.logger.debug('Popup is open, ignoring focus change');
@@ -155,9 +155,9 @@ export class Background {
             `[focus change] resume monetization for window=${windowId}, tabIds=${JSON.stringify(tabIds)}`,
           );
           for (const tabId of tabIds) {
-            void this.monetizationService.resumePaymentSessionsByTabId(tabId);
+            await this.monetizationService.resumePaymentSessionsByTabId(tabId);
           }
-          void this.updateVisualIndicatorsForCurrentTab();
+          await this.updateVisualIndicatorsForCurrentTab();
         } else {
           this.logger.info(
             `[focus change] stop monetization for window=${windowId}, tabIds=${JSON.stringify(tabIds)}`,

--- a/src/background/services/index.ts
+++ b/src/background/services/index.ts
@@ -4,6 +4,7 @@ export { MonetizationService } from './monetization';
 export { Background } from './background';
 export { TabEvents } from './tabEvents';
 export { TabState } from './tabState';
+export { WindowState } from './windowState';
 export { SendToPopup } from './sendToPopup';
 export { EventsService } from './events';
 export { Deduplicator } from './deduplicator';

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -5,12 +5,7 @@ import {
   StopMonetizationPayload,
 } from '@/shared/messages';
 import { PaymentSession } from './paymentSession';
-import {
-  computeRate,
-  getCurrentActiveTab,
-  getSender,
-  getTabId,
-} from '../utils';
+import { computeRate, getSender, getTabId } from '../utils';
 import { isOutOfBalanceError } from './openPayments';
 import { isOkState, removeQueryParams } from '@/shared/helpers';
 import { ALLOWED_PROTOCOLS } from '@/shared/defines';
@@ -239,7 +234,7 @@ export class MonetizationService {
   }
 
   async resumePaymentSessionActiveTab() {
-    const currentTab = await getCurrentActiveTab(this.browser);
+    const currentTab = await this.windowState.getCurrentTab();
     if (!currentTab?.id) return;
     await this.resumePaymentSessionsByTabId(currentTab.id);
   }
@@ -319,7 +314,7 @@ export class MonetizationService {
       const tabIds = this.tabState.getAllTabs();
 
       // Move the current active tab to the front of the array
-      const currentTab = await getCurrentActiveTab(this.browser);
+      const currentTab = await this.windowState.getCurrentTab();
       if (currentTab?.id) {
         const idx = tabIds.indexOf(currentTab.id);
         if (idx !== -1) {

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -25,6 +25,7 @@ export class MonetizationService {
   private browser: Cradle['browser'];
   private events: Cradle['events'];
   private tabState: Cradle['tabState'];
+  private windowState: Cradle['windowState'];
   private message: Cradle['message'];
 
   constructor({
@@ -35,6 +36,7 @@ export class MonetizationService {
     events,
     openPaymentsService,
     tabState,
+    windowState,
     message,
   }: Cradle) {
     Object.assign(this, {
@@ -45,6 +47,7 @@ export class MonetizationService {
       browser,
       events,
       tabState,
+      windowState,
       message,
     });
 
@@ -253,7 +256,7 @@ export class MonetizationService {
   }
 
   async pay(amount: string) {
-    const tab = await getCurrentActiveTab(this.browser);
+    const tab = await this.windowState.getCurrentTab();
     if (!tab || !tab.id) {
       throw new Error('Unexpected error: could not find active tab.');
     }

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -1,9 +1,10 @@
 import { isOkState, removeQueryParams } from '@/shared/helpers';
 import { ALLOWED_PROTOCOLS } from '@/shared/defines';
 import type { Storage, TabId } from '@/shared/types';
-import type { Browser } from 'webextension-polyfill';
+import type { Browser, Tabs } from 'webextension-polyfill';
 import type { Cradle } from '@/background/container';
 
+type IconPath = Record<number, string>;
 const ICONS = {
   default: {
     32: '/assets/icons/32x32/default.png',
@@ -45,7 +46,7 @@ const ICONS = {
     48: '/assets/icons/48x48/disabled-warn.png',
     128: '/assets/icons/128x128/disabled-warn.png',
   },
-};
+} satisfies Record<string, IconPath>;
 
 type CallbackTab<T extends Extract<keyof Browser['tabs'], `on${string}`>> =
   Parameters<Browser['tabs'][T]['addListener']>[0];
@@ -53,17 +54,29 @@ type CallbackTab<T extends Extract<keyof Browser['tabs'], `on${string}`>> =
 export class TabEvents {
   private storage: Cradle['storage'];
   private tabState: Cradle['tabState'];
+  private windowState: Cradle['windowState'];
   private sendToPopup: Cradle['sendToPopup'];
   private t: Cradle['t'];
   private browser: Cradle['browser'];
+  private browserName: Cradle['browserName'];
 
-  constructor({ storage, tabState, sendToPopup, t, browser }: Cradle) {
+  constructor({
+    storage,
+    tabState,
+    windowState,
+    sendToPopup,
+    t,
+    browser,
+    browserName,
+  }: Cradle) {
     Object.assign(this, {
       storage,
       tabState,
+      windowState,
       sendToPopup,
       t,
       browser,
+      browserName,
     });
   }
 
@@ -90,6 +103,8 @@ export class TabEvents {
   };
 
   onActivatedTab: CallbackTab<'onActivated'> = async (info) => {
+    const updated = this.windowState.setCurrentTabId(info.windowId, info.tabId);
+    if (!updated) return;
     const tab = await this.browser.tabs.get(info.tabId);
     await this.updateVisualIndicators(info.tabId, tab?.url);
   };
@@ -97,6 +112,14 @@ export class TabEvents {
   onCreatedTab: CallbackTab<'onCreated'> = async (tab) => {
     if (!tab.id) return;
     await this.updateVisualIndicators(tab.id, tab.url);
+  };
+
+  onFocussedTab = async (tab: Tabs.Tab) => {
+    if (!tab.id) return;
+    const updated = this.windowState.setCurrentTabId(tab.windowId!, tab.id);
+    if (!updated) return;
+    const tabUrl = tab.url ?? (await this.browser.tabs.get(tab.id)).url;
+    await this.updateVisualIndicators(tab.id, tabUrl);
   };
 
   updateVisualIndicators = async (
@@ -128,20 +151,33 @@ export class TabEvents {
 
     this.sendToPopup.send('SET_IS_MONETIZED', isMonetized);
     this.sendToPopup.send('SET_ALL_SESSIONS_INVALID', hasTabAllSessionsInvalid);
-    await this.setIconAndTooltip(path, title, tabId);
+    await this.setIconAndTooltip(tabId, path, title);
   };
 
   private setIconAndTooltip = async (
-    path: (typeof ICONS)[keyof typeof ICONS],
-    title: string,
     tabId: TabId,
+    icon: IconPath,
+    title: string,
   ) => {
-    if (this.tabState.getIcon(tabId) !== path) {
-      this.tabState.setIcon(tabId, path);
-      await this.browser.action.setIcon({ path, tabId });
-    }
+    await this.setIcon(tabId, icon);
     await this.browser.action.setTitle({ title, tabId });
   };
+
+  private async setIcon(tabId: TabId, icon: IconPath) {
+    if (this.browserName === 'edge') {
+      // Edge has split-view, and if we specify a tabId, it will only set the
+      // icon for the left-pane when split-view is open. So, we ignore the
+      // tabId. As it's inefficient, we do it only for Edge.
+      // We'd have set this for a windowId, but that's not supported in Edge/Chrome
+      await this.browser.action.setIcon({ path: icon });
+      return;
+    }
+
+    if (this.tabState.getIcon(tabId) !== icon) {
+      this.tabState.setIcon(tabId, icon); // memoize
+      await this.browser.action.setIcon({ path: icon, tabId });
+    }
+  }
 
   private getIconAndTooltip({
     enabled,

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -97,12 +97,14 @@ export class TabEvents {
     }
   };
 
-  onRemovedTab: CallbackTab<'onRemoved'> = (tabId, _removeInfo) => {
+  onRemovedTab: CallbackTab<'onRemoved'> = (tabId, info) => {
+    this.windowState.removeTab(tabId, info.windowId);
     this.tabState.clearSessionsByTabId(tabId);
     this.tabState.clearOverpayingByTabId(tabId);
   };
 
   onActivatedTab: CallbackTab<'onActivated'> = async (info) => {
+    this.windowState.addTab(info.tabId, info.windowId);
     const updated = this.windowState.setCurrentTabId(info.windowId, info.tabId);
     if (!updated) return;
     const tab = await this.browser.tabs.get(info.tabId);
@@ -111,11 +113,13 @@ export class TabEvents {
 
   onCreatedTab: CallbackTab<'onCreated'> = async (tab) => {
     if (!tab.id) return;
+    this.windowState.addTab(tab.id, tab.windowId);
     await this.updateVisualIndicators(tab.id, tab.url);
   };
 
   onFocussedTab = async (tab: Tabs.Tab) => {
     if (!tab.id) return;
+    this.windowState.addTab(tab.id, tab.windowId);
     const updated = this.windowState.setCurrentTabId(tab.windowId!, tab.id);
     if (!updated) return;
     const tabUrl = tab.url ?? (await this.browser.tabs.get(tab.id)).url;

--- a/src/background/services/windowState.ts
+++ b/src/background/services/windowState.ts
@@ -56,13 +56,12 @@ export class WindowState {
   }
 
   /**
-   * Browsers like Edge, Vivaldi allow having multiple tabs in same "view". We
-   * can use this data to resume/pause monetization for multiple tabs on window
-   * focus change, not just the one active tab that browser APIs return.
+   * For given window, get the list of tabs that are currently in view.
    *
-   * For given window, we store the set of tabs that are currently in view. We
-   * only store per window, as we don't have anything like a view ID, and we
-   * reset the view when new tab is opened or switched.
+   * Browsers like Edge, Vivaldi allow having multiple tabs in same "view"
+   * (split-view, tab-tiling). We can use this data to resume/pause monetization
+   * for multiple tabs on window focus change, not just the one active tab that
+   * browser APIs return.
    */
   async getTabsForCurrentView(
     windowId: WindowId = this.getCurrentWindowId(),

--- a/src/background/services/windowState.ts
+++ b/src/background/services/windowState.ts
@@ -1,0 +1,44 @@
+import type { TabId, WindowId } from '@/shared/types';
+import type { Cradle } from '@/background/container';
+import { getCurrentActiveTab } from '@/background/utils';
+
+export class WindowState {
+  private browser: Cradle['browser'];
+  private currentWindowId: WindowId;
+  private currentTab = new Map<WindowId, TabId>();
+
+  constructor({ browser }: Cradle) {
+    Object.assign(this, { browser });
+  }
+
+  setCurrentWindowId(windowId: WindowId) {
+    this.currentWindowId = windowId;
+  }
+
+  getCurrentWindowId() {
+    return this.currentWindowId;
+  }
+
+  setCurrentTabId(windowId: WindowId, tabId: TabId) {
+    const existing = this.currentTab.get(windowId);
+    if (existing === tabId) return false;
+    this.currentTab.set(windowId, tabId);
+    return true;
+  }
+
+  getCurrentTabId(windowId: WindowId = this.getCurrentWindowId()) {
+    return this.currentTab.get(windowId);
+  }
+
+  async getCurrentTab(windowId: WindowId = this.getCurrentWindowId()) {
+    const tabId = this.getCurrentTabId(windowId);
+    const tab = tabId
+      ? await this.browser.tabs.get(tabId)
+      : await getCurrentActiveTab(this.browser);
+    return tab;
+  }
+
+  onWindowRemoved = (windowId: WindowId) => {
+    this.currentTab.delete(windowId);
+  };
+}

--- a/src/background/services/windowState.ts
+++ b/src/background/services/windowState.ts
@@ -1,26 +1,86 @@
+import type { Browser } from 'webextension-polyfill';
 import type { TabId, WindowId } from '@/shared/types';
 import type { Cradle } from '@/background/container';
 import { getCurrentActiveTab } from '@/background/utils';
 
+type CallbackWindow<
+  T extends Extract<keyof Browser['windows'], `on${string}`>,
+> = Parameters<Browser['windows'][T]['addListener']>[0];
+
 export class WindowState {
   private browser: Cradle['browser'];
+  private message: Cradle['message'];
+
   private currentWindowId: WindowId;
   private currentTab = new Map<WindowId, TabId>();
+  /**
+   * In Edge's split view, `browser.tabs.query({ windowId })` doesn't return
+   * all tabs. So, we maintain the set of tabs per window.
+   */
+  private tabs = new Map<WindowId, Set<TabId>>();
 
-  constructor({ browser }: Cradle) {
-    Object.assign(this, { browser });
+  constructor({ browser, message }: Cradle) {
+    Object.assign(this, { browser, message });
   }
 
   setCurrentWindowId(windowId: WindowId) {
+    if (this.currentWindowId === windowId) {
+      return false;
+    }
     this.currentWindowId = windowId;
+    return true;
   }
 
   getCurrentWindowId() {
     return this.currentWindowId;
   }
 
+  addTab(tabId: TabId, windowId: WindowId = this.getCurrentWindowId()) {
+    const tabs = this.tabs.get(windowId);
+    if (tabs) {
+      const prevSize = tabs.size;
+      tabs.add(tabId);
+      return prevSize !== tabs.size;
+    } else {
+      this.tabs.set(windowId, new Set([tabId]));
+      return true;
+    }
+  }
+
+  removeTab(tabId: TabId, windowId: WindowId = this.getCurrentWindowId()) {
+    return this.tabs.get(windowId)?.delete(tabId) ?? false;
+  }
+
+  getTabs(windowId: WindowId = this.getCurrentWindowId()): TabId[] {
+    return Array.from(this.tabs.get(windowId) ?? []);
+  }
+
+  /**
+   * Browsers like Edge, Vivaldi allow having multiple tabs in same "view". We
+   * can use this data to resume/pause monetization for multiple tabs on window
+   * focus change, not just the one active tab that browser APIs return.
+   *
+   * For given window, we store the set of tabs that are currently in view. We
+   * only store per window, as we don't have anything like a view ID, and we
+   * reset the view when new tab is opened or switched.
+   */
+  async getTabsForCurrentView(
+    windowId: WindowId = this.getCurrentWindowId(),
+  ): Promise<TabId[]> {
+    const TOP_FRAME_ID = 0;
+    const tabs = this.getTabs(windowId);
+    const responses = await Promise.all(
+      tabs.map((tabId) =>
+        this.message
+          .sendToTab(tabId, TOP_FRAME_ID, 'IS_TAB_IN_VIEW', undefined)
+          .then((r) => (r.success ? r.payload : null)),
+      ),
+    );
+    return tabs.filter((_, i) => responses[i]);
+  }
+
   setCurrentTabId(windowId: WindowId, tabId: TabId) {
-    const existing = this.currentTab.get(windowId);
+    const existing = this.getCurrentTabId(windowId);
     if (existing === tabId) return false;
     this.currentTab.set(windowId, tabId);
     return true;
@@ -38,7 +98,27 @@ export class WindowState {
     return tab;
   }
 
-  onWindowRemoved = (windowId: WindowId) => {
+  onWindowCreated: CallbackWindow<'onCreated'> = async (window) => {
+    if (window.type && window.type !== 'normal') {
+      return;
+    }
+
+    const prevWindowId = this.getCurrentWindowId();
+    const prevTabId = this.getCurrentTabId(prevWindowId);
+    // if the window was created with a tab (like move tab to new window),
+    // remove tab from previous window
+    if (prevWindowId && window.id !== prevWindowId) {
+      if (prevTabId) {
+        const tab = await this.browser.tabs.get(prevTabId);
+        if (tab.windowId !== prevWindowId) {
+          this.removeTab(prevTabId, prevWindowId);
+        }
+      }
+    }
+  };
+
+  onWindowRemoved: CallbackWindow<'onRemoved'> = (windowId) => {
     this.currentTab.delete(windowId);
+    this.tabs.delete(windowId);
   };
 }

--- a/src/background/services/windowState.ts
+++ b/src/background/services/windowState.ts
@@ -72,7 +72,8 @@ export class WindowState {
       tabs.map((tabId) =>
         this.message
           .sendToTab(tabId, TOP_FRAME_ID, 'IS_TAB_IN_VIEW', undefined)
-          .then((r) => (r.success ? r.payload : null)),
+          .then((r) => (r.success ? r.payload : null))
+          .catch(() => null),
       ),
     );
     return tabs.filter((_, i) => responses[i]);

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -1,5 +1,10 @@
-import type { AmountValue, GrantDetails, WalletAmount } from '@/shared/types';
-import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
+import type {
+  AmountValue,
+  GrantDetails,
+  Tab,
+  WalletAmount,
+} from '@/shared/types';
+import type { Browser, Runtime } from 'webextension-polyfill';
 import { DEFAULT_SCALE, EXCHANGE_RATES_URL } from './config';
 import { notNullOrUndef } from '@/shared/helpers';
 
@@ -81,8 +86,8 @@ export const getTabId = (sender: Runtime.MessageSender): number => {
   return notNullOrUndef(notNullOrUndef(sender.tab, 'sender.tab').id, 'tab.id');
 };
 
-export const getTab = (sender: Runtime.MessageSender): Tabs.Tab => {
-  return notNullOrUndef(notNullOrUndef(sender.tab, 'sender.tab'), 'tab');
+export const getTab = (sender: Runtime.MessageSender): Tab => {
+  return notNullOrUndef(notNullOrUndef(sender.tab, 'sender.tab'), 'tab') as Tab;
 };
 
 export const getSender = (sender: Runtime.MessageSender) => {

--- a/src/content/services/contentScript.ts
+++ b/src/content/services/contentScript.ts
@@ -1,6 +1,6 @@
 import type { ToContentMessage } from '@/shared/messages';
 import type { Cradle } from '@/content/container';
-import { failure } from '@/shared/helpers';
+import { failure, success } from '@/shared/helpers';
 
 export class ContentScript {
   private browser: Cradle['browser'];
@@ -54,6 +54,8 @@ export class ContentScript {
                 message.payload,
               );
               return;
+            case 'IS_TAB_IN_VIEW':
+              return success(document.visibilityState === 'visible');
             default:
               return;
           }

--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -106,10 +106,8 @@ export class MonetizationLinkManager extends EventEmitter {
       'visibilitychange',
       this.onDocumentVisibilityChange,
     );
-    if (this.isTopFrame) {
-      this.onFocus();
-      this.window.addEventListener('focus', this.onFocus);
-    }
+    this.onFocus();
+    this.window.addEventListener('focus', this.onFocus);
 
     if (!this.isTopFrame && this.isFirstLevelFrame) {
       this.window.addEventListener('message', this.onWindowMessage);

--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -95,6 +95,7 @@ export class MonetizationLinkManager extends EventEmitter {
       this.onDocumentVisibilityChange,
     );
     this.window.removeEventListener('message', this.onWindowMessage);
+    this.window.removeEventListener('focus', this.onFocus);
   }
 
   /**
@@ -105,6 +106,8 @@ export class MonetizationLinkManager extends EventEmitter {
       'visibilitychange',
       this.onDocumentVisibilityChange,
     );
+    this.onFocus();
+    this.window.addEventListener('focus', this.onFocus);
 
     if (!this.isTopFrame && this.isFirstLevelFrame) {
       this.window.addEventListener('message', this.onWindowMessage);
@@ -346,6 +349,12 @@ export class MonetizationLinkManager extends EventEmitter {
       await this.resumeMonetization();
     } else {
       await this.stopMonetization();
+    }
+  };
+
+  private onFocus = async () => {
+    if (this.document.hasFocus()) {
+      await this.message.send('TAB_FOCUSED');
     }
   };
 

--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -106,8 +106,10 @@ export class MonetizationLinkManager extends EventEmitter {
       'visibilitychange',
       this.onDocumentVisibilityChange,
     );
-    this.onFocus();
-    this.window.addEventListener('focus', this.onFocus);
+    if (this.isTopFrame) {
+      this.onFocus();
+      this.window.addEventListener('focus', this.onFocus);
+    }
 
     if (!this.isTopFrame && this.isFirstLevelFrame) {
       this.window.addEventListener('message', this.onWindowMessage);

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -263,3 +263,28 @@ export const getNextOccurrence = (
 
   return date;
 };
+
+export type BrowserName = 'chrome' | 'edge' | 'firefox' | 'unknown';
+
+export const getBrowserName = (
+  browser: Browser,
+  userAgent: string,
+): BrowserName => {
+  const url = browser.runtime.getURL('');
+  if (url.startsWith('moz-extension://')) {
+    return 'firefox';
+  }
+  if (url.startsWith('extension://')) {
+    // works only in Playwright?
+    return 'edge';
+  }
+
+  if (url.startsWith('chrome-extension://')) {
+    if (userAgent.includes('Edg/')) {
+      return 'edge';
+    }
+    return 'chrome';
+  }
+
+  return 'unknown';
+};

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -221,6 +221,10 @@ export type BackgroundToContentMessage = {
     input: MonetizationEventPayload;
     output: never;
   };
+  IS_TAB_IN_VIEW: {
+    input: undefined;
+    output: boolean;
+  };
 };
 
 export type ToContentMessage = {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -173,6 +173,10 @@ export type ContentToBackgroundMessage = {
     input: GetWalletAddressInfoPayload;
     output: WalletAddress;
   };
+  TAB_FOCUSED: {
+    input: never;
+    output: never;
+  };
   STOP_MONETIZATION: {
     input: StopMonetizationPayload;
     output: never;
@@ -184,10 +188,6 @@ export type ContentToBackgroundMessage = {
   RESUME_MONETIZATION: {
     input: ResumeMonetizationPayload;
     output: never;
-  };
-  IS_WM_ENABLED: {
-    input: never;
-    output: boolean;
   };
 };
 // #endregion

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,5 +108,8 @@ export type DeepNonNullable<T> = {
   [P in keyof T]?: NonNullable<T[P]>;
 };
 
+export type RequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+export type Tab = RequiredFields<Tabs.Tab, 'id' | 'url'>;
 export type TabId = NonNullable<Tabs.Tab['id']>;
 export type WindowId = NonNullable<Tabs.Tab['windowId']>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,3 +109,4 @@ export type DeepNonNullable<T> = {
 };
 
 export type TabId = NonNullable<Tabs.Tab['id']>;
+export type WindowId = NonNullable<Tabs.Tab['windowId']>;


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/67

Why:
- In Edge, `browser.tabs.query()` skips tabs in right-pane of split-view, as if it don't exist. So, we need to keep track of existing tabs in a window ourselves.
- Similarly, we can't know which tab was last focused.
- There's no API to tell which all tabs are visible (that can be monetized) in a Edge split-view or Vivaldi tab-tiling view.

## Changes proposed in this pull request

- Fire a `TAB_FOCUSED` event from content script, on load (if focused) and on focus change (if focused).
- Use the `sender.tab.id` from above event to store last focused tabId for given window.
- Store that info in newly added `WindowState` service.
- Also store last focused window in above service.
- Note: Both pages in split-mode are monetized together.
- For Edge, if we call `browser.action.setIcon()` with a tabId, it'll only update the icon for the left pane. So, added a `browserName` value, and skip using `tabId` for Edge when setting icon. This will set a global icon for Edge, but other browsers stay like before.
- Instead of relying on `onActivatedTab` which is buggy in Edge with split-view, rely on `TAB_FOCUSED` events' `sender.tab.id` to update icon state. Also use this last focused tab to show popup content.
- In order to support start/stop monetizing all tabs in given view on window focus change (not same as `visibilitychange`, which works like before), we send `IS_TAB_IN_VIEW` message to content script (top frame only) to know if tab is currently visible. This way, we get all visible tabs in current window.
- Remove `IS_WM_ENABLED` message as unused.
- Made some improvements to avoid needless checking need to pause/resume on focus change when extension popup is opened.

For reviewers: Radu is on vacation so I was asked to ask you good folks instead.

## To be decided

Right now, the rate of pay is decided per tab, using the global rate of pay. Now we have multiple active visible tabs getting monetized, so the effective global rate of pay is multiplied by number of active visible tabs - user is paying more than they initially set to as they're paying multiple websites at once. In future, we'll have exception lists (https://github.com/interledger/web-monetization-extension/issues/146), which will again make rate of pay per site/tab.