### PR TITLE
chore(.eslintrc): scope plugins to files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,14 +4,7 @@
     "browser": true,
     "node": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:jsx-a11y/recommended",
-    "plugin:jest/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module",
@@ -30,57 +23,70 @@
     "semi": "off",
     "no-extra-semi": "off",
     "maxWarnings": "off",
-    "react/self-closing-comp": [
-      "error",
-      {
-        "component": true,
-        "html": true
-      }
-    ],
     "no-constant-condition": "off",
-    "no-console": "warn",
-    "react/prop-types": "off",
     "block-scoped-var": "error",
     "consistent-return": "off",
-    "react/jsx-props-no-spreading": "off",
+    "no-console": "warn",
     "import/prefer-default-export": "off",
-    "jsx-a11y/anchor-is-valid": "warn",
-    "jsx-a11y/no-noninteractive-tabindex": [
-      "warn",
-      {
-        "tags": [],
-        "roles": ["tabpanel"],
-        "allowExpressionValues": true
-      }
-    ],
-    "jsx-a11y/tabindex-no-positive": "warn",
-    "jsx-a11y/click-events-have-key-events": "warn",
-    "jsx-a11y/no-static-element-interactions": "warn",
-    "jsx-a11y/no-noninteractive-element-interactions": "warn",
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "error",
-    "react/react-in-jsx-scope": "off",
-    "react/jsx-uses-react": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
-      {
-        "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^_"
-      }
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
     "@typescript-eslint/no-explicit-any": "off"
   },
   "overrides": [
     {
       "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:n/recommended"
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
+        "plugin:jsx-a11y/recommended"
       ],
-      "files": ["**/*.js", "**/*.cjs"],
-      "env": {
-        "node": true
+      "files": ["src/**/*.tsx"],
+      "env": { "browser": true },
+      "rules": {
+        "react/self-closing-comp": [
+          "error",
+          { "component": true, "html": true }
+        ],
+        "react/jsx-props-no-spreading": "off",
+        "react/jsx-uses-react": "off",
+        "react-hooks/exhaustive-deps": "error",
+        "react-hooks/rules-of-hooks": "error",
+        "jsx-a11y/anchor-is-valid": "warn",
+        "jsx-a11y/no-noninteractive-tabindex": [
+          "warn",
+          { "tags": [], "roles": ["tabpanel"], "allowExpressionValues": true }
+        ],
+        "jsx-a11y/tabindex-no-positive": "warn",
+        "jsx-a11y/click-events-have-key-events": "warn",
+        "jsx-a11y/no-static-element-interactions": "warn",
+        "jsx-a11y/no-noninteractive-element-interactions": "warn"
       }
+    },
+    {
+      "extends": [
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
+        "plugin:jest/recommended"
+      ],
+      "files": ["**/*.test.tsx", "**/*.test.ts"],
+      "excludedFiles": ["tests/e2e/**/*"],
+      "env": { "browser": true, "jest": true },
+      "rules": {
+        "react/self-closing-comp": [
+          "error",
+          { "component": true, "html": true }
+        ],
+        "react/jsx-props-no-spreading": "off",
+        "react/jsx-uses-react": "off",
+        "react-hooks/exhaustive-deps": "error",
+        "react-hooks/rules-of-hooks": "error"
+      }
+    },
+    {
+      "extends": ["plugin:n/recommended"],
+      "files": ["**/*.js", "**/*.cjs"],
+      "env": { "node": true }
     }
   ],
   "ignorePatterns": ["dist/**", "dev/**", "coverage/**"],


### PR DESCRIPTION
As seen in https://github.com/interledger/web-monetization-extension/pull/719#issuecomment-2485243119.

- Now we scope plugin and rules, targeted to files.
- Removed some rules that were already part of "recommended" extends.