### PR TITLE
fix(ci/bump-manifest-version): format manifest.json after update

### DIFF
--- a/.github/workflows/bump-manifest-version.yml
+++ b/.github/workflows/bump-manifest-version.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with: { node-version-file: '.nvmrc' }
+      - name: Environment setup
+        uses: ./.github/actions/setup
 
       - name: Bump version
         id: bump
@@ -38,6 +37,9 @@ jobs:
           script: |
             const script = require('./.github/actions/bump-manifest-version.cjs')
             await script({ github, context, core })
+
+      - name: Format with prettier
+        run: pnpm format:fix
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
As seen in https://github.com/interledger/web-monetization-extension/pull/687/commits/8cb6b85b8235861e5b6ce71d8cc3184fad1fd06b