### PR TITLE
chore(deps): revert update structured-headers to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "string_decoder": "1.3.0",
       "readable-stream": "2.3.8",
       "bn.js": "5.2.1",
-      "structured-headers": "2.0.0"
+      "structured-headers": "1.0.1"
     }
   },
   "packageManager": "pnpm@9.12.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   string_decoder: 1.3.0
   readable-stream: 2.3.8
   bn.js: 5.2.1
-  structured-headers: 2.0.0
+  structured-headers: 1.0.1
 
 importers:
 
@@ -2262,7 +2262,6 @@ packages:
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -3941,9 +3940,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  structured-headers@2.0.0:
-    resolution: {integrity: sha512-qX9utDaDolZWTcAep0EZDSQASTu4mx16Jh5dBSpplfvK3ro1CF8mWqRByAwncRojnlaCCUZA2jPcCqKNnp7uCA==}
-    engines: {node: '>=18', npm: '>=6'}
+  structured-headers@1.0.1:
+    resolution: {integrity: sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==}
+    engines: {node: '>= 14', npm: '>=6'}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -7014,7 +7013,7 @@ snapshots:
 
   http-message-signatures@1.0.4:
     dependencies:
-      structured-headers: 2.0.0
+      structured-headers: 1.0.1
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -7026,7 +7025,7 @@ snapshots:
 
   httpbis-digest-headers@1.0.0:
     dependencies:
-      structured-headers: 2.0.0
+      structured-headers: 1.0.1
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -8593,7 +8592,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  structured-headers@2.0.0: {}
+  structured-headers@1.0.1: {}
 
   sucrase@3.35.0:
     dependencies:


### PR DESCRIPTION
Reverts 2176a58fbd3d458e40018594119721471386dfc9
Was getting error `structured_headers_1.ByteSequence is not a constructor` on connect. Should've run E2E tests before merging #664 