### PR TITLE
chore(.eslintignore): exclude playwright test results & reports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ dev/
 temp/
 dist/
 build/
+tests/e2e/playwright-report
+tests/e2e/test-results


### PR DESCRIPTION
Was leading to too many errors in generated files.