### PR TITLE
fix(content/KeyAutoAdd): get output of any step, not just of previous

### DIFF
--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -43,7 +43,7 @@ export class KeyAutoAdd {
     this.port.onMessage.addListener(
       (message: BackgroundToKeyAutoAddMessage) => {
         if (message.action === 'BEGIN') {
-          this.run(message.payload);
+          this.runAll(message.payload);
         }
       },
     );
@@ -121,7 +121,7 @@ export class KeyAutoAdd {
     return promise;
   }
 
-  private async run(payload: BeginPayload) {
+  private async runAll(payload: BeginPayload) {
     const helpers: StepRunHelpers = {
       output: <T extends StepRun>(fn: T) => {
         if (!this.outputs.has(fn)) {

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -210,7 +210,7 @@ class SkipError extends Error {
   }
 }
 
-function errorToDetails(err: { message: string } | ErrorWithKeyLike) {
+function errorToDetails(err: { message: string } | ErrorWithKeyLike): Details {
   return isErrorWithKey(err)
     ? { error: errorWithKeyToJSON(err), message: err.key }
     : { message: err.message as string };

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -7,14 +7,14 @@ export interface StepRunHelpers {
   output: <T extends StepRun>(fn: T) => Awaited<ReturnType<T>>;
 }
 
-export type StepRun<T = unknown> = (
+export type StepRun<TOutput = unknown> = (
   payload: BeginPayload,
   helpers: StepRunHelpers,
-) => Promise<T>;
+) => Promise<TOutput>;
 
-export interface Step<T = unknown> {
+export interface Step<TOutput = unknown> {
   name: string;
-  run: StepRun<T>;
+  run: StepRun<TOutput>;
   maxDuration?: number;
 }
 

--- a/src/content/keyAutoAdd/lib/types.ts
+++ b/src/content/keyAutoAdd/lib/types.ts
@@ -1,21 +1,20 @@
 import type { ErrorWithKeyLike } from '@/shared/helpers';
 import type { ErrorResponse } from '@/shared/messages';
 
-export interface StepRunParams extends BeginPayload {
+export interface StepRunHelpers {
   skip: (message: string | Error | ErrorWithKeyLike) => never;
   setNotificationSize: (size: 'notification' | 'fullscreen') => void;
+  output: <T extends StepRun>(fn: T) => Awaited<ReturnType<T>>;
 }
 
-export type StepRun<T = unknown, R = void> = (
-  params: StepRunParams,
-  prevStepResult: T extends (...args: any[]) => PromiseLike<any>
-    ? Exclude<Awaited<ReturnType<T>>, void | { type: symbol }>
-    : T,
-) => Promise<R | void>;
+export type StepRun<T = unknown> = (
+  payload: BeginPayload,
+  helpers: StepRunHelpers,
+) => Promise<T>;
 
-export interface Step<T = unknown, R = unknown> {
+export interface Step<T = unknown> {
   name: string;
-  run: StepRun<T, R>;
+  run: StepRun<T>;
   maxDuration?: number;
 }
 

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -3,7 +3,7 @@ import { errorWithKey, ErrorWithKey, sleep } from '@/shared/helpers';
 import {
   KeyAutoAdd,
   LOGIN_WAIT_TIMEOUT,
-  type StepRun as Step,
+  type StepRun as Run,
 } from './lib/keyAutoAdd';
 import { isTimedOut, waitForURL } from './lib/helpers';
 import { toWalletAddressUrl } from '@/popup/lib/utils';
@@ -26,11 +26,10 @@ type AccountDetails = {
   };
 };
 
-const waitForLogin: Step<never> = async ({
-  skip,
-  setNotificationSize,
-  keyAddUrl,
-}) => {
+const waitForLogin: Run<void> = async (
+  { keyAddUrl },
+  { skip, setNotificationSize },
+) => {
   let alreadyLoggedIn = window.location.href.startsWith(keyAddUrl);
   if (!alreadyLoggedIn) setNotificationSize('notification');
   try {
@@ -51,9 +50,7 @@ const waitForLogin: Step<never> = async ({
   }
 };
 
-const getAccountDetails: Step<never, Account[]> = async ({
-  setNotificationSize,
-}) => {
+const getAccounts: Run<Account[]> = async (_, { setNotificationSize }) => {
   setNotificationSize('fullscreen');
   await sleep(1000);
 
@@ -88,16 +85,13 @@ const getAccountDetails: Step<never, Account[]> = async ({
  * with a different account (user disconnected and changed account), revoke from
  * there first.
  */
-const revokeExistingKey: Step<typeof getAccountDetails, Account[]> = async (
-  { keyId, skip },
-  accounts,
-) => {
+const revokeExistingKey: Run<void> = async ({ keyId }, { skip, output }) => {
+  const accounts = output(getAccounts);
   for (const account of accounts) {
     for (const wallet of account.walletAddresses) {
       for (const key of wallet.keys) {
         if (key.id === keyId) {
           await revokeKey(account.id, wallet.id, key.id);
-          return accounts;
         }
       }
     }
@@ -106,10 +100,11 @@ const revokeExistingKey: Step<typeof getAccountDetails, Account[]> = async (
   skip('No existing keys that need to be revoked');
 };
 
-const findWallet: Step<
-  typeof revokeExistingKey,
-  { accountId: string; walletId: string }
-> = async ({ walletAddressUrl }, accounts) => {
+const findWallet: Run<{ accountId: string; walletId: string }> = async (
+  { walletAddressUrl },
+  { output },
+) => {
+  const accounts = output(getAccounts);
   for (const account of accounts) {
     for (const wallet of account.walletAddresses) {
       if (toWalletAddressUrl(wallet.url) === walletAddressUrl) {
@@ -120,10 +115,8 @@ const findWallet: Step<
   throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
 };
 
-const addKey: Step<typeof findWallet> = async (
-  { publicKey, nickName },
-  { accountId, walletId },
-) => {
+const addKey: Run<void> = async ({ publicKey, nickName }, { output }) => {
+  const { accountId, walletId } = output(findWallet);
   const url = `https://api.rafiki.money/accounts/${accountId}/wallet-addresses/${walletId}/upload-key`;
   const res = await fetch(url, {
     method: 'POST',
@@ -169,7 +162,7 @@ new KeyAutoAdd([
     run: waitForLogin,
     maxDuration: LOGIN_WAIT_TIMEOUT,
   },
-  { name: 'Getting account details', run: getAccountDetails },
+  { name: 'Getting account details', run: getAccounts },
   { name: 'Revoking existing key', run: revokeExistingKey },
   { name: 'Finding wallet', run: findWallet },
   { name: 'Adding key', run: addKey },

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -84,6 +84,14 @@ const getAccounts: Run<Account[]> = async (_, { setNotificationSize }) => {
  * The test wallet associates key with an account. If the same key is associated
  * with a different account (user disconnected and changed account), revoke from
  * there first.
+ *
+ * Why? Say, user connected once to `USD -> Addr#1`. Then disconnected. The key
+ * is still there in wallet added to `USD -> Addr#1` account. If now user wants
+ * to connect `EUR -> Addr#2` account, the extension still has the same key. So
+ * adding it again will throw an `internal server error`. But we'll continue
+ * getting `invalid_client` if we try to connect without the key added to new
+ * address. That's why we first revoke existing key (by ID) if any (from any
+ * existing account/address). It's a test-wallet specific thing.
  */
 const revokeExistingKey: Run<void> = async ({ keyId }, { skip, output }) => {
   const accounts = output(getAccounts);


### PR DESCRIPTION
Simplifies KeyAutoAdd's step runner to let us get output of any step (that has been previously run), not just result of previous. Getting result of previous had limitation that any intermediate steps had to pass through data from previous steps. Now we store outputs in a Map and get those with the `output(fn)` helper (WeakMap not needed, as we store reference to function anyway in steps array).

Also update signature of StepRun function.

Additionally, turn `skip` call to throw an instance of `SkipError` instead of object with symbol.