### PR TITLE
feat: auto-add key to wallet, support for test wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ All commands are run from the root of the project, from a terminal:
 
 Inside this project, you'll see the following folders and files:
 
-```
+```sh
 .
 ├── .github/ # GitHub Workflows
 ├── docs/ # Repository documentation
@@ -85,7 +85,8 @@ Inside this project, you'll see the following folders and files:
 │   ├── _locales/ # Files for multi-lang support
 │   ├── assets/ # Images for the extension (icon, etc.)
 │   ├── background/ # Source code for the background script/service worker
-│   ├── content/ # Source  code for the content script
+│   ├── content/ # Source  code for the content scripts
+│   │   └── keyAutoAdd/ # content scripts for automatic key addition to wallets
 │   ├── popup/ # Source code for the popup UI
 │   ├── shared/ # Shared utilities
 │   └── manifest.json # Extension's manifest - processed by Webpack depending on the target build

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -14,6 +14,8 @@ iframes
 unmangles
 data-testid
 nums
+jwks
+requestfinished
 
 # scripts and 3rd party terms
 nvmrc

--- a/esbuild/config.ts
+++ b/esbuild/config.ts
@@ -29,6 +29,10 @@ export const options: BuildOptions = {
       out: path.join('content', 'content'),
     },
     {
+      in: path.join(SRC_DIR, 'content', 'keyAutoAdd', 'testWallet.ts'),
+      out: path.join('content', 'keyAutoAdd', 'testWallet'),
+    },
+    {
       in: path.join(SRC_DIR, 'content', 'polyfill.ts'),
       out: path.join('polyfill', 'polyfill'),
     },

--- a/esbuild/dev.ts
+++ b/esbuild/dev.ts
@@ -69,7 +69,7 @@ function liveReloadPlugin({ target }: { target: Target }): ESBuildPlugin {
     new EventSource("http://localhost:${port}/esbuild").addEventListener(
       "change",
       (ev) => {
-        const patterns = ["background.js", "content.js", "polyfill.js"];
+        const patterns = ["background.js", "content.js", "polyfill.js", "keyAutoAdd/"];
         const data = JSON.parse(ev.data);
         if (data.updated.some((s) => patterns.some(e => s.includes(e)))) {
           globalThis.location.reload();

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -173,10 +173,19 @@
     "message": "Automatic key addition is not implemented for given wallet provider yet."
   },
   "connectWalletKeyService_error_failed": {
-    "message": "Automatic key addition failed at step `$STEP_ID$` with message `$MESSAGE$`.",
+    "message": "Automatic key addition failed at step “$STEP_ID$” with message “$MESSAGE$”.",
     "placeholders": {
-      "STEP_ID": { "content": "$1", "example": "Some step ID" },
-      "MESSAGE": { "content": "$2", "example": "Error message" }
+      "STEP_ID": { "content": "$1", "example": "Doing something" },
+      "MESSAGE": { "content": "$2", "example": "Could not do something" }
     }
+  },
+  "connectWalletKeyService_error_timeoutLogin": {
+    "message": "Timed out waiting for login"
+  },
+  "connectWalletKeyService_error_skipAlreadyLoggedIn": {
+    "message": "Already logged in"
+  },
+  "connectWalletKeyService_error_accountNotFound": {
+    "message": "Failed to find account for given wallet address. Are you logged in to some other account?"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -171,5 +171,12 @@
   },
   "connectWalletKeyService_error_notImplemented": {
     "message": "Automatic key addition is not implemented for given wallet provider yet."
+  },
+  "connectWalletKeyService_error_failed": {
+    "message": "Automatic key addition failed at step `$STEP_ID$` with message `$MESSAGE$`.",
+    "placeholders": {
+      "STEP_ID": { "content": "$1", "example": "Some step ID" },
+      "MESSAGE": { "content": "$2", "example": "Error message" }
+    }
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -169,6 +169,9 @@
   "connectWallet_error_tabClosed": {
     "message": "Connect wallet cancelled. You closed the tab before completion."
   },
+  "connectWallet_error_grantRejected": {
+    "message": "Connect wallet cancelled. You rejected the request."
+  },
   "connectWalletKeyService_error_notImplemented": {
     "message": "Automatic key addition is not implemented for given wallet provider yet."
   },

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -197,7 +197,7 @@ export class Background {
               if (message.payload.recurring) {
                 this.scheduleResetOutOfFundsState();
               }
-              return;
+              return success(undefined);
 
             case 'RECONNECT_WALLET': {
               await this.openPaymentsService.reconnectWallet();

--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -152,9 +152,7 @@ export function walletAddressToProvider(walletAddress: WalletAddress): {
   const { host } = new URL(walletAddress.id);
   switch (host) {
     case 'ilp.rafiki.money':
-      return {
-        url: 'https://rafiki.money/settings/developer-keys',
-      };
+      return { url: 'https://rafiki.money/settings/developer-keys' };
     // case 'eu1.fynbos.me': // fynbos dev
     // case 'fynbos.me': // fynbos production
     default:

--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -1,4 +1,9 @@
-import { ErrorWithKey, ensureEnd, withResolvers } from '@/shared/helpers';
+import {
+  ErrorWithKey,
+  ensureEnd,
+  isErrorWithKey,
+  withResolvers,
+} from '@/shared/helpers';
 import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { TabId } from '@/shared/types';
@@ -50,6 +55,7 @@ export class KeyAutoAddService {
         keyId,
         walletAddressUrl: walletAddress.id,
         nickName: this.t('appName') + ' - ' + this.browserName,
+        keyAddUrl: info.url,
       });
       await this.validate(walletAddress.id, keyId);
     } catch (error) {
@@ -110,10 +116,11 @@ export class KeyAutoAddService {
       } else if (message.action === 'ERROR') {
         this.browser.runtime.onConnect.removeListener(onConnectListener);
         this.browser.tabs.onRemoved.removeListener(onTabCloseListener);
+        const { stepName, details: err } = message.payload;
         reject(
           new ErrorWithKey('connectWalletKeyService_error_failed', [
-            message.payload.stepName,
-            message.payload.error.message,
+            stepName,
+            isErrorWithKey(err.error) ? this.t(err.error) : err.message,
           ]),
         );
       } else if (message.action === 'PROGRESS') {

--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -1,5 +1,4 @@
-// cSpell:ignore jwks
-import { ErrorWithKey, withResolvers } from '@/shared/helpers';
+import { ErrorWithKey, ensureEnd, withResolvers } from '@/shared/helpers';
 import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { TabId } from '@/shared/types';
@@ -132,7 +131,7 @@ export class KeyAutoAddService {
 
   private async validate(walletAddressUrl: string, keyId: string) {
     type JWKS = { keys: { kid: string }[] };
-    const jwksUrl = new URL('jwks.json', walletAddressUrl + '/');
+    const jwksUrl = new URL('jwks.json', ensureEnd(walletAddressUrl, '/'));
     const res = await fetch(jwksUrl.toString());
     const jwks: JWKS = await res.json();
     if (!jwks.keys.find((key) => key.kid === keyId)) {

--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -24,12 +24,18 @@ type OnPortMessageListener = Parameters<
 export class KeyAutoAddService {
   private browser: Cradle['browser'];
   private storage: Cradle['storage'];
+  private browserName: Cradle['browserName'];
+  private t: Cradle['t'];
 
-  private status: null | 'SUCCESS' | 'ERROR' = null;
   private tab: Tabs.Tab | null = null;
 
-  constructor({ browser, storage }: Pick<Cradle, 'browser' | 'storage'>) {
-    Object.assign(this, { browser, storage });
+  constructor({
+    browser,
+    storage,
+    browserName,
+    t,
+  }: Pick<Cradle, 'browser' | 'storage' | 'browserName' | 't'>) {
+    Object.assign(this, { browser, storage, browserName, t });
   }
 
   async addPublicKeyToWallet(walletAddress: WalletAddress) {
@@ -44,7 +50,7 @@ export class KeyAutoAddService {
         publicKey,
         keyId,
         walletAddressUrl: walletAddress.id,
-        nickName: 'web monetization extension',
+        nickName: this.t('appName') + ' - ' + this.browserName,
       });
       await this.validate(walletAddress.id, keyId);
     } catch (error) {

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -118,7 +118,7 @@ export class KeyShareService {
         );
       } else if (message.action === 'PROGRESS') {
         // can save progress to show in popup
-        console.table(message.payload.steps);
+        // console.table(message.payload.steps);
       } else {
         reject(new Error(`Unexpected message: ${JSON.stringify(message)}`));
       }

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -1,0 +1,141 @@
+import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
+import type { WalletAddress } from '@interledger/open-payments';
+import type { Cradle } from '@/background/container';
+import { ErrorWithKey, withResolvers } from '@/shared/helpers';
+
+export const CONNECTION_NAME = 'key-share';
+
+type OnTabRemovedCallback = Parameters<
+  Browser['tabs']['onRemoved']['addListener']
+>[0];
+type OnConnectCallback = Parameters<
+  Browser['runtime']['onConnect']['addListener']
+>[0];
+type OnPortMessageListener = Parameters<
+  Runtime.Port['onMessage']['addListener']
+>[0];
+
+type BeginPayload = { walletAddressUrl: string; publicKey: string };
+
+export class KeyShareService {
+  private browser: Cradle['browser'];
+  private storage: Cradle['storage'];
+
+  private status: null | 'SUCCESS' | 'ERROR' = null;
+  private tab: Tabs.Tab | null = null;
+
+  constructor({ browser, storage }: Pick<Cradle, 'browser' | 'storage'>) {
+    Object.assign(this, { browser, storage });
+  }
+
+  async addPublicKeyToWallet(walletAddress: WalletAddress) {
+    const { publicKey } = await this.storage.get(['publicKey']);
+    if (!publicKey) {
+      // won't happen, just added for lint fix
+      throw new Error('No public key found');
+    }
+    const info = walletAddressToProvider(walletAddress);
+    try {
+      this.setConnectState('adding-key');
+      await this.process(info.url, {
+        publicKey,
+        walletAddressUrl: walletAddress.id,
+      });
+    } catch (error) {
+      if (this.tab?.id) {
+        // can redirect to OPEN_PAYMENTS_REDIRECT_URL
+        await this.browser.tabs.remove(this.tab.id);
+      }
+      this.setConnectState('error-key');
+      throw error;
+    }
+  }
+
+  private async process(
+    url: string,
+    { walletAddressUrl, publicKey }: BeginPayload,
+  ) {
+    const { resolve, reject, promise } = withResolvers();
+
+    const tab = await this.browser.tabs.create({ url });
+    this.tab = tab;
+    if (!tab.id) {
+      reject(new Error('Could not create tab'));
+      return promise;
+    }
+
+    const onTabCloseListener: OnTabRemovedCallback = (tabId) => {
+      if (tabId !== tab.id) {
+        // ignore. not our tab
+        return;
+      }
+
+      if (this.status === 'SUCCESS') {
+        // ok
+      } else {
+        reject(new Error('Tab closed before completion'));
+      }
+    };
+    this.browser.tabs.onRemoved.addListener(onTabCloseListener);
+
+    const onConnectListener: OnConnectCallback = (port) => {
+      if (port.name !== CONNECTION_NAME) return;
+      if (port.error) {
+        reject(new Error(port.error.message));
+        return;
+      }
+
+      port.postMessage({
+        action: 'BEGIN',
+        payload: { walletAddressUrl, publicKey },
+      });
+
+      port.onMessage.addListener(onMessageListener);
+
+      port.onDisconnect.addListener(() => {
+        // wait for connect again so we can send message again if not connected,
+        // and not errored already (e.g. page refreshed)
+      });
+    };
+
+    const onMessageListener: OnPortMessageListener = (message: {
+      action: string;
+      payload: any;
+    }) => {
+      if (message.action === 'SUCCESS') {
+        resolve(message.payload);
+      } else if (message.action === 'ERROR') {
+        reject(message.payload);
+      } else if (message.action === 'PROGRESS') {
+        // can save progress to show in popup
+      } else {
+        reject(new Error(`Unexpected message: ${JSON.stringify(message)}`));
+      }
+    };
+
+    this.browser.runtime.onConnect.addListener(onConnectListener);
+
+    return promise;
+  }
+
+  private setConnectState(status: 'adding-key' | 'error-key' | null) {
+    const state = status ? { status } : null;
+    this.storage.setPopupTransientState('connect', () => state);
+  }
+}
+
+export function walletAddressToProvider(walletAddress: WalletAddress): {
+  url: string;
+} {
+  const { host } = new URL(walletAddress.id);
+  switch (host) {
+    case 'ilp.rafiki.money':
+      return {
+        url: 'https://rafiki.money/settings/developer-keys',
+      };
+    // case 'eu1.fynbos.me': // fynbos dev
+    // case 'fynbos.me': // fynbos production
+    default:
+      throw new ErrorWithKey('connectWalletKeyService_error_notImplemented');
+  }
+}

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -118,6 +118,7 @@ export class KeyShareService {
         );
       } else if (message.action === 'PROGRESS') {
         // can save progress to show in popup
+        console.table(message.payload.steps);
       } else {
         reject(new Error(`Unexpected message: ${JSON.stringify(message)}`));
       }

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -42,6 +42,7 @@ export class KeyShareService {
       this.setConnectState('connecting:adding-key');
       await this.process(info.url, {
         publicKey,
+        keyId,
         walletAddressUrl: walletAddress.id,
         nickName: 'web monetization extension',
       });

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -39,7 +39,7 @@ export class KeyShareService {
         'publicKey',
         'keyId',
       ]);
-      this.setConnectState('adding-key');
+      this.setConnectState('connecting:adding-key');
       await this.process(info.url, {
         publicKey,
         walletAddressUrl: walletAddress.id,
@@ -47,7 +47,7 @@ export class KeyShareService {
       });
       await this.validate(walletAddress.id, keyId);
     } catch (error) {
-      this.setConnectState('error-key');
+      this.setConnectState('error:key-add');
       throw error;
     }
   }
@@ -137,7 +137,9 @@ export class KeyShareService {
     }
   }
 
-  private setConnectState(status: 'adding-key' | 'error-key' | null) {
+  private setConnectState(
+    status: 'connecting:adding-key' | 'error:key-add' | null,
+  ) {
     const state = status ? { status } : null;
     this.storage.setPopupTransientState('connect', () => state);
   }

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -1,6 +1,7 @@
 import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { Cradle } from '@/background/container';
+import type { ContentToBackgroundMessage } from '@/content/keyAutoAdd/lib/types';
 import { ErrorWithKey, withResolvers } from '@/shared/helpers';
 
 export const CONNECTION_NAME = 'key-share';
@@ -98,15 +99,20 @@ export class KeyShareService {
       });
     };
 
-    const onMessageListener: OnPortMessageListener = (message: {
-      action: string;
-      payload: any;
-    }) => {
+    const onMessageListener: OnPortMessageListener = (
+      message: ContentToBackgroundMessage,
+    ) => {
       if (message.action === 'SUCCESS') {
         resolve(message.payload);
       } else if (message.action === 'ERROR') {
-        reject(message.payload);
+        reject(
+          new ErrorWithKey('connectWalletKeyService_error_failed', [
+            message.payload.stepId,
+            message.payload.error.message,
+          ]),
+        );
       } else if (message.action === 'PROGRESS') {
+        console.log(message);
         // can save progress to show in popup
       } else {
         reject(new Error(`Unexpected message: ${JSON.stringify(message)}`));

--- a/src/background/services/keyShare.ts
+++ b/src/background/services/keyShare.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore jwks
 import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { TabId } from '@/shared/types';
@@ -119,7 +120,6 @@ export class KeyShareService {
           ]),
         );
       } else if (message.action === 'PROGRESS') {
-        console.log(message);
         // can save progress to show in popup
       } else {
         reject(new Error(`Unexpected message: ${JSON.stringify(message)}`));
@@ -132,9 +132,10 @@ export class KeyShareService {
   }
 
   private async validate(walletAddressUrl: string, keyId: string) {
+    type JWKS = { keys: { kid: string }[] };
     const jwksUrl = new URL('jwks.json', walletAddressUrl + '/');
     const res = await fetch(jwksUrl.toString());
-    const jwks = await res.json();
+    const jwks: JWKS = await res.json();
     if (!jwks.keys.find((key) => key.kid === keyId)) {
       throw new Error('Key not found in jwks');
     }

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -24,7 +24,7 @@ import { signMessage } from 'http-message-signatures/lib/httpbis';
 import { createContentDigestHeader } from 'httpbis-digest-headers';
 import type { Browser, Tabs } from 'webextension-polyfill';
 import { getExchangeRates, getRateOfPay, toAmount } from '../utils';
-import { KeyShareService } from './keyShare';
+import { KeyAutoAddService } from './keyAutoAdd';
 import { exportJWK, generateEd25519KeyPair } from '@/shared/crypto';
 import { bytesToHex } from '@noble/hashes/utils';
 import {
@@ -534,15 +534,15 @@ export class OpenPaymentsService {
   private async addPublicKeyToWallet(
     walletAddress: WalletAddress,
   ): Promise<TabId | undefined> {
-    const keyShare = new KeyShareService({
+    const keyAutoAdd = new KeyAutoAddService({
       browser: this.browser,
       storage: this.storage,
     });
     try {
-      await keyShare.addPublicKeyToWallet(walletAddress);
-      return keyShare.tabId;
+      await keyAutoAdd.addPublicKeyToWallet(walletAddress);
+      return keyAutoAdd.tabId;
     } catch (error) {
-      const tabId = keyShare.tabId;
+      const tabId = keyAutoAdd.tabId;
       if (tabId) {
         await this.redirectToWelcomeScreen(
           tabId,

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -560,7 +560,8 @@ export class OpenPaymentsService {
       return keyAutoAdd.tabId;
     } catch (error) {
       const tabId = keyAutoAdd.tabId;
-      if (tabId) {
+      const isTabClosed = error.key === 'connectWallet_error_tabClosed';
+      if (tabId && !isTabClosed) {
         await this.redirectToWelcomeScreen(
           tabId,
           GrantResult.ERROR,

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -708,6 +708,8 @@ export class OpenPaymentsService {
 
         if (interactRef && hash) {
           resolve({ interactRef, hash, tabId });
+        } else if (result === 'grant_rejected') {
+          reject(new ErrorWithKey('connectWallet_error_grantRejected'));
         }
       } catch {
         /* do nothing */

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -650,12 +650,17 @@ export class OpenPaymentsService {
     if (calculatedHash !== hash) throw new Error('Invalid interaction hash');
   }
 
-  private async getInteractionInfo(url: string): Promise<InteractionParams> {
+  private async getInteractionInfo(
+    url: string,
+    existingTabId?: TabId,
+  ): Promise<InteractionParams> {
     const { resolve, reject, promise } = withResolvers<InteractionParams>();
 
-    const tab = await this.browser.tabs.create({ url });
+    const tab = existingTabId
+      ? await this.browser.tabs.update(existingTabId, { url })
+      : await this.browser.tabs.create({ url });
     if (!tab.id) {
-      reject(new Error('Could not create tab'));
+      reject(new Error('Could not create/update tab'));
       return promise;
     }
 

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -120,6 +120,7 @@ export class OpenPaymentsService {
   private storage: Cradle['storage'];
   private deduplicator: Cradle['deduplicator'];
   private logger: Cradle['logger'];
+  private browserName: Cradle['browserName'];
   private t: Cradle['t'];
 
   client?: AuthenticatedClient;
@@ -131,8 +132,22 @@ export class OpenPaymentsService {
   /** Whether a grant has enough balance to make payments */
   private isGrantUsable = { recurring: false, oneTime: false };
 
-  constructor({ browser, storage, deduplicator, logger, t }: Cradle) {
-    Object.assign(this, { browser, storage, deduplicator, logger, t });
+  constructor({
+    browser,
+    storage,
+    deduplicator,
+    logger,
+    t,
+    browserName,
+  }: Cradle) {
+    Object.assign(this, {
+      browser,
+      storage,
+      deduplicator,
+      logger,
+      t,
+      browserName,
+    });
 
     void this.initialize();
     this.switchGrant = this.deduplicator.dedupe(this._switchGrant.bind(this));
@@ -537,6 +552,8 @@ export class OpenPaymentsService {
     const keyAutoAdd = new KeyAutoAddService({
       browser: this.browser,
       storage: this.storage,
+      browserName: this.browserName,
+      t: this.t,
     });
     try {
       await keyAutoAdd.addPublicKeyToWallet(walletAddress);

--- a/src/content/keyAutoAdd/lib/helpers.ts
+++ b/src/content/keyAutoAdd/lib/helpers.ts
@@ -46,10 +46,10 @@ export async function waitForURL(
   match: (url: URL) => boolean,
   { timeout = 10 * 1000 }: Partial<WaitForURLOptions> = {},
 ) {
-  const { resolve, reject, promise } = withResolvers<void>();
+  const { resolve, reject, promise } = withResolvers<boolean>();
 
   if (match(new URL(window.location.href))) {
-    resolve();
+    resolve(true);
     return promise;
   }
 
@@ -68,7 +68,7 @@ export async function waitForURL(
     url = window.location.href;
     if (match(new URL(url))) {
       observer.disconnect();
-      resolve();
+      resolve(false);
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });

--- a/src/content/keyAutoAdd/lib/helpers.ts
+++ b/src/content/keyAutoAdd/lib/helpers.ts
@@ -1,0 +1,86 @@
+// cSpell:ignore locationchange
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
+import { withResolvers } from '@/shared/helpers';
+
+interface WaitForOptions {
+  timeout: number;
+}
+
+interface WaitForElementOptions extends WaitForOptions {
+  root: HTMLElement | HTMLHtmlElement | Document;
+}
+
+export function waitForElement<T extends HTMLElement = HTMLElement>(
+  selector: string,
+  { root = document, timeout = 10 * 1000 }: Partial<WaitForElementOptions> = {},
+): Promise<T> {
+  const { resolve, reject, promise } = withResolvers<T>();
+  if (document.querySelector(selector)) {
+    resolve(document.querySelector<T>(selector)!);
+    return promise;
+  }
+
+  const abortSignal = AbortSignal.timeout(timeout);
+  abortSignal.addEventListener('abort', (e) => {
+    observer.disconnect();
+    reject(e);
+  });
+
+  const observer = new MutationObserver(() => {
+    const el = document.querySelector<T>(selector);
+    if (el) {
+      observer.disconnect();
+      resolve(el);
+    }
+  });
+
+  observer.observe(root, { childList: true, subtree: true });
+
+  return promise;
+}
+
+interface WaitForURLOptions extends WaitForOptions {}
+
+export async function waitForURL(
+  match: (url: URL) => boolean,
+  { timeout = 10 * 1000 }: Partial<WaitForURLOptions> = {},
+) {
+  const { resolve, reject, promise } = withResolvers<void>();
+
+  if (match(new URL(window.location.href))) {
+    resolve();
+    return promise;
+  }
+
+  const abortSignal = AbortSignal.timeout(timeout);
+  abortSignal.addEventListener('abort', (e) => {
+    observer.disconnect();
+    reject(e);
+  });
+
+  let url = window.location.href;
+  // There's no stable 'locationchange' event, so we assume there's a chance
+  // when the DOM changes, the URL might have changed too, and we make our URL
+  // test then.
+  const observer = new MutationObserver(() => {
+    if (window.location.href === url) return;
+    url = window.location.href;
+    if (match(new URL(url))) {
+      observer.disconnect();
+      resolve();
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  return promise;
+}
+
+export function isTimedOut(e: any) {
+  return (
+    e instanceof Event &&
+    e.type === 'abort' &&
+    e.currentTarget instanceof AbortSignal &&
+    e.currentTarget.reason?.name === 'TimeoutError'
+  );
+}

--- a/src/content/keyAutoAdd/lib/helpers.ts
+++ b/src/content/keyAutoAdd/lib/helpers.ts
@@ -7,39 +7,6 @@ interface WaitForOptions {
   timeout: number;
 }
 
-interface WaitForElementOptions extends WaitForOptions {
-  root: HTMLElement | HTMLHtmlElement | Document;
-}
-
-export function waitForElement<T extends HTMLElement = HTMLElement>(
-  selector: string,
-  { root = document, timeout = 10 * 1000 }: Partial<WaitForElementOptions> = {},
-): Promise<T> {
-  const { resolve, reject, promise } = withResolvers<T>();
-  if (document.querySelector(selector)) {
-    resolve(document.querySelector<T>(selector)!);
-    return promise;
-  }
-
-  const abortSignal = AbortSignal.timeout(timeout);
-  abortSignal.addEventListener('abort', (e) => {
-    observer.disconnect();
-    reject(e);
-  });
-
-  const observer = new MutationObserver(() => {
-    const el = document.querySelector<T>(selector);
-    if (el) {
-      observer.disconnect();
-      resolve(el);
-    }
-  });
-
-  observer.observe(root, { childList: true, subtree: true });
-
-  return promise;
-}
-
 interface WaitForURLOptions extends WaitForOptions {}
 
 export async function waitForURL(

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -35,8 +35,18 @@ export class KeyAutoAdd {
     });
   }
 
-  private async run({ walletAddressUrl, publicKey, nickName }: BeginPayload) {
-    const params: StepRunParams = { walletAddressUrl, publicKey, nickName };
+  private async run({
+    walletAddressUrl,
+    publicKey,
+    nickName,
+    keyId,
+  }: BeginPayload) {
+    const params: StepRunParams = {
+      walletAddressUrl,
+      publicKey,
+      nickName,
+      keyId,
+    };
     let prevStepId = '';
     let prevStepResult: unknown = undefined;
     for (const [stepIdx, step] of this.steps.entries()) {

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -1,0 +1,64 @@
+import browser, { type Runtime } from 'webextension-polyfill';
+import { CONNECTION_NAME } from '@/background/services/keyShare';
+import type {
+  BackgroundToContentMessage,
+  BeginPayload,
+  ContentToBackgroundMessage,
+  ContentToBackgroundMessagesMap,
+  Step,
+  StepRunParams,
+  StepWithStatus,
+} from './types';
+
+export class KeyAutoAdd {
+  private port: Runtime.Port;
+
+  private stepsInput: Map<string, Step>;
+  private steps: StepWithStatus[];
+
+  constructor(steps: Step[]) {
+    this.stepsInput = new Map(steps.map((step) => [step.id, step]));
+    this.steps = steps.map((step) => ({ id: step.id, status: 'pending' }));
+  }
+
+  init() {
+    this.port = browser.runtime.connect({ name: CONNECTION_NAME });
+
+    this.port.onMessage.addListener((message: BackgroundToContentMessage) => {
+      if (message.action === 'BEGIN') {
+        this.run(message.payload);
+      }
+    });
+  }
+
+  private async run({ walletAddressUrl, publicKey }: BeginPayload) {
+    const params: StepRunParams = { walletAddressUrl, publicKey };
+    for (const [stepIdx, step] of this.steps.entries()) {
+      step.status = 'active';
+      this.postMessage('PROGRESS', { steps: this.steps });
+      try {
+        await this.stepsInput.get(step.id)!.run(params);
+        step.status = 'success';
+      } catch (error) {
+        step.status = 'error';
+        this.postMessage('ERROR', {
+          error: { message: error.message },
+          stepId: step.id,
+          stepIdx,
+        });
+        this.port.disconnect();
+        return;
+      }
+    }
+    this.postMessage('SUCCESS', true);
+    this.port.disconnect();
+  }
+
+  private postMessage<T extends keyof ContentToBackgroundMessagesMap>(
+    action: T,
+    payload: ContentToBackgroundMessagesMap[T],
+  ) {
+    const message = { action, payload } as ContentToBackgroundMessage;
+    this.port.postMessage(message);
+  }
+}

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -1,5 +1,6 @@
 import browser, { type Runtime } from 'webextension-polyfill';
 import { CONNECTION_NAME } from '@/background/services/keyShare';
+import type { ErrorWithKeyLike } from '@/shared/helpers';
 import type {
   BackgroundToContentMessage,
   BeginPayload,
@@ -100,7 +101,9 @@ export class KeyAutoAdd {
     this.port.postMessage(message);
   }
 
-  static isSkip(err: unknown): err is { type: symbol; message?: string } {
+  static isSkip(
+    err: unknown,
+  ): err is { type: symbol; message?: string | ErrorWithKeyLike } {
     if (!err || typeof err !== 'object') return false;
     return 'type' in err && err.type === SYMBOL_SKIP;
   }

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -33,8 +33,13 @@ export class KeyAutoAdd {
     });
   }
 
-  private async run({ walletAddressUrl, publicKey }: BeginPayload) {
-    const params: StepRunParams = { walletAddressUrl, publicKey };
+  private async run({ walletAddressUrl, publicKey, nickName }: BeginPayload) {
+    const params: StepRunParams = {
+      walletAddressUrl,
+      publicKey,
+      nickName,
+      helpers: {},
+    };
     let prevStepId = '';
     let prevStepResult: unknown = undefined;
     for (const [stepIdx, step] of this.steps.entries()) {

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -60,6 +60,7 @@ export class KeyAutoAdd {
         step.status = 'success';
       } catch (error) {
         step.status = 'error';
+        this.postMessage('PROGRESS', { steps: this.steps });
         this.postMessage('ERROR', {
           error: { message: error.message },
           stepId: step.id,
@@ -69,6 +70,7 @@ export class KeyAutoAdd {
         return;
       }
     }
+    this.postMessage('PROGRESS', { steps: this.steps });
     this.postMessage('SUCCESS', true);
     this.port.disconnect();
   }

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -40,6 +40,7 @@ export class KeyAutoAdd {
         await this.stepsInput.get(step.id)!.run(params);
         step.status = 'success';
       } catch (error) {
+        console.error(error)
         step.status = 'error';
         this.postMessage('ERROR', {
           error: { message: error.message },

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -12,6 +12,8 @@ import type {
 
 export type { StepRun } from './types';
 
+export const LOGIN_WAIT_TIMEOUT = 10 * 60 * 1000;
+
 export class KeyAutoAdd {
   private port: Runtime.Port;
 
@@ -34,12 +36,7 @@ export class KeyAutoAdd {
   }
 
   private async run({ walletAddressUrl, publicKey, nickName }: BeginPayload) {
-    const params: StepRunParams = {
-      walletAddressUrl,
-      publicKey,
-      nickName,
-      helpers: {},
-    };
+    const params: StepRunParams = { walletAddressUrl, publicKey, nickName };
     let prevStepId = '';
     let prevStepResult: unknown = undefined;
     for (const [stepIdx, step] of this.steps.entries()) {

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -2,7 +2,7 @@ import type { ErrorWithKeyLike } from '@/shared/helpers';
 import type { ErrorResponse } from '@/shared/messages';
 
 export interface StepRunParams extends BeginPayload {
-  skip: (message?: string | ErrorWithKeyLike) => never;
+  skip: (message: string | Error | ErrorWithKeyLike) => never;
 }
 
 export type StepRun<T = unknown, R = void> = (
@@ -17,6 +17,8 @@ export interface Step<T = unknown, R = unknown> {
   run: StepRun<T, R>;
 }
 
+export type Details = Omit<ErrorResponse, 'success'>;
+
 interface StepWithStatusBase {
   name: Step['name'];
   status: string;
@@ -26,11 +28,11 @@ interface StepWithStatusNormal extends StepWithStatusBase {
 }
 interface StepWithStatusSkipped extends StepWithStatusBase {
   status: 'skipped';
-  details: { message?: string | ErrorWithKeyLike };
+  details: Details;
 }
 interface StepWithStatusError extends StepWithStatusBase {
   status: 'error';
-  details: Omit<ErrorResponse, 'success'>;
+  details: Details;
 }
 
 export type StepWithStatus =
@@ -43,6 +45,7 @@ export interface BeginPayload {
   publicKey: string;
   keyId: string;
   nickName: string;
+  keyAddUrl: string;
 }
 
 export type BackgroundToKeyAutoAddMessagesMap = {
@@ -62,7 +65,7 @@ export type KeyAutoAddToBackgroundMessagesMap = {
   ERROR: {
     stepIdx: number;
     stepName: StepWithStatus['name'];
-    error: { message: string };
+    details: Details;
   };
 };
 

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -1,9 +1,8 @@
-export interface StepRunParams {
-  walletAddressUrl: string;
-  publicKey: string;
+export interface StepRunParams extends BeginPayload {
+  helpers: Record<string, never>;
 }
 
-export type StepRun<T = unknown, R = unknown> = (
+export type StepRun<T = unknown, R = void> = (
   params: StepRunParams,
   prevStep: [
     result: T extends (...args: any[]) => PromiseLike<any>
@@ -13,7 +12,7 @@ export type StepRun<T = unknown, R = unknown> = (
   ],
 ) => Promise<R>;
 
-export interface Step<T = any, R = any> {
+export interface Step<T = unknown, R = unknown> {
   id: string;
   run: StepRun<T, R>;
 }
@@ -23,10 +22,11 @@ export interface StepWithStatus {
   status: 'pending' | 'active' | 'error' | 'success' | 'skipped';
 }
 
-export type BeginPayload = {
+export interface BeginPayload {
   walletAddressUrl: string;
   publicKey: string;
-};
+  nickName: string;
+}
 
 export type BackgroundToContentMessagesMap = {
   BEGIN: BeginPayload;

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -1,0 +1,47 @@
+export interface StepRunParams {
+  walletAddressUrl: string;
+  publicKey: string;
+}
+
+export interface Step {
+  id: string;
+  run: (params: StepRunParams) => Promise<void>;
+}
+
+export interface StepWithStatus {
+  id: Step['id'];
+  status: 'pending' | 'active' | 'error' | 'success' | 'skipped';
+}
+
+export type BeginPayload = {
+  walletAddressUrl: string;
+  publicKey: string;
+};
+
+export type BackgroundToContentMessagesMap = {
+  BEGIN: BeginPayload;
+};
+
+export type BackgroundToContentMessage = {
+  [K in keyof BackgroundToContentMessagesMap]: {
+    action: K;
+    payload: BackgroundToContentMessagesMap[K];
+  };
+}[keyof BackgroundToContentMessagesMap];
+
+export type ContentToBackgroundMessagesMap = {
+  PROGRESS: { steps: StepWithStatus[] };
+  SUCCESS: true;
+  ERROR: {
+    stepIdx: number;
+    stepId: StepWithStatus['id'];
+    error: { message: string };
+  };
+};
+
+export type ContentToBackgroundMessage = {
+  [K in keyof ContentToBackgroundMessagesMap]: {
+    action: K;
+    payload: ContentToBackgroundMessagesMap[K];
+  };
+}[keyof ContentToBackgroundMessagesMap];

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -1,6 +1,4 @@
-export interface StepRunParams extends BeginPayload {
-  helpers: Record<string, never>;
-}
+export type StepRunParams = BeginPayload;
 
 export type StepRun<T = unknown, R = void> = (
   params: StepRunParams,

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -3,9 +3,19 @@ export interface StepRunParams {
   publicKey: string;
 }
 
-export interface Step {
+export type StepRun<T = unknown, R = unknown> = (
+  params: StepRunParams,
+  prevStep: [
+    result: T extends (...args: any[]) => PromiseLike<any>
+      ? Awaited<ReturnType<T>>
+      : T,
+    id: string,
+  ],
+) => Promise<R>;
+
+export interface Step<T = any, R = any> {
   id: string;
-  run: (params: StepRunParams) => Promise<void>;
+  run: StepRun<T, R>;
 }
 
 export interface StepWithStatus {

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -23,6 +23,7 @@ export interface StepWithStatus {
 export interface BeginPayload {
   walletAddressUrl: string;
   publicKey: string;
+  keyId: string;
   nickName: string;
 }
 

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -1,7 +1,8 @@
-import { ErrorResponse } from '@/shared/messages';
+import type { ErrorWithKeyLike } from '@/shared/helpers';
+import type { ErrorResponse } from '@/shared/messages';
 
 export interface StepRunParams extends BeginPayload {
-  skip: (message?: string) => never;
+  skip: (message?: string | ErrorWithKeyLike) => never;
 }
 
 export type StepRun<T = unknown, R = void> = (
@@ -25,7 +26,7 @@ interface StepWithStatusNormal extends StepWithStatusBase {
 }
 interface StepWithStatusSkipped extends StepWithStatusBase {
   status: 'skipped';
-  details: { message?: string };
+  details: { message?: string | ErrorWithKeyLike };
 }
 interface StepWithStatusError extends StepWithStatusBase {
   status: 'error';

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -13,12 +13,12 @@ export type StepRun<T = unknown, R = void> = (
 ) => Promise<R | void>;
 
 export interface Step<T = unknown, R = unknown> {
-  id: string;
+  name: string;
   run: StepRun<T, R>;
 }
 
 interface StepWithStatusBase {
-  id: string;
+  name: Step['name'];
   status: string;
 }
 interface StepWithStatusNormal extends StepWithStatusBase {
@@ -45,30 +45,30 @@ export interface BeginPayload {
   nickName: string;
 }
 
-export type BackgroundToContentMessagesMap = {
+export type BackgroundToKeyAutoAddMessagesMap = {
   BEGIN: BeginPayload;
 };
 
-export type BackgroundToContentMessage = {
-  [K in keyof BackgroundToContentMessagesMap]: {
+export type BackgroundToKeyAutoAddMessage = {
+  [K in keyof BackgroundToKeyAutoAddMessagesMap]: {
     action: K;
-    payload: BackgroundToContentMessagesMap[K];
+    payload: BackgroundToKeyAutoAddMessagesMap[K];
   };
-}[keyof BackgroundToContentMessagesMap];
+}[keyof BackgroundToKeyAutoAddMessagesMap];
 
-export type ContentToBackgroundMessagesMap = {
+export type KeyAutoAddToBackgroundMessagesMap = {
   PROGRESS: { steps: StepWithStatus[] };
   SUCCESS: true;
   ERROR: {
     stepIdx: number;
-    stepId: StepWithStatus['id'];
+    stepName: StepWithStatus['name'];
     error: { message: string };
   };
 };
 
-export type ContentToBackgroundMessage = {
-  [K in keyof ContentToBackgroundMessagesMap]: {
+export type KeyAutoAddToBackgroundMessage = {
+  [K in keyof KeyAutoAddToBackgroundMessagesMap]: {
     action: K;
-    payload: ContentToBackgroundMessagesMap[K];
+    payload: KeyAutoAddToBackgroundMessagesMap[K];
   };
-}[keyof ContentToBackgroundMessagesMap];
+}[keyof KeyAutoAddToBackgroundMessagesMap];

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -142,7 +142,7 @@ new KeyAutoAdd([
   { id: 'Waiting for login', run: waitForLogin },
   { id: 'Finding build ID', run: findBuildId },
   { id: 'Getting account details', run: getAccountDetails },
-  { id: 'Revoke existing key', run: revokeExistingKey },
+  { id: 'Revoking existing key', run: revokeExistingKey },
   { id: 'Finding account & wallet ID', run: findAccountAndWalletId },
   { id: 'Adding key', run: addKey },
 ]).init();

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -139,30 +139,12 @@ const addKey: Step<typeof findAccountAndWalletId> = async (
 };
 
 new KeyAutoAdd([
-  {
-    id: 'Waiting for login',
-    run: waitForLogin,
-  },
-  {
-    id: 'Finding build ID',
-    run: findBuildId,
-  },
-  {
-    id: 'Getting account details',
-    run: getAccountDetails,
-  },
-  {
-    id: 'Revoke existing key',
-    run: revokeExistingKey,
-  },
-  {
-    id: 'Finding account & wallet ID',
-    run: findAccountAndWalletId,
-  },
-  {
-    id: 'Adding key',
-    run: addKey,
-  },
+  { id: 'Waiting for login', run: waitForLogin },
+  { id: 'Finding build ID', run: findBuildId },
+  { id: 'Getting account details', run: getAccountDetails },
+  { id: 'Revoke existing key', run: revokeExistingKey },
+  { id: 'Finding account & wallet ID', run: findAccountAndWalletId },
+  { id: 'Adding key', run: addKey },
 ]).init();
 
 // region: Helpers

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -76,7 +76,7 @@ const findAccountAndWalletId: Step<
 };
 
 const addKey: Step<typeof findAccountAndWalletId> = async (
-  { publicKey },
+  { publicKey, nickName },
   [{ accountId, walletId }],
 ) => {
   const url = `https://api.rafiki.money/accounts/${accountId}/wallet-addresses/${walletId}/upload-key`;
@@ -88,7 +88,7 @@ const addKey: Step<typeof findAccountAndWalletId> = async (
     },
     body: JSON.stringify({
       base64Key: publicKey,
-      nickname: 'web monetization extension',
+      nickname: nickName,
     }),
     mode: 'cors',
     credentials: 'include',

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -68,10 +68,6 @@ const getAccountDetails: Step<never, Account[]> = async (_) => {
   const url = `https://rafiki.money/_next/data/${buildId}/settings/developer-keys.json`;
   const res = await fetch(url, {
     method: 'GET',
-    headers: {
-      accept: '*/*',
-      'x-nextjs-data': '1',
-    },
     mode: 'cors',
     credentials: 'include',
   });

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -1,129 +1,118 @@
+// cSpell:ignore nextjs
 import { sleep } from '@/shared/helpers';
-import { KeyAutoAdd } from './lib/keyAutoAdd';
+import { KeyAutoAdd, type StepRun } from './lib/keyAutoAdd';
+import { toWalletAddressUrl } from '@/popup/lib/utils';
+
+type Account = {
+  id: string;
+  walletAddresses: {
+    id: string;
+    url: string;
+    keys: {
+      id: string;
+    }[];
+  }[];
+};
+
+type AccountDetails = {
+  pageProps: {
+    accounts: Account[];
+  };
+};
+
+const stepFindBuildId: StepRun<never, { buildId: string }> = async () => {
+  if (!location.pathname.startsWith('/settings/developer-keys')) {
+    throw new Error('Not on keys page. Are you not logged in?');
+  }
+  await sleep(1000);
+
+  const NEXT_DATA = document.querySelector('script#__NEXT_DATA__')?.textContent;
+  if (!NEXT_DATA) {
+    throw new Error('Failed to find `_NEXT_DATA_` script');
+  }
+  try {
+    const buildId = JSON.parse(NEXT_DATA).buildId;
+    if (!buildId) {
+      throw new Error('Failed to parse `_NEXT_DATA_` script');
+    }
+    return { buildId };
+  } catch (error) {
+    throw new Error('Failed to parse `_NEXT_DATA_` script', {
+      cause: error,
+    });
+  }
+};
+
+const stepGetAccountDetails: StepRun<
+  typeof stepFindBuildId,
+  Account[]
+> = async (_, [{ buildId }]) => {
+  const url = `https://rafiki.money/_next/data/${buildId}/settings/developer-keys.json`;
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      accept: '*/*',
+      'x-nextjs-data': '1',
+    },
+    mode: 'cors',
+    credentials: 'include',
+  });
+  const json: AccountDetails = await res.json();
+  return json.pageProps.accounts;
+};
+
+const findAccountAndWalletId: StepRun<
+  typeof stepGetAccountDetails,
+  { accountId: string; walletId: string }
+> = async ({ walletAddressUrl }, [accounts]) => {
+  for (const account of accounts) {
+    for (const wallet of account.walletAddresses) {
+      if (toWalletAddressUrl(wallet.url) === walletAddressUrl) {
+        return { accountId: account.id, walletId: wallet.id };
+      }
+    }
+  }
+  throw new Error('Failed to find account ID');
+};
+
+const addKey: StepRun<typeof findAccountAndWalletId> = async (
+  { publicKey },
+  [{ accountId, walletId }],
+) => {
+  const url = `https://api.rafiki.money/accounts/${accountId}/wallet-addresses/${walletId}/upload-key`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      base64Key: publicKey,
+      nickname: 'web monetization extension',
+    }),
+    mode: 'cors',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to add key: ${await res.text()}`);
+  }
+};
 
 new KeyAutoAdd([
   {
-    id: 'Find',
-    async run({ walletAddressUrl }) {
-      const walletAddressURL = new URL(walletAddressUrl);
-      if (!location.pathname.startsWith('/settings/developer-keys')) {
-        throw new Error('Not on keys page. Are you not logged in?');
-      }
-
-      await sleep(2000);
-
-      const buttons = document.querySelectorAll<HTMLButtonElement>(
-        'main dl dt button[aria-expanded]', // disclosure button
-      );
-      for (const button of buttons) {
-        button.click();
-        await sleep(500);
-
-        const dt = button.closest('dt');
-        if (!dt) {
-          throw new Error('Failed to find matching `dt`');
-        }
-        const dd = dt.nextElementSibling?.querySelector('dd ul');
-        console.log(
-          dt,
-          dt.nextElementSibling,
-          dt.nextElementSibling?.querySelector('dd ul'),
-        );
-        if (!(dd instanceof HTMLElement) || dd.tagName !== 'UL') {
-          throw new Error('Failed to find matching `ul` list');
-        }
-
-        let keyListContainer;
-        for (const subGroup of dd.querySelectorAll('li')) {
-          const pointerHeading = subGroup.querySelector<HTMLParagraphElement>(
-            ':scope > div > p.font-semibold',
-          );
-          if (!pointerHeading) {
-            throw new Error('Failed to find payment pointer heading');
-          }
-          if (
-            pointerHeading.textContent?.endsWith(
-              walletAddressURL.host + walletAddressURL.pathname,
-            )
-          ) {
-            // found right group for our wallet
-            keyListContainer = pointerHeading.nextElementSibling;
-            if (keyListContainer instanceof HTMLElement) {
-              break;
-            }
-          }
-        }
-        if (!keyListContainer) {
-          throw new Error('Failed to find key list container');
-        }
-
-        const uploadKeyButton =
-          keyListContainer.querySelector<HTMLButtonElement>(
-            'button[aria-label="upload keys"]',
-          );
-        if (!uploadKeyButton) {
-          throw new Error('Failed to find upload key button');
-        }
-        uploadKeyButton.click();
-
-        await sleep(1000); // wait for the popup with form open
-        const inputNickname = document.querySelector<HTMLInputElement>(
-          'input#nicknameUpload',
-        );
-        if (!inputNickname) {
-          throw new Error('Failed to find input nickname');
-        }
-        return;
-      }
-
-      throw new Error('Failed to find the right key section');
-    },
+    id: 'Find build ID',
+    run: stepFindBuildId,
   },
   {
-    id: 'Submit',
-    async run({ publicKey }) {
-      const inputNickname = document.querySelector<HTMLInputElement>(
-        'input#nicknameUpload',
-      );
-      if (!inputNickname) {
-        throw new Error('Failed to find input nickname');
-      }
-
-      const form = inputNickname.closest('form');
-      if (!form) {
-        throw new Error('Failed to find form');
-      }
-      const textArea = form?.querySelector('textarea');
-      if (!textArea) {
-        throw new Error('Failed to find text area');
-      }
-      const submitButton = form.querySelector<HTMLButtonElement>(
-        'button[type="submit"][aria-label="upload"]',
-      );
-      if (!submitButton) {
-        throw new Error('Failed to find submit button');
-      }
-
-      inputNickname.focus();
-      inputNickname.value = 'web monetization extension';
-      inputNickname.blur();
-      await sleep(500);
-
-      textArea.focus();
-      textArea.value = publicKey;
-      textArea.blur();
-      await sleep(1000);
-
-      submitButton.click();
-
-      let remain = 10;
-      while (form.isConnected && remain > 0) {
-        await sleep(1000);
-        remain--;
-      }
-      if (!remain && form.isConnected) {
-        throw new Error('Form did not disappear on submit');
-      }
-    },
+    id: 'Get account details',
+    run: stepGetAccountDetails,
+  },
+  {
+    id: 'Find account & wallet ID',
+    run: findAccountAndWalletId,
+  },
+  {
+    id: 'Add key',
+    run: addKey,
   },
 ]).init();

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -46,30 +46,25 @@ const waitForLogin: Step<never> = async ({ skip }) => {
   }
 };
 
-const findBuildId: Step<never, { buildId: string }> = async () => {
+const getAccountDetails: Step<never, Account[]> = async (_) => {
   await sleep(1000);
 
   const NEXT_DATA = document.querySelector('script#__NEXT_DATA__')?.textContent;
   if (!NEXT_DATA) {
     throw new Error('Failed to find `__NEXT_DATA__` script');
   }
+  let buildId: string;
   try {
-    const buildId = JSON.parse(NEXT_DATA).buildId;
+    buildId = JSON.parse(NEXT_DATA).buildId;
     if (!buildId || typeof buildId !== 'string') {
       throw new Error('Failed to get buildId from `__NEXT_DATA__` script');
     }
-    return { buildId };
   } catch (error) {
     throw new Error('Failed to parse `__NEXT_DATA__` script', {
       cause: error,
     });
   }
-};
 
-const getAccountDetails: Step<typeof findBuildId, Account[]> = async (
-  _,
-  { buildId },
-) => {
   const url = `https://rafiki.money/_next/data/${buildId}/settings/developer-keys.json`;
   const res = await fetch(url, {
     method: 'GET',
@@ -166,7 +161,6 @@ async function revokeKey(accountId: string, walletId: string, keyId: string) {
 // region: Main
 new KeyAutoAdd([
   { name: 'Waiting for login', run: waitForLogin },
-  { name: 'Finding build ID', run: findBuildId },
   { name: 'Getting account details', run: getAccountDetails },
   { name: 'Revoking existing key', run: revokeExistingKey },
   { name: 'Finding wallet', run: findWallet },

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -1,10 +1,129 @@
+import { sleep } from '@/shared/helpers';
 import { KeyAutoAdd } from './lib/keyAutoAdd';
 
 new KeyAutoAdd([
   {
-    id: 'step-1',
-    run() {
-      throw new Error('Step 1 error');
+    id: 'Find',
+    async run({ walletAddressUrl }) {
+      const walletAddressURL = new URL(walletAddressUrl);
+      if (!location.pathname.startsWith('/settings/developer-keys')) {
+        throw new Error('Not on keys page. Are you not logged in?');
+      }
+
+      await sleep(2000);
+
+      const buttons = document.querySelectorAll<HTMLButtonElement>(
+        'main dl dt button[aria-expanded]', // disclosure button
+      );
+      for (const button of buttons) {
+        button.click();
+        await sleep(500);
+
+        const dt = button.closest('dt');
+        if (!dt) {
+          throw new Error('Failed to find matching `dt`');
+        }
+        const dd = dt.nextElementSibling?.querySelector('dd ul');
+        console.log(
+          dt,
+          dt.nextElementSibling,
+          dt.nextElementSibling?.querySelector('dd ul'),
+        );
+        if (!(dd instanceof HTMLElement) || dd.tagName !== 'UL') {
+          throw new Error('Failed to find matching `ul` list');
+        }
+
+        let keyListContainer;
+        for (const subGroup of dd.querySelectorAll('li')) {
+          const pointerHeading = subGroup.querySelector<HTMLParagraphElement>(
+            ':scope > div > p.font-semibold',
+          );
+          if (!pointerHeading) {
+            throw new Error('Failed to find payment pointer heading');
+          }
+          if (
+            pointerHeading.textContent?.endsWith(
+              walletAddressURL.host + walletAddressURL.pathname,
+            )
+          ) {
+            // found right group for our wallet
+            keyListContainer = pointerHeading.nextElementSibling;
+            if (keyListContainer instanceof HTMLElement) {
+              break;
+            }
+          }
+        }
+        if (!keyListContainer) {
+          throw new Error('Failed to find key list container');
+        }
+
+        const uploadKeyButton =
+          keyListContainer.querySelector<HTMLButtonElement>(
+            'button[aria-label="upload keys"]',
+          );
+        if (!uploadKeyButton) {
+          throw new Error('Failed to find upload key button');
+        }
+        uploadKeyButton.click();
+
+        await sleep(1000); // wait for the popup with form open
+        const inputNickname = document.querySelector<HTMLInputElement>(
+          'input#nicknameUpload',
+        );
+        if (!inputNickname) {
+          throw new Error('Failed to find input nickname');
+        }
+        return;
+      }
+
+      throw new Error('Failed to find the right key section');
+    },
+  },
+  {
+    id: 'Submit',
+    async run({ publicKey }) {
+      const inputNickname = document.querySelector<HTMLInputElement>(
+        'input#nicknameUpload',
+      );
+      if (!inputNickname) {
+        throw new Error('Failed to find input nickname');
+      }
+
+      const form = inputNickname.closest('form');
+      if (!form) {
+        throw new Error('Failed to find form');
+      }
+      const textArea = form?.querySelector('textarea');
+      if (!textArea) {
+        throw new Error('Failed to find text area');
+      }
+      const submitButton = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"][aria-label="upload"]',
+      );
+      if (!submitButton) {
+        throw new Error('Failed to find submit button');
+      }
+
+      inputNickname.focus();
+      inputNickname.value = 'web monetization extension';
+      inputNickname.blur();
+      await sleep(500);
+
+      textArea.focus();
+      textArea.value = publicKey;
+      textArea.blur();
+      await sleep(1000);
+
+      submitButton.click();
+
+      let remain = 10;
+      while (form.isConnected && remain > 0) {
+        await sleep(1000);
+        remain--;
+      }
+      if (!remain && form.isConnected) {
+        throw new Error('Form did not disappear on submit');
+      }
     },
   },
 ]).init();

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -165,11 +165,11 @@ async function revokeKey(accountId: string, walletId: string, keyId: string) {
 
 // region: Main
 new KeyAutoAdd([
-  { id: 'Waiting for login', run: waitForLogin },
-  { id: 'Finding build ID', run: findBuildId },
-  { id: 'Getting account details', run: getAccountDetails },
-  { id: 'Revoking existing key', run: revokeExistingKey },
-  { id: 'Finding wallet', run: findWallet },
-  { id: 'Adding key', run: addKey },
+  { name: 'Waiting for login', run: waitForLogin },
+  { name: 'Finding build ID', run: findBuildId },
+  { name: 'Getting account details', run: getAccountDetails },
+  { name: 'Revoking existing key', run: revokeExistingKey },
+  { name: 'Finding wallet', run: findWallet },
+  { name: 'Adding key', run: addKey },
 ]).init();
 // endregion

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -8,6 +8,7 @@ import {
 import { isTimedOut, waitForURL } from './lib/helpers';
 import { toWalletAddressUrl } from '@/popup/lib/utils';
 
+// region: Steps
 type Account = {
   id: string;
   walletAddresses: {
@@ -137,18 +138,9 @@ const addKey: Step<typeof findAccountAndWalletId> = async (
     throw new Error(`Failed to add key: ${await res.text()}`);
   }
 };
-
-new KeyAutoAdd([
-  { id: 'Waiting for login', run: waitForLogin },
-  { id: 'Finding build ID', run: findBuildId },
-  { id: 'Getting account details', run: getAccountDetails },
-  { id: 'Revoking existing key', run: revokeExistingKey },
-  { id: 'Finding account & wallet ID', run: findAccountAndWalletId },
-  { id: 'Adding key', run: addKey },
-]).init();
+// endregion
 
 // region: Helpers
-
 async function revokeKey(accountId: string, walletId: string, keyId: string) {
   const url = `https://api.rafiki.money/accounts/${accountId}/wallet-addresses/${walletId}/${keyId}/revoke-key/`;
   const res = await fetch(url, {
@@ -164,5 +156,15 @@ async function revokeKey(accountId: string, walletId: string, keyId: string) {
     throw new Error(`Failed to revoke key: ${await res.text()}`);
   }
 }
+// endregion
 
+// region: Main
+new KeyAutoAdd([
+  { id: 'Waiting for login', run: waitForLogin },
+  { id: 'Finding build ID', run: findBuildId },
+  { id: 'Getting account details', run: getAccountDetails },
+  { id: 'Revoking existing key', run: revokeExistingKey },
+  { id: 'Finding account & wallet ID', run: findAccountAndWalletId },
+  { id: 'Adding key', run: addKey },
+]).init();
 // endregion

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -26,12 +26,11 @@ type AccountDetails = {
   };
 };
 
-const waitForLogin: Step<never> = async ({ skip }) => {
-  const expectedUrl = 'https://rafiki.money/settings/developer-keys';
-  let foundOnLoad = false;
+const waitForLogin: Step<never> = async ({ skip, keyAddUrl }) => {
+  let alreadyLoggedIn = false;
   try {
-    foundOnLoad = await waitForURL(
-      (url) => (url.origin + url.pathname).startsWith(expectedUrl),
+    alreadyLoggedIn = await waitForURL(
+      (url) => (url.origin + url.pathname).startsWith(keyAddUrl),
       { timeout: LOGIN_WAIT_TIMEOUT },
     );
   } catch (error) {
@@ -41,7 +40,7 @@ const waitForLogin: Step<never> = async ({ skip }) => {
     throw new Error(error);
   }
 
-  if (foundOnLoad) {
+  if (alreadyLoggedIn) {
     skip(errorWithKey('connectWalletKeyService_error_skipAlreadyLoggedIn'));
   }
 };

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -1,0 +1,10 @@
+import { KeyAutoAdd } from './lib/keyAutoAdd';
+
+new KeyAutoAdd([
+  {
+    id: 'step-1',
+    run() {
+      throw new Error('Step 1 error');
+    },
+  },
+]).init();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
     {
       "matches": ["https://rafiki.money/*/*"],
       "js": ["content/keyAutoAdd/testWallet.js"],
-      "run_at": "document_start"
+      "run_at": "document_end"
     }
   ],
   "background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,11 @@
       "js": ["content/content.js"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["https://rafiki.money/*/*"],
+      "js": ["content/keyAutoAdd/testWallet.js"],
+      "run_at": "document_start"
     }
   ],
   "background": {

--- a/src/popup/components/ConnectWalletForm.tsx
+++ b/src/popup/components/ConnectWalletForm.tsx
@@ -76,7 +76,7 @@ export const ConnectWalletForm = ({
     amount: false,
   });
   const [isSubmitting, setIsSubmitting] = React.useState(
-    state?.status === 'connecting',
+    state?.status?.startsWith('connecting') || false,
   );
 
   const [currencySymbol, setCurrencySymbol] = React.useState<{

--- a/src/popup/components/ConnectWalletForm.tsx
+++ b/src/popup/components/ConnectWalletForm.tsx
@@ -173,7 +173,7 @@ export const ConnectWalletForm = ({
       } else {
         if (isErrorWithKey(res.error)) {
           const error = res.error;
-          if (error.key === 'connectWalletKeyService_error_notImplemented') {
+          if (error.key.startsWith('connectWalletKeyService_error_')) {
             setErrors((_) => ({ ..._, keyPair: t(error) }));
           } else {
             setErrors((_) => ({ ..._, connect: t(error) }));

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -31,6 +31,8 @@ export const Component = () => {
         onConnect={() => {
           // The popup closes due to redirects on connect, so we don't need to
           // update any state manually.
+          // But we reload it, as it's open all-time when running E2E tests
+          window.location.reload();
         }}
       />
     );

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -106,6 +106,10 @@ export const isErrorWithKey = (err: any): err is ErrorWithKeyLike => {
   );
 };
 
+export const errorWithKeyToJSON = (err: ErrorWithKeyLike): ErrorWithKeyLike => {
+  return { key: err.key, substitutions: err.substitutions };
+};
+
 export const success = <TPayload = undefined>(
   payload: TPayload,
 ): SuccessResponse<TPayload> => ({

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -293,6 +293,10 @@ export const removeQueryParams = (urlString: string) => {
   return url.origin + url.pathname;
 };
 
+export const ensureEnd = (str: string, suffix: string) => {
+  return str.endsWith(suffix) ? str : str + suffix;
+};
+
 /**
  * Polyfill for `Promise.withResolvers()`
  */

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -293,6 +293,20 @@ export const removeQueryParams = (urlString: string) => {
   return url.origin + url.pathname;
 };
 
+/**
+ * Polyfill for `Promise.withResolvers()`
+ */
+export function withResolvers<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // @ts-expect-error we know TypeScript!
+  return { resolve, reject, promise };
+}
+
 export const isOkState = (state: Storage['state']) => {
   return Object.values(state).every((value) => value === false);
 };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -116,7 +116,7 @@ export type PopupToBackgroundMessage = {
   };
   CONNECT_WALLET: {
     input: ConnectWalletPayload;
-    output: never;
+    output: void;
   };
   RECONNECT_WALLET: {
     input: never;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -110,12 +110,7 @@ export type PopupTabInfo = {
 
 export type PopupTransientState = Partial<{
   connect: Partial<{
-    status:
-      | 'connecting'
-      | 'connecting:adding-key'
-      | 'error'
-      | 'error:key-add'
-      | null;
+    status: 'connecting' | 'connecting:key' | 'error' | 'error:key' | null;
   }> | null;
 }>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -110,7 +110,7 @@ export type PopupTabInfo = {
 
 export type PopupTransientState = Partial<{
   connect: Partial<{
-    status: 'connecting' | 'error' | null;
+    status: 'connecting' | 'error' | 'adding-key' | 'error-key' | null;
   }> | null;
 }>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -110,7 +110,12 @@ export type PopupTabInfo = {
 
 export type PopupTransientState = Partial<{
   connect: Partial<{
-    status: 'connecting' | 'error' | 'adding-key' | 'error-key' | null;
+    status:
+      | 'connecting'
+      | 'connecting:adding-key'
+      | 'error'
+      | 'error:key-add'
+      | null;
   }> | null;
 }>;
 

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -70,30 +70,4 @@ test.describe('should fail to connect if:', () => {
       }),
     ).toEqual({ connected: false });
   });
-
-  test('public key not added', async ({ popup, i18n }) => {
-    const { CONNECT_WALLET_ADDRESS_URL } = process.env;
-    expect(CONNECT_WALLET_ADDRESS_URL).toBeDefined();
-
-    const connectButton = await fillPopup(popup, {
-      walletAddressUrl: CONNECT_WALLET_ADDRESS_URL!,
-      amount: '10',
-      recurring: false,
-    });
-    await expect(popup.locator('p.text-error')).not.toBeAttached();
-    await expect(connectButton).not.toBeDisabled();
-
-    await connectButton.click();
-    await popup.waitForTimeout(1000);
-    await expect(popup.locator('.text-error span').first()).toHaveText(
-      i18n.getMessage('connectWallet_error_failedAutoKeyAdd'),
-    );
-
-    await connectButton.click();
-    await popup.waitForTimeout(1000);
-    await expect(popup.getByTestId('ErrorMessage')).toHaveText(
-      i18n.getMessage('connectWallet_error_invalidClient'),
-    );
-    await expect(popup.getByTestId('ErrorMessage')).toHaveRole('alert');
-  });
 });

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from './fixtures/base';
+import { disconnectWallet, fillPopup } from './pages/popup';
+import {
+  acceptGrant,
+  KEYS_PAGE_URL,
+  getContinueWaitTime,
+  revokeKey,
+  waitForGrantConsentPage,
+  waitForWelcomePage,
+} from './helpers/testWallet';
+import { ensureEnd, withResolvers } from '@/shared/helpers';
+import { getJWKS } from './helpers/common';
+
+test.only('Connect to test wallet with automatic key addition when not logged-in to wallet', async ({
+  page,
+  popup,
+  persistentContext: context,
+  background,
+}) => {
+  const username = process.env.WALLET_USERNAME!;
+  const password = process.env.WALLET_PASSWORD!;
+  const walletAddressUrl = process.env.CONNECT_WALLET_ADDRESS_URL!;
+
+  const jwksUrl = new URL('jwks.json', ensureEnd(walletAddressUrl, '/')).href;
+
+  const loginPageUrl = `https://rafiki.money/auth/login?callbackUrl=%2Fsettings%2Fdeveloper-keys`;
+
+  const connectButton = await test.step('fill popup', async () => {
+    const connectButton = await fillPopup(popup, {
+      walletAddressUrl,
+      amount: '10',
+      recurring: false,
+    });
+    return connectButton;
+  });
+
+  await test.step('ensure not logged in', async () => {
+    await context.clearCookies();
+
+    await page.goto(KEYS_PAGE_URL);
+    expect(page.url()).toBe(loginPageUrl);
+    await page.close();
+  });
+
+  page = await test.step('shows login page', async () => {
+    await connectButton.click();
+
+    const openedPage = await context.waitForEvent('page', {
+      predicate: (page) => page.url().startsWith(loginPageUrl),
+      timeout: 3 * 1000,
+    });
+    await openedPage.getByLabel('E-mail').fill(username);
+    await openedPage.getByLabel('Password').fill(password);
+    await openedPage.getByRole('button', { name: 'login' }).click();
+    await openedPage.waitForURL(KEYS_PAGE_URL);
+    await expect(openedPage.locator('h1')).toHaveText('Developer Keys');
+
+    return openedPage;
+  });
+
+  const continueWaitMsPromise = getContinueWaitTime(context, {
+    walletAddressUrl,
+  });
+
+  const revokeInfo = await test.step('adds key to wallet', async () => {
+    const { resolve, reject, promise } = withResolvers<{
+      accountId: string;
+      walletId: string;
+    }>();
+    const pause = withResolvers<void>();
+    page.on('requestfinished', async function intercept(req) {
+      if (req.serviceWorker()) return;
+      if (req.method() !== 'POST') return;
+      const url = new URL(req.url());
+      if (url.origin !== 'https://api.rafiki.money') return;
+      if (!url.pathname.startsWith('/accounts/')) return;
+      if (!url.pathname.includes('/upload-key')) return;
+
+      const pattern =
+        /^\/accounts\/(?<accountId>.+)\/wallet-addresses\/(?<walletId>.+)\/upload-key$/;
+      const match = url.pathname.match(pattern);
+      if (!match) {
+        throw new Error('no match for URL pattern');
+      }
+      const result = match.groups as { accountId: string; walletId: string };
+
+      const res = await req.response();
+      page.off('requestfinished', intercept);
+      if (!res) {
+        reject('no response from /upload-key API');
+      } else {
+        await pause.promise;
+        resolve(result);
+      }
+    });
+
+    const { keyId } = await background.evaluate(() => {
+      return chrome.storage.local.get<{ keyId: string }>(['keyId']);
+    });
+
+    const jwksBefore = await getJWKS(page, jwksUrl);
+    expect(jwksBefore.keys.length).toBeGreaterThanOrEqual(0);
+    expect(jwksBefore.keys.find((key) => key.kid === keyId)).toBeUndefined();
+
+    pause.resolve();
+    const { accountId, walletId } = await promise;
+
+    const jwks = await getJWKS(page, jwksUrl);
+    expect(jwks.keys.length).toBeGreaterThan(0);
+    const key = jwks.keys.find((key) => key.kid === keyId);
+    expect(key).toMatchObject({ kid: keyId });
+
+    return { accountId, walletId, keyId };
+  });
+
+  await test.step('shows connect consent page', async () => {
+    await page.waitForURL((url) =>
+      url.pathname.startsWith('/grant-interactions'),
+    );
+    await waitForGrantConsentPage(page);
+  });
+
+  await test.step('connects', async () => {
+    const continueWaitMs = await continueWaitMsPromise;
+    await acceptGrant(page, continueWaitMs);
+    await waitForWelcomePage(page);
+
+    expect(
+      await background.evaluate(() => chrome.storage.local.get(['connected'])),
+    ).toEqual({ connected: true });
+  });
+
+  await test.step('revoke key', async () => {
+    await revokeKey(page, revokeInfo);
+
+    const { keys } = await getJWKS(page, jwksUrl);
+    expect(keys.find((key) => key.kid === revokeInfo.keyId)).toBeUndefined();
+  });
+
+  await test.step('disconnect wallet', async () => {
+    await disconnectWallet(popup);
+  });
+});

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures/base';
+import { ensureEnd, withResolvers } from '@/shared/helpers';
 import { disconnectWallet, fillPopup } from './pages/popup';
 import {
   acceptGrant,
@@ -8,10 +9,9 @@ import {
   waitForGrantConsentPage,
   waitForWelcomePage,
 } from './helpers/testWallet';
-import { ensureEnd, withResolvers } from '@/shared/helpers';
 import { getJWKS } from './helpers/common';
 
-test.only('Connect to test wallet with automatic key addition when not logged-in to wallet', async ({
+test('Connect to test wallet with automatic key addition when not logged-in to wallet', async ({
   page,
   popup,
   persistentContext: context,

--- a/tests/e2e/helpers/common.ts
+++ b/tests/e2e/helpers/common.ts
@@ -1,0 +1,8 @@
+import type { Page } from '@playwright/test';
+
+export async function getJWKS(page: Page, jwksUrl: string) {
+  type JWKS = { keys: { kid: string }[] };
+  return await page.evaluate(async (jwksUrl) => {
+    return await fetch(jwksUrl).then((r) => r.json() as Promise<JWKS>);
+  }, jwksUrl);
+}

--- a/tests/e2e/helpers/testWallet.ts
+++ b/tests/e2e/helpers/testWallet.ts
@@ -1,0 +1,119 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import {
+  loadKeysToExtension,
+  type Background,
+  type KeyInfo,
+} from '../fixtures/helpers';
+import { fillPopup, type Popup, type ConnectDetails } from '../pages/popup';
+import { getWalletInformation } from '@/shared/helpers';
+
+export const KEYS_PAGE_URL = `https://rafiki.money/settings/developer-keys`;
+const CONFIG_OPEN_PAYMENTS_REDIRECT_URL = `https://webmonetization.org/welcome`;
+
+export async function connectWallet(
+  context: BrowserContext,
+  background: Background,
+  keyInfo: KeyInfo,
+  popup: Popup,
+  params: ConnectDetails,
+) {
+  await loadKeysToExtension(background, keyInfo);
+
+  const connectButton = await fillPopup(popup, params);
+  await connectButton.click();
+
+  const continueWaitMs = await getContinueWaitTime(context, params);
+
+  const page = await context.waitForEvent('page', (page) =>
+    page.url().includes('/grant-interactions'),
+  );
+  await completeGrant(page, continueWaitMs);
+  await page.close();
+  await popup.bringToFront();
+}
+
+export async function completeGrant(page: Page, continueWaitMs: number) {
+  await waitForGrantConsentPage(page);
+  await acceptGrant(page, continueWaitMs);
+  await waitForWelcomePage(page);
+}
+
+export async function getContinueWaitTime(
+  context: BrowserContext,
+  params: Pick<ConnectDetails, 'walletAddressUrl'>,
+) {
+  const continueWaitMs = await (async () => {
+    const defaultWaitMs = 1001;
+    if (process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1') {
+      return Promise.resolve(defaultWaitMs);
+    }
+    const walletInfo = await getWalletInformation(params.walletAddressUrl);
+    return await new Promise<number>((resolve) => {
+      const authServer = new URL(walletInfo.authServer).href;
+      context.on('requestfinished', async function intercept(req) {
+        if (!req.serviceWorker()) return;
+        if (new URL(req.url()).href !== authServer) return;
+
+        const res = await req.response();
+        const json = await res?.json();
+        context.off('requestfinished', intercept);
+        if (typeof json?.continue?.wait !== 'number') {
+          return resolve(defaultWaitMs);
+        }
+        return resolve(json.continue.wait * 1000);
+      });
+    });
+  })();
+  return continueWaitMs;
+}
+
+export async function waitForGrantConsentPage(page: Page) {
+  await page.waitForURL((url) => {
+    return (
+      url.searchParams.has('interactId') &&
+      url.searchParams.has('nonce') &&
+      url.searchParams.has('clientUri')
+    );
+  });
+}
+
+export async function acceptGrant(page: Page, continueWaitMs: number) {
+  await page.waitForTimeout(continueWaitMs);
+  await page.getByRole('button', { name: 'Accept' }).click();
+}
+
+export async function waitForWelcomePage(page: Page) {
+  await page.waitForURL(
+    (url) =>
+      url.href.startsWith(CONFIG_OPEN_PAYMENTS_REDIRECT_URL) &&
+      url.searchParams.get('result') === 'grant_success',
+  );
+}
+
+export async function revokeKey(
+  page: Page,
+  info: {
+    accountId: string;
+    walletId: string;
+    keyId: string;
+  },
+) {
+  const { accountId, walletId, keyId } = info;
+  const url = `https://api.rafiki.money/accounts/${accountId}/wallet-addresses/${walletId}/${keyId}/revoke-key/`;
+
+  await page.goto(KEYS_PAGE_URL);
+  await page.evaluate(async (url) => {
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      mode: 'cors',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      throw new Error('Failed to revoke key: ' + (await res.text()));
+    }
+  }, url);
+}

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -1,14 +1,9 @@
-// cSpell:ignore requestfinished
 import type { BrowserContext } from '@playwright/test';
-import {
-  loadKeysToExtension,
-  type Background,
-  type BrowserInfo,
-  type KeyInfo,
-} from '../fixtures/helpers';
-import { getWalletInformation } from '@/shared/helpers';
+import type { BrowserInfo } from '../fixtures/helpers';
 
 export type Popup = Awaited<ReturnType<typeof openPopup>>;
+
+export { connectWallet } from '../helpers/testWallet';
 
 export async function openPopup(
   context: BrowserContext,
@@ -50,64 +45,6 @@ function getPopupUrl(
     throw new Error('Unsupported browser: ' + browserName);
   }
   return url;
-}
-
-export async function connectWallet(
-  context: BrowserContext,
-  background: Background,
-  keyInfo: KeyInfo,
-  popup: Popup,
-  params: ConnectDetails,
-) {
-  await loadKeysToExtension(background, keyInfo);
-
-  const connectButton = await fillPopup(popup, params);
-  await connectButton.click();
-
-  const continueWaitMs = await (async () => {
-    const defaultWaitMs = 1001;
-    if (process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1') {
-      return Promise.resolve(defaultWaitMs);
-    }
-    const walletInfo = await getWalletInformation(params.walletAddressUrl);
-    return await new Promise<number>((resolve) => {
-      const authServer = new URL(walletInfo.authServer).href;
-      context.on('requestfinished', async function intercept(req) {
-        if (!req.serviceWorker()) return;
-        if (new URL(req.url()).href !== authServer) return;
-
-        const res = await req.response();
-        const json = await res?.json();
-        context.off('requestfinished', intercept);
-        if (typeof json?.continue?.wait !== 'number') {
-          return resolve(defaultWaitMs);
-        }
-        return resolve(json.continue.wait * 1000);
-      });
-    });
-  })();
-
-  const page = await context.waitForEvent('page', (page) =>
-    page.url().includes('/grant-interactions'),
-  );
-  await page.waitForURL((url) => {
-    return (
-      url.searchParams.has('interactId') &&
-      url.searchParams.has('nonce') &&
-      url.searchParams.has('clientUri')
-    );
-  });
-  await page.waitForTimeout(continueWaitMs);
-  await page.getByRole('button', { name: 'Accept' }).click();
-
-  const CONFIG_OPEN_PAYMENTS_REDIRECT_URL = `https://webmonetization.org/welcome`;
-  await page.waitForURL(
-    (url) =>
-      url.href.startsWith(CONFIG_OPEN_PAYMENTS_REDIRECT_URL) &&
-      url.searchParams.get('result') === 'grant_success',
-  );
-  await page.close();
-  await popup.bringToFront();
 }
 
 export async function disconnectWallet(popup: Popup) {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

- Closes https://github.com/interledger/web-monetization-extension/issues/615
- Closes https://github.com/interledger/web-monetization-extension/issues/616
- Part of https://github.com/interledger/web-monetization-extension/issues/613

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

- Add new content script to automate key-addition to wallets.
   - The scripts are in `content/keyAutoAdd/*`
   - `content/keyAutoAdd/lib/*` contains script integration with background, along with some helper utils.
   - These content scripts are injected only to specific wallet URLs, and not to all URLs.
   - The content scripts are written as "steps" so we can track their breakage better, and show progress to user. Some steps can be marked as "skipped".
   - `content/keyAutoAdd/testWallet.ts` contains a sample automation for the test wallet, via API reverse engineering.
   - The key nickname is extension name + browser name.
- `background/keyAutoAdd.ts` contains background service to orchestrate key-addition. It sends the `BEGIN` message to content script and monitors progress via `Runtime.Port` based messaging.
- `connectWallet` in `background/openPayments.ts` handles key-addition, if needed.
   -  Most other changes in `background/openPayments.ts` are to handle rejections, tab closes, and reusing tabs for further process.
   - More errors need to be handled as we now store connect state in background's `transientPopupState` to give user more info if they re-open popup during connect process.
- E2E tests:
  - add test for most common, but complex path (not logged-in)
  - refactor: move testWallet specific code to separate helper, and into smaller chunks so we can test connect process specifically.

Follow-up:
- https://github.com/interledger/web-monetization-extension/issues/625
- https://github.com/interledger/web-monetization-extension/issues/622