### PR TITLE
fix(scripts/build): use correct asset-copy paths on Windows 

### DIFF
--- a/esbuild/config.ts
+++ b/esbuild/config.ts
@@ -7,9 +7,15 @@ export const TARGETS = ['chrome', 'firefox'] as const;
 export const CHANNELS = ['nightly', 'preview', 'stable'] as const;
 
 export const ROOT_DIR = path.resolve(__dirname, '..');
-export const SRC_DIR = path.resolve(ROOT_DIR, 'src');
-export const DEV_DIR = path.resolve(ROOT_DIR, 'dev');
-export const DIST_DIR = path.resolve(ROOT_DIR, 'dist');
+export const SRC_DIR = path
+  .resolve(ROOT_DIR, 'src')
+  .replaceAll(path.sep, path.posix.sep);
+export const DEV_DIR = path
+  .resolve(ROOT_DIR, 'dev')
+  .replaceAll(path.sep, path.posix.sep);
+export const DIST_DIR = path
+  .resolve(ROOT_DIR, 'dist')
+  .replaceAll(path.sep, path.posix.sep);
 
 const KEY_AUTO_ADD_TARGETS = readdirSync(
   path.join(SRC_DIR, 'content', 'keyAutoAdd'),

--- a/esbuild/config.ts
+++ b/esbuild/config.ts
@@ -7,15 +7,9 @@ export const TARGETS = ['chrome', 'firefox'] as const;
 export const CHANNELS = ['nightly', 'preview', 'stable'] as const;
 
 export const ROOT_DIR = path.resolve(__dirname, '..');
-export const SRC_DIR = path
-  .resolve(ROOT_DIR, 'src')
-  .replaceAll(path.sep, path.posix.sep);
-export const DEV_DIR = path
-  .resolve(ROOT_DIR, 'dev')
-  .replaceAll(path.sep, path.posix.sep);
-export const DIST_DIR = path
-  .resolve(ROOT_DIR, 'dist')
-  .replaceAll(path.sep, path.posix.sep);
+export const SRC_DIR = path.resolve(ROOT_DIR, 'src');
+export const DEV_DIR = path.resolve(ROOT_DIR, 'dev');
+export const DIST_DIR = path.resolve(ROOT_DIR, 'dist');
 
 const KEY_AUTO_ADD_TARGETS = readdirSync(
   path.join(SRC_DIR, 'content', 'keyAutoAdd'),

--- a/esbuild/plugins.ts
+++ b/esbuild/plugins.ts
@@ -80,26 +80,26 @@ function getAssetPaths(srcDir: string, outDir: string) {
   const assetPaths = [
     {
       from: path.join(srcDir, 'popup', 'index.html'),
-      to: path.join(outDir, 'popup', 'index.html')
+      to: path.join(outDir, 'popup', 'index.html'),
     },
     {
       from: path.join(srcDir, 'pages', 'progress-connect', 'index.html'),
-      to: path.join(outDir, 'pages', 'progress-connect', 'index.html')
+      to: path.join(outDir, 'pages', 'progress-connect', 'index.html'),
     },
     {
       from: path.join(srcDir, '_locales', '**', '*'),
-      to: path.join(outDir, '_locales')
+      to: path.join(outDir, '_locales'),
     },
     {
       from: path.join(srcDir, 'assets', '**', '*'),
-      to: path.join(outDir, 'assets')
-    }
+      to: path.join(outDir, 'assets'),
+    },
   ];
 
   // normalize paths to use forward slashes
   return assetPaths.map(({ from, to }) => ({
     from: from.split(sep).join('/'),
-    to: to.split(sep).join('/')
+    to: to.split(sep).join('/'),
   }));
 }
 

--- a/esbuild/plugins.ts
+++ b/esbuild/plugins.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import path, { posix, sep } from 'node:path';
 import fs from 'node:fs/promises';
 import type { Plugin as ESBuildPlugin } from 'esbuild';
 import { nodeBuiltin } from 'esbuild-node-builtin';
@@ -48,30 +48,24 @@ export const getPlugins = ({
       resolveFrom: ROOT_DIR,
       assets: [
         {
-          from: path.posix.join(SRC_DIR, 'popup', 'index.html'),
-          to: path.posix.join(outDir, 'popup', 'index.html'),
+          from: toPosix(path.join(SRC_DIR, 'popup', 'index.html')),
+          to: toPosix(path.join(outDir, 'popup', 'index.html')),
         },
         {
-          from: path.posix.join(
-            SRC_DIR,
-            'pages',
-            'progress-connect',
-            'index.html',
+          from: toPosix(
+            path.join(SRC_DIR, 'pages', 'progress-connect', 'index.html'),
           ),
-          to: path.posix.join(
-            outDir,
-            'pages',
-            'progress-connect',
-            'index.html',
+          to: toPosix(
+            path.join(outDir, 'pages', 'progress-connect', 'index.html'),
           ),
         },
         {
-          from: path.posix.join(SRC_DIR, '_locales', '**', '*'),
-          to: path.posix.join(outDir, '_locales'),
+          from: toPosix(path.join(SRC_DIR, '_locales', '**', '*')),
+          to: toPosix(path.join(outDir, '_locales')),
         },
         {
-          from: path.posix.join(SRC_DIR, 'assets', '**', '*'),
-          to: path.posix.join(outDir, 'assets'),
+          from: toPosix(path.join(SRC_DIR, 'assets', '**', '*')),
+          to: toPosix(path.join(outDir, 'assets')),
         },
       ],
       watch: dev,
@@ -183,4 +177,8 @@ function cleanPlugin(dirs: string[]): ESBuildPlugin {
       });
     },
   };
+}
+
+function toPosix(path: string): string {
+  return path.replaceAll(sep, posix.sep);
 }

--- a/esbuild/plugins.ts
+++ b/esbuild/plugins.ts
@@ -1,4 +1,4 @@
-import path, { posix, sep } from 'node:path';
+import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { Plugin as ESBuildPlugin } from 'esbuild';
 import { nodeBuiltin } from 'esbuild-node-builtin';
@@ -179,6 +179,6 @@ function cleanPlugin(dirs: string[]): ESBuildPlugin {
   };
 }
 
-function toPosix(path: string): string {
-  return path.replaceAll(sep, posix.sep);
+function toPosix(filePath: string): string {
+  return filePath.replaceAll(path.sep, path.posix.sep);
 }

--- a/esbuild/plugins.ts
+++ b/esbuild/plugins.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { sep } from 'node:path';
 import fs from 'node:fs/promises';
 import type { Plugin as ESBuildPlugin } from 'esbuild';
 import { nodeBuiltin } from 'esbuild-node-builtin';
@@ -47,7 +46,34 @@ export const getPlugins = ({
     }),
     copy({
       resolveFrom: ROOT_DIR,
-      assets: getAssetPaths(SRC_DIR, outDir),
+      assets: [
+        {
+          from: path.posix.join(SRC_DIR, 'popup', 'index.html'),
+          to: path.posix.join(outDir, 'popup', 'index.html'),
+        },
+        {
+          from: path.posix.join(
+            SRC_DIR,
+            'pages',
+            'progress-connect',
+            'index.html',
+          ),
+          to: path.posix.join(
+            outDir,
+            'pages',
+            'progress-connect',
+            'index.html',
+          ),
+        },
+        {
+          from: path.posix.join(SRC_DIR, '_locales', '**', '*'),
+          to: path.posix.join(outDir, '_locales'),
+        },
+        {
+          from: path.posix.join(SRC_DIR, 'assets', '**', '*'),
+          to: path.posix.join(outDir, 'assets'),
+        },
+      ],
       watch: dev,
     }),
     processManifestPlugin({ outDir, dev, target, channel }),
@@ -74,33 +100,6 @@ function ignorePackagePlugin(ignores: RegExp[]): ESBuildPlugin {
       }));
     },
   };
-}
-
-function getAssetPaths(srcDir: string, outDir: string) {
-  const assetPaths = [
-    {
-      from: path.join(srcDir, 'popup', 'index.html'),
-      to: path.join(outDir, 'popup', 'index.html'),
-    },
-    {
-      from: path.join(srcDir, 'pages', 'progress-connect', 'index.html'),
-      to: path.join(outDir, 'pages', 'progress-connect', 'index.html'),
-    },
-    {
-      from: path.join(srcDir, '_locales', '**', '*'),
-      to: path.join(outDir, '_locales'),
-    },
-    {
-      from: path.join(srcDir, 'assets', '**', '*'),
-      to: path.join(outDir, 'assets'),
-    },
-  ];
-
-  // normalize paths to use forward slashes
-  return assetPaths.map(({ from, to }) => ({
-    from: from.split(sep).join('/'),
-    to: to.split(sep).join('/'),
-  }));
 }
 
 function processManifestPlugin({

--- a/esbuild/plugins.ts
+++ b/esbuild/plugins.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { sep } from 'node:path';
 import fs from 'node:fs/promises';
 import type { Plugin as ESBuildPlugin } from 'esbuild';
 import { nodeBuiltin } from 'esbuild-node-builtin';
@@ -46,24 +47,7 @@ export const getPlugins = ({
     }),
     copy({
       resolveFrom: ROOT_DIR,
-      assets: [
-        {
-          from: path.join(SRC_DIR, 'popup', 'index.html'),
-          to: path.join(outDir, 'popup', 'index.html'),
-        },
-        {
-          from: path.join(SRC_DIR, 'pages', 'progress-connect', 'index.html'),
-          to: path.join(outDir, 'pages', 'progress-connect', 'index.html'),
-        },
-        {
-          from: path.join(SRC_DIR, '_locales/**/*'),
-          to: path.join(outDir, '_locales'),
-        },
-        {
-          from: path.join(SRC_DIR, 'assets/**/*'),
-          to: path.join(outDir, 'assets'),
-        },
-      ],
+      assets: getAssetPaths(SRC_DIR, outDir),
       watch: dev,
     }),
     processManifestPlugin({ outDir, dev, target, channel }),
@@ -90,6 +74,33 @@ function ignorePackagePlugin(ignores: RegExp[]): ESBuildPlugin {
       }));
     },
   };
+}
+
+function getAssetPaths(srcDir: string, outDir: string) {
+  const assetPaths = [
+    {
+      from: path.join(srcDir, 'popup', 'index.html'),
+      to: path.join(outDir, 'popup', 'index.html')
+    },
+    {
+      from: path.join(srcDir, 'pages', 'progress-connect', 'index.html'),
+      to: path.join(outDir, 'pages', 'progress-connect', 'index.html')
+    },
+    {
+      from: path.join(srcDir, '_locales', '**', '*'),
+      to: path.join(outDir, '_locales')
+    },
+    {
+      from: path.join(srcDir, 'assets', '**', '*'),
+      to: path.join(outDir, 'assets')
+    }
+  ];
+
+  // normalize paths to use forward slashes
+  return assetPaths.map(({ from, to }) => ({
+    from: from.split(sep).join('/'),
+    to: to.split(sep).join('/')
+  }));
 }
 
 function processManifestPlugin({


### PR DESCRIPTION

## Context

The copy plugin should be able to copy all the files correctly, regardless of the operating system (Windows, Linux, or macOS).

Closes #711 .

## Changes proposed in this pull request

Convert the backslashes to forward slashes in the from and to paths passed to the copy plugin.
