### PR TITLE
fix(popup/ConnectWalletForm): fix paste after field is emptied

### DIFF
--- a/src/popup/components/ConnectWalletForm.tsx
+++ b/src/popup/components/ConnectWalletForm.tsx
@@ -296,6 +296,7 @@ export const ConnectWalletForm = ({
           if (!value) return;
           if (!validateWalletAddressUrl(value)) {
             ev.preventDefault(); // full url was pasted
+            input.value = value;
           } else {
             await sleep(0); // allow paste to be complete
             value = input.value;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

If we emptied the input, and then pasted something (for example, cut and paste), we weren't setting the input value (with `ev.preventDefault`). This was looking as if we pasted empty string in input (leading to "wallet address is required" error).

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
