### PR TITLE
fix: update popup tab data along with icon

### DIFF
--- a/src/background/constants.ts
+++ b/src/background/constants.ts
@@ -1,0 +1,15 @@
+// cSpell:ignore newtab, webui, startpage
+
+export const INTERNAL_PAGE_URL_PROTOCOLS = new Set([
+  'chrome:',
+  'about:',
+  'edge:',
+]);
+
+export const NEW_TAB_PAGES = [
+  'about:blank',
+  'chrome://newtab',
+  'about:newtab',
+  'edge://newtab',
+  'chrome://vivaldi-webui/startpage',
+];

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -296,7 +296,7 @@ export class Background {
   private async updateVisualIndicatorsForCurrentTab() {
     const activeTab = await this.windowState.getCurrentTab();
     if (activeTab?.id) {
-      void this.tabEvents.updateVisualIndicators(activeTab.id, activeTab.url);
+      void this.tabEvents.updateVisualIndicators(activeTab);
     }
   }
 
@@ -313,7 +313,7 @@ export class Background {
 
     this.events.on('monetization.state_update', async (tabId) => {
       const tab = await this.browser.tabs.get(tabId);
-      void this.tabEvents.updateVisualIndicators(tabId, tab?.url);
+      void this.tabEvents.updateVisualIndicators(tab);
     });
 
     this.events.on('storage.balance_update', (balance) =>

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -8,7 +8,6 @@ import { PaymentSession } from './paymentSession';
 import { computeRate, getSender, getTabId } from '../utils';
 import { isOutOfBalanceError } from './openPayments';
 import { isOkState, removeQueryParams } from '@/shared/helpers';
-import { ALLOWED_PROTOCOLS } from '@/shared/defines';
 import type { AmountValue, PopupStore, Storage } from '@/shared/types';
 import type { Cradle } from '../container';
 
@@ -386,35 +385,14 @@ export class MonetizationService {
 
     const { oneTimeGrant, recurringGrant, ...dataFromStorage } = storedData;
 
-    const tabId = tab.id;
-    if (!tabId) {
-      throw new Error('Tab ID not found');
-    }
-    let url;
-    if (tab && tab.url) {
-      try {
-        const tabUrl = new URL(tab.url);
-        if (ALLOWED_PROTOCOLS.includes(tabUrl.protocol)) {
-          // Do not include search params
-          url = `${tabUrl.origin}${tabUrl.pathname}`;
-        }
-      } catch {
-        // noop
-      }
-    }
-    const isSiteMonetized = this.tabState.isTabMonetized(tabId);
-    const hasAllSessionsInvalid = this.tabState.tabHasAllSessionsInvalid(tabId);
-
     return {
       ...dataFromStorage,
       balance: balance.total.toString(),
-      url,
+      tab: this.tabState.getPopupTabData(tab),
       grants: {
         oneTime: oneTimeGrant?.amount,
         recurring: recurringGrant?.amount,
       },
-      isSiteMonetized,
-      hasAllSessionsInvalid,
     };
   }
 

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/shared/types';
 import type { Browser, Runtime } from 'webextension-polyfill';
 import { DEFAULT_SCALE, EXCHANGE_RATES_URL } from './config';
+import { INTERNAL_PAGE_URL_PROTOCOLS, NEW_TAB_PAGES } from './constants';
 import { notNullOrUndef } from '@/shared/helpers';
 
 export const getCurrentActiveTab = async (browser: Browser) => {
@@ -95,6 +96,14 @@ export const getSender = (sender: Runtime.MessageSender) => {
   const frameId = notNullOrUndef(sender.frameId, 'sender.frameId');
 
   return { tabId, frameId, url: sender.url };
+};
+
+export const isBrowserInternalPage = (url: URL) => {
+  return INTERNAL_PAGE_URL_PROTOCOLS.has(url.protocol);
+};
+
+export const isBrowserNewTabPage = (url: URL) => {
+  return NEW_TAB_PAGES.some((e) => url.href.startsWith(e));
 };
 
 export const computeRate = (rate: string, sessionsCount: number): AmountValue =>

--- a/src/popup/components/PayWebsiteForm.tsx
+++ b/src/popup/components/PayWebsiteForm.tsx
@@ -26,7 +26,7 @@ const BUTTON_STATE = {
 export const PayWebsiteForm = () => {
   const message = useMessage();
   const {
-    state: { walletAddress, url },
+    state: { walletAddress, tab },
   } = usePopupState();
   const [buttonState, setButtonState] =
     React.useState<keyof typeof BUTTON_STATE>('idle');
@@ -84,7 +84,7 @@ export const PayWebsiteForm = () => {
         addOn={getCurrencySymbol(walletAddress.assetCode)}
         label={
           <p className="overflow-hidden text-ellipsis whitespace-nowrap">
-            Pay <span className="text-ellipsis text-primary">{url}</span>
+            Pay <span className="text-ellipsis text-primary">{tab.url}</span>
           </p>
         }
         placeholder="0.00"

--- a/src/popup/lib/context.tsx
+++ b/src/popup/lib/context.tsx
@@ -73,12 +73,10 @@ const reducer = (state: PopupState, action: ReducerActions): PopupState => {
       return { ...state, rateOfPay: action.data.rateOfPay };
     case 'SET_STATE':
       return { ...state, state: action.data.state };
-    case 'SET_IS_MONETIZED':
-      return { ...state, isSiteMonetized: action.data };
+    case 'SET_TAB_DATA':
+      return { ...state, tab: action.data };
     case 'SET_BALANCE':
       return { ...state, balance: action.data.total };
-    case 'SET_ALL_SESSIONS_INVALID':
-      return { ...state, hasAllSessionsInvalid: action.data };
     default:
       return state;
   }
@@ -113,8 +111,7 @@ export function PopupContextProvider({ children }: PopupContextProviderProps) {
       switch (message.type) {
         case 'SET_BALANCE':
         case 'SET_STATE':
-        case 'SET_IS_MONETIZED':
-        case 'SET_ALL_SESSIONS_INVALID':
+        case 'SET_TAB_DATA':
           return dispatch(message);
       }
     });

--- a/src/popup/pages/Home.tsx
+++ b/src/popup/pages/Home.tsx
@@ -19,14 +19,12 @@ export const Component = () => {
   const {
     state: {
       enabled,
-      isSiteMonetized,
       rateOfPay,
       minRateOfPay,
       maxRateOfPay,
       balance,
       walletAddress,
-      url,
-      hasAllSessionsInvalid,
+      tab,
     },
     dispatch,
   } = usePopupState();
@@ -65,12 +63,12 @@ export const Component = () => {
     dispatch({ type: 'TOGGLE_WM', data: {} });
   };
 
-  if (!isSiteMonetized) {
-    return <SiteNotMonetized />;
-  }
-
-  if (hasAllSessionsInvalid) {
-    return <AllSessionsInvalid />;
+  if (tab.status !== 'monetized') {
+    if (tab.status === 'all_sessions_invalid') {
+      return <AllSessionsInvalid />;
+    } else {
+      return <SiteNotMonetized />;
+    }
   }
 
   return (
@@ -113,7 +111,7 @@ export const Component = () => {
 
       <hr />
 
-      {url ? <PayWebsiteForm /> : null}
+      {tab.url ? <PayWebsiteForm /> : null}
     </div>
   );
 };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -243,9 +243,8 @@ export const BACKGROUND_TO_POPUP_CONNECTION_NAME = 'popup';
 // These methods are fire-and-forget, nothing is returned.
 export interface BackgroundToPopupMessagesMap {
   SET_BALANCE: Record<'recurring' | 'oneTime' | 'total', AmountValue>;
-  SET_IS_MONETIZED: boolean;
+  SET_TAB_DATA: PopupState['tab'];
   SET_STATE: { state: Storage['state']; prevState: Storage['state'] };
-  SET_ALL_SESSIONS_INVALID: boolean;
 }
 
 export type BackgroundToPopupMessage = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -85,6 +85,29 @@ export interface Storage {
 }
 export type StorageKey = keyof Storage;
 
+export type PopupTabInfo = {
+  tabId: TabId;
+  url: string;
+  status:
+    | never // just added for code formatting
+    /** Happy state */
+    | 'monetized'
+    /** No monetization links or all links disabled */
+    | 'no_monetization_links'
+    /** New tab */
+    | 'new_tab'
+    /** Browser internal pages */
+    | 'internal_page'
+    /** Not https:// */
+    | 'unsupported_scheme'
+    /**
+     * All wallet addresses belong to wallets that are not peered with the
+     * connected wallet, or cannot receive payments for some other reason.
+     */
+    | 'all_sessions_invalid'
+    | never; // just added for code formatting
+};
+
 export type PopupStore = Omit<
   Storage,
   | 'version'
@@ -95,13 +118,11 @@ export type PopupStore = Omit<
   | 'oneTimeGrant'
 > & {
   balance: AmountValue;
-  isSiteMonetized: boolean;
-  url: string | undefined;
+  tab: PopupTabInfo;
   grants?: Partial<{
     oneTime: OneTimeGrant['amount'];
     recurring: RecurringGrant['amount'];
   }>;
-  hasAllSessionsInvalid: boolean;
 };
 
 export type DeepNonNullable<T> = {


### PR DESCRIPTION
- Closes https://github.com/interledger/web-monetization-extension/issues/560
- Will help with https://github.com/interledger/web-monetization-extension/issues/584

## Changes proposed in this pull request

- refactor(PopupState): add all popup data related to tab under `tab`
   - `tabUrl` -> `tab.url`
   - `isSiteMonetized` -> `tab.status === 'monetized'`
   - `hasAllSessionsInvalid` -> `tab.status === 'all_sessions_invalid'`
- refactor(monetization): extract `getPopupTabData` to tabState service
- refactor(tabEvents): use `getPopupTabData` instead of multiple params

Paves way to show more useful messages with `tab.status` (e.g. new tab, internal extension pages, non-https pages)