### PR TITLE
fix(content): ignore non-monetization links when `<link>` removed

### DIFF
--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -363,8 +363,9 @@ export class MonetizationLinkManager extends EventEmitter {
 
     for (const record of records) {
       if (record.type === 'childList') {
-        record.removedNodes.forEach(async (node) => {
+        record.removedNodes.forEach((node) => {
           if (!(node instanceof HTMLLinkElement)) return;
+          if (!node.relList.contains('monetization') || node.disabled) return;
           const payloadEntry = this.onRemovedLink(node);
           stopMonetizationPayload.push(payloadEntry);
         });

--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -365,7 +365,7 @@ export class MonetizationLinkManager extends EventEmitter {
       if (record.type === 'childList') {
         record.removedNodes.forEach((node) => {
           if (!(node instanceof HTMLLinkElement)) return;
-          if (!node.relList.contains('monetization') || node.disabled) return;
+          if (!this.monetizationLinks.has(node)) return;
           const payloadEntry = this.onRemovedLink(node);
           stopMonetizationPayload.push(payloadEntry);
         });


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Visiting some sites that remove link tags on load (in this case Google calendar) led to following error in console:

```
Uncaught (in promise) Error: Could not find details for monetization node <link rel="icon" id="favicon" type="image/x-icon" href="https://calendar.google.com/googlecalendar/images/favicons_2020q4/calendar_1.ico">
    at MonetizationLinkManager.onRemovedLink (content.js:3456:15)
    at content.js:3347:39
    at NodeList.forEach (<anonymous>)
    at MonetizationLinkManager.onWholeDocumentObserved (content.js:3345:31)
```

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Ignore removed link nodes that aren't relevant.