### PR TITLE
refactor(tests/e2e): rename environment variables

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -49,13 +49,13 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
-          WALLET_URL_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
-          WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
-          WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
-          CONNECT_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}
-          CONNECT_KEY_ID: ${{ vars.E2E_CONNECT_KEY_ID }}
-          CONNECT_PUBLIC_KEY: ${{ secrets.E2E_CONNECT_PUBLIC_KEY }}
-          CONNECT_PRIVATE_KEY: ${{ secrets.E2E_CONNECT_PRIVATE_KEY }}
+          TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
+          TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
+          TEST_WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
+          TEST_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}
+          TEST_WALLET_KEY_ID: ${{ vars.E2E_CONNECT_KEY_ID }}
+          TEST_WALLET_PUBLIC_KEY: ${{ secrets.E2E_CONNECT_PUBLIC_KEY }}
+          TEST_WALLET_PRIVATE_KEY: ${{ secrets.E2E_CONNECT_PRIVATE_KEY }}
 
       - name: Encrypt report
         shell: bash

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -47,13 +47,13 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
-          WALLET_URL_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
-          WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
-          WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
-          CONNECT_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}
-          CONNECT_KEY_ID: ${{ vars.E2E_CONNECT_KEY_ID }}
-          CONNECT_PUBLIC_KEY: ${{ secrets.E2E_CONNECT_PUBLIC_KEY }}
-          CONNECT_PRIVATE_KEY: ${{ secrets.E2E_CONNECT_PRIVATE_KEY }}
+          TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
+          TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
+          TEST_WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
+          TEST_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}
+          TEST_WALLET_KEY_ID: ${{ vars.E2E_CONNECT_KEY_ID }}
+          TEST_WALLET_PUBLIC_KEY: ${{ secrets.E2E_CONNECT_PUBLIC_KEY }}
+          TEST_WALLET_PRIVATE_KEY: ${{ secrets.E2E_CONNECT_PRIVATE_KEY }}
 
       - name: Encrypt report
         shell: bash

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,30 +10,30 @@ To run end-to-end tests, run `pnpm test:e2e` in terminal. To run tests with Chro
 
 Make sure you run `pnpm build chrome` before running tests.
 
-**Before you begin**, you need to setup some environment variables/secrets in `tests/.env`.
+**Before you begin**, you need to setup some environment variables/secrets in `tests/e2e/.env`.
 
-1. Copy `tests/.env.example` to `tests/.env`
-2. Update `tests/.env` with your secrets.
+1. Copy `tests/e2e/.env.example` to `tests/e2e/.env`
+2. Update `tests/e2e/.env` with your secrets.
 
-| Environment Variable         | Description                                                 | Is secret? |
-| ---------------------------- | ----------------------------------------------------------- | ---------- |
-| `WALLET_URL_ORIGIN`          | URL of the wallet (e.g. https://rafiki.money)               | No         |
-| `WALLET_USERNAME`            | Login email for the wallet                                  | No         |
-| `WALLET_PASSWORD`            | Login password for the wallet                               | Yes        |
-| `CONNECT_WALLET_ADDRESS_URL` | Your wallet address that will be connected to extension     | No         |
-| `CONNECT_KEY_ID`             | ID of the key that will be connected to extension (UUID v4) | No         |
-| `CONNECT_PRIVATE_KEY`        | Private key (hex-encoded Ed25519 private key)               | Yes        |
-| `CONNECT_PUBLIC_KEY`         | Public key (base64-encoded Ed25519 public key)              | No         |
+| Environment Variable      | Description                                                 | Secret? |
+| ------------------------- | ----------------------------------------------------------- | ------- |
+| `TEST_WALLET_ORIGIN`      | URL origin of the test wallet (e.g. https://rafiki.money)   | -       |
+| `TEST_WALLET_USERNAME`    | -- Login email for the test wallet                          | -       |
+| `TEST_WALLET_PASSWORD`    | -- Login password for the test wallet                       | Yes     |
+| `TEST_WALLET_ADDRESS_URL` | Your wallet address URL that will be connected to extension | -       |
+| `TEST_WALLET_KEY_ID`      | ID of the key that will be connected to extension (UUID v4) | -       |
+| `TEST_WALLET_PRIVATE_KEY` | Private key (hex-encoded Ed25519 private key)               | Yes     |
+| `TEST_WALLET_PUBLIC_KEY`  | Public key (base64-encoded Ed25519 public key)              | -       |
 
-To get the `CONNECT_KEY_ID`, `CONNECT_PRIVATE_KEY` and `CONNECT_PUBLIC_KEY`:
+To get the `TEST_WALLET_KEY_ID`, `TEST_WALLET_PRIVATE_KEY` and `TEST_WALLET_PUBLIC_KEY`:
 
 1. Load the extension in browser (via `chrome://extensions/`)
    - Once the extension is loaded, it'll generate a key-pair that we will need to connect with our wallet.
 1. Inspect service worker with "Inspect views service worker"
-1. Run following in devtools console to copy keys to your clipboard, and paste it in `tests/.env`:
+1. Run following in devtools console to copy keys to your clipboard, and paste it in `tests/e2e/.env`:
    ```js
    // 1. Gets generated keys from extension storage.
-   // 2. Converts result to `CONNECT_{X}="VAL"` format for use in .env file.
+   // 2. Converts result to `TEST_WALLET_{X}="VAL"` format for use in .env file.
    // 3. Copies result to clipboard.
    copy(
      Object.entries(
@@ -41,12 +41,12 @@ To get the `CONNECT_KEY_ID`, `CONNECT_PRIVATE_KEY` and `CONNECT_PUBLIC_KEY`:
      )
        .map(
          ([k, v]) =>
-           `CONNECT_${k.replace(/([A-Z])/g, '_$1').toUpperCase()}="${v}"`,
+           `TEST_WALLET_${k.replace(/([A-Z])/g, '_$1').toUpperCase()}="${v}"`,
        )
        .join('\n'),
    );
    ```
-1. Then copy `CONNECT_PUBLIC_KEY` key to https://rafiki.money/settings/developer-keys under your wallet address.
+1. Then copy `TEST_WALLET_PUBLIC_KEY` key to https://rafiki.money/settings/developer-keys under your wallet address.
 1. Now you're ready to run the tests.
 
 ### How to run in end-to-end tests in GitHub

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -3,14 +3,13 @@
 PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1
 
 # Can replace with a localhost instance if needed. Ensure doesn't end with /
-WALLET_URL_ORIGIN=https://rafiki.money
-WALLET_USERNAME=user@email.com
-WALLET_PASSWORD=some-password
+TEST_WALLET_ORIGIN=https://rafiki.money
+TEST_WALLET_USERNAME=user@email.com
+TEST_WALLET_PASSWORD=some-password
 
 # To connect extension to wallet
-CONNECT_WALLET_ADDRESS_URL="https://ilp.rafiki.money/something"
-
+TEST_WALLET_ADDRESS_URL="https://ilp.rafiki.money/something"
 # We'll make extension use this key-pair consistently. See docs/CONTRIBUTING.md
-CONNECT_KEY_ID=uuid-v4-key-id
-CONNECT_PUBLIC_KEY="base-64-public-key=="
-CONNECT_PRIVATE_KEY="hex-encoded-private-key"
+TEST_WALLET_KEY_ID=uuid-v4-key-id
+TEST_WALLET_PUBLIC_KEY="base-64-public-key=="
+TEST_WALLET_PRIVATE_KEY="hex-encoded-private-key"

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -11,19 +11,20 @@ import { authFile } from './fixtures/helpers';
 setup('authenticate', async ({ page }) => {
   setup.skip(existsSync(authFile), 'Already authenticated');
 
-  const { WALLET_URL_ORIGIN, WALLET_USERNAME, WALLET_PASSWORD } = process.env;
+  const { TEST_WALLET_ORIGIN, TEST_WALLET_USERNAME, TEST_WALLET_PASSWORD } =
+    process.env;
 
-  expect(WALLET_URL_ORIGIN).toBeDefined();
-  expect(WALLET_USERNAME).toBeDefined();
-  expect(WALLET_PASSWORD).toBeDefined();
+  expect(TEST_WALLET_ORIGIN).toBeDefined();
+  expect(TEST_WALLET_USERNAME).toBeDefined();
+  expect(TEST_WALLET_PASSWORD).toBeDefined();
 
-  await page.goto(`${WALLET_URL_ORIGIN!}/auth/login`);
-  await page.getByLabel('E-mail').fill(WALLET_USERNAME!);
-  await page.getByLabel('Password').fill(WALLET_PASSWORD!);
+  await page.goto(`${TEST_WALLET_ORIGIN}/auth/login`);
+  await page.getByLabel('E-mail').fill(TEST_WALLET_USERNAME);
+  await page.getByLabel('Password').fill(TEST_WALLET_PASSWORD);
   await page.getByRole('button', { name: 'login' }).click();
-  await page.waitForURL(WALLET_URL_ORIGIN!);
+  await page.waitForURL(TEST_WALLET_ORIGIN);
 
-  await page.goto(`${WALLET_URL_ORIGIN!}/settings/developer-keys`);
+  await page.goto(`${TEST_WALLET_ORIGIN}/settings/developer-keys`);
   await expect(page.locator('h1')).toHaveText('Developer Keys');
 
   await page.context().storageState({ path: authFile });

--- a/tests/e2e/connect.spec.ts
+++ b/tests/e2e/connect.spec.ts
@@ -14,15 +14,15 @@ test('connects with correct details provided', async ({
   page,
 }) => {
   const {
-    CONNECT_KEY_ID,
-    CONNECT_PRIVATE_KEY,
-    CONNECT_PUBLIC_KEY,
-    CONNECT_WALLET_ADDRESS_URL,
+    TEST_WALLET_KEY_ID,
+    TEST_WALLET_PRIVATE_KEY,
+    TEST_WALLET_PUBLIC_KEY,
+    TEST_WALLET_ADDRESS_URL,
   } = process.env;
-  expect(CONNECT_KEY_ID).toBeDefined();
-  expect(CONNECT_PRIVATE_KEY).toBeDefined();
-  expect(CONNECT_PUBLIC_KEY).toBeDefined();
-  expect(CONNECT_WALLET_ADDRESS_URL).toBeDefined();
+  expect(TEST_WALLET_KEY_ID).toBeDefined();
+  expect(TEST_WALLET_PRIVATE_KEY).toBeDefined();
+  expect(TEST_WALLET_PUBLIC_KEY).toBeDefined();
+  expect(TEST_WALLET_ADDRESS_URL).toBeDefined();
 
   expect(
     await background.evaluate(() => {
@@ -31,12 +31,12 @@ test('connects with correct details provided', async ({
   ).toEqual({ connected: false });
 
   const keyInfo = {
-    keyId: CONNECT_KEY_ID!,
-    privateKey: CONNECT_PRIVATE_KEY!,
-    publicKey: CONNECT_PUBLIC_KEY!,
+    keyId: TEST_WALLET_KEY_ID,
+    privateKey: TEST_WALLET_PRIVATE_KEY,
+    publicKey: TEST_WALLET_PUBLIC_KEY,
   };
   await connectWallet(persistentContext, background, i18n, keyInfo, popup, {
-    walletAddressUrl: CONNECT_WALLET_ADDRESS_URL!,
+    walletAddressUrl: TEST_WALLET_ADDRESS_URL,
     amount: '10',
     recurring: false,
   });

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -18,9 +18,9 @@ test('Connect to test wallet with automatic key addition when not logged-in to w
   background,
   i18n,
 }) => {
-  const username = process.env.WALLET_USERNAME!;
-  const password = process.env.WALLET_PASSWORD!;
-  const walletAddressUrl = process.env.CONNECT_WALLET_ADDRESS_URL!;
+  const username = process.env.TEST_WALLET_USERNAME;
+  const password = process.env.TEST_WALLET_PASSWORD;
+  const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
 
   const jwksUrl = new URL('jwks.json', ensureEnd(walletAddressUrl, '/')).href;
 

--- a/tests/e2e/env.d.ts
+++ b/tests/e2e/env.d.ts
@@ -1,0 +1,20 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      /** Can replace with a localhost instance if needed */
+      TEST_WALLET_ORIGIN: string;
+      TEST_WALLET_USERNAME: string;
+      TEST_WALLET_PASSWORD: string;
+      /** Wallet address that we'll use to connect with the extension */
+      TEST_WALLET_ADDRESS_URL: string;
+      /** UUID v4 */
+      TEST_WALLET_KEY_ID: string;
+      /** Base-64 public key */
+      TEST_WALLET_PUBLIC_KEY: string;
+      /** Hex-encoded private key */
+      TEST_WALLET_PRIVATE_KEY: string;
+    }
+  }
+}
+
+export {};

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -7,12 +7,12 @@ export const test = base.extend<{ page: Page }, { popup: Popup }>({
   popup: [
     async ({ persistentContext: context, background, popup, i18n }, use) => {
       const keyInfo = {
-        keyId: process.env.CONNECT_KEY_ID!,
-        privateKey: process.env.CONNECT_PRIVATE_KEY!,
-        publicKey: process.env.CONNECT_PUBLIC_KEY!,
+        keyId: process.env.TEST_WALLET_KEY_ID,
+        privateKey: process.env.TEST_WALLET_PRIVATE_KEY,
+        publicKey: process.env.TEST_WALLET_PUBLIC_KEY,
       };
       await connectWallet(context, background, i18n, keyInfo, popup, {
-        walletAddressUrl: process.env.CONNECT_WALLET_ADDRESS_URL!,
+        walletAddressUrl: process.env.TEST_WALLET_ADDRESS_URL,
         amount: '10',
         recurring: false,
       });

--- a/tests/e2e/simple.spec.ts
+++ b/tests/e2e/simple.spec.ts
@@ -8,7 +8,7 @@ test('should monetize site with single wallet address', async ({
   page,
   popup,
 }) => {
-  const walletAddressUrl = process.env.CONNECT_WALLET_ADDRESS_URL!;
+  const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
   const playgroundUrl = 'https://webmonetization.org/play/';
 
   await page.goto(playgroundUrl);


### PR DESCRIPTION
1. Add `TEST_WALLET_` prefix to test wallet related vars
2. Add types for `process.env`
3. Update location of .env file from tests/.env to tests/e2e/.env