### PR TITLE
fix(bg/openPayments): handle tab close before accept

### DIFF
--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -21,7 +21,7 @@ import * as ed from '@noble/ed25519';
 import { type Request } from 'http-message-signatures';
 import { signMessage } from 'http-message-signatures/lib/httpbis';
 import { createContentDigestHeader } from 'httpbis-digest-headers';
-import type { Tabs } from 'webextension-polyfill';
+import type { Browser, Tabs } from 'webextension-polyfill';
 import { getExchangeRates, getRateOfPay, toAmount } from '../utils';
 import { exportJWK, generateEd25519KeyPair } from '@/shared/crypto';
 import { bytesToHex } from '@noble/hashes/utils';
@@ -89,6 +89,9 @@ interface CreateOutgoingPaymentParams {
 }
 
 type TabUpdateCallback = Parameters<Tabs.onUpdatedEvent['addListener']>[0];
+type TabRemovedCallback = Parameters<
+  Browser['tabs']['onRemoved']['addListener']
+>[0];
 
 const enum ErrorCode {
   CONTINUATION_FAILED = 'continuation_failed',
@@ -570,9 +573,16 @@ export class OpenPaymentsService {
   }
 
   private async getInteractionInfo(url: string): Promise<InteractionParams> {
-    return await new Promise((res) => {
+    return await new Promise((resolve, reject) => {
       this.browser.tabs.create({ url }).then((tab) => {
         if (!tab.id) return;
+        const tabCloseListener: TabRemovedCallback = (tabId) => {
+          if (tabId !== tab.id) return;
+
+          this.browser.tabs.onRemoved.removeListener(tabCloseListener);
+          reject(new Error('Tab closed before getting interaction info'));
+        };
+
         const getInteractionInfo: TabUpdateCallback = async (
           tabId,
           changeInfo,
@@ -590,15 +600,18 @@ export class OpenPaymentsService {
               result === 'grant_invalid'
             ) {
               this.browser.tabs.onUpdated.removeListener(getInteractionInfo);
+              this.browser.tabs.onRemoved.removeListener(tabCloseListener);
             }
 
             if (interactRef && hash) {
-              res({ interactRef, hash, tabId });
+              resolve({ interactRef, hash, tabId });
             }
           } catch {
             /* do nothing */
           }
         };
+
+        this.browser.tabs.onRemoved.addListener(tabCloseListener);
         this.browser.tabs.onUpdated.addListener(getInteractionInfo);
       });
     });


### PR DESCRIPTION
Reject if user closes tab before accepting. Prevent leaving a dangling tab watcher.

Rejection not need to be handled at the moment, but will be handled as a part of https://github.com/interledger/web-monetization-extension/issues/626 so we can show user any errors or progress as needed.