### PR TITLE
refactor(tests/e2e): extract `getContinueWaitTime` helper

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,7 +17,7 @@ Make sure you run `pnpm build chrome` before running tests.
 
 | Environment Variable        | Description                                                 | Secret? | Optional? |
 | --------------------------- | ----------------------------------------------------------- | ------- | --------- |
-| `TEST_WALLET_ORIGIN`        | URL origin of the test wallet (e.g. https://rafiki.money)   | -       | -         |
+| `TEST_WALLET_ORIGIN`        | URL origin of the test wallet                               | -       | -         |
 | `TEST_WALLET_USERNAME`      | -- Login email for the test wallet                          | -       | -         |
 | `TEST_WALLET_PASSWORD`      | -- Login password for the test wallet                       | Yes     | -         |
 | `TEST_WALLET_ADDRESS_URL`   | Your wallet address URL that will be connected to extension | -       | -         |

--- a/tests/e2e/connectAutoKeyFynbos.spec.ts
+++ b/tests/e2e/connectAutoKeyFynbos.spec.ts
@@ -4,7 +4,6 @@ import { disconnectWallet, fillPopup } from './pages/popup';
 import { getContinueWaitTime, waitForWelcomePage } from './helpers/common';
 import {
   acceptGrant,
-  DEFAULT_CONTINUE_WAIT_MS,
   KEYS_PAGE_URL,
   LOGIN_PAGE_URL,
   revokeKey,
@@ -77,11 +76,9 @@ test('Connect to Fynbos with automatic key addition when not logged-in to wallet
     return openedPage;
   });
 
-  const continueWaitMsPromise = getContinueWaitTime(
-    context,
-    { walletAddressUrl },
-    DEFAULT_CONTINUE_WAIT_MS,
-  );
+  const continueWaitMsPromise = getContinueWaitTime(context, {
+    walletAddressUrl,
+  });
 
   const keyNickName = await test.step('adds key to wallet', async () => {
     const { resolve, promise } = withResolvers<string>();

--- a/tests/e2e/connectAutoKeyFynbos.spec.ts
+++ b/tests/e2e/connectAutoKeyFynbos.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from './fixtures/base';
 import { getJWKS, withResolvers } from '@/shared/helpers';
 import { disconnectWallet, fillPopup } from './pages/popup';
-import { waitForWelcomePage } from './helpers/common';
+import { getContinueWaitTime, waitForWelcomePage } from './helpers/common';
 import {
   acceptGrant,
-  getContinueWaitTime,
+  DEFAULT_CONTINUE_WAIT_MS,
   KEYS_PAGE_URL,
   LOGIN_PAGE_URL,
   revokeKey,
@@ -77,9 +77,11 @@ test('Connect to Fynbos with automatic key addition when not logged-in to wallet
     return openedPage;
   });
 
-  const continueWaitMsPromise = getContinueWaitTime(context, {
-    walletAddressUrl,
-  });
+  const continueWaitMsPromise = getContinueWaitTime(
+    context,
+    { walletAddressUrl },
+    DEFAULT_CONTINUE_WAIT_MS,
+  );
 
   const keyNickName = await test.step('adds key to wallet', async () => {
     const { resolve, promise } = withResolvers<string>();

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from './fixtures/base';
 import { withResolvers, getJWKS } from '@/shared/helpers';
 import { disconnectWallet, fillPopup } from './pages/popup';
-import { waitForWelcomePage } from './helpers/common';
+import { getContinueWaitTime, waitForWelcomePage } from './helpers/common';
 import {
   acceptGrant,
   API_URL_ORIGIN,
+  DEFAULT_CONTINUE_WAIT_MS,
   KEYS_PAGE_URL,
   LOGIN_PAGE_URL,
-  getContinueWaitTime,
   revokeKey,
   waitForGrantConsentPage,
 } from './helpers/testWallet';
@@ -68,9 +68,11 @@ test('Connect to test wallet with automatic key addition when not logged-in to w
     return openedPage;
   });
 
-  const continueWaitMsPromise = getContinueWaitTime(context, {
-    walletAddressUrl,
-  });
+  const continueWaitMsPromise = getContinueWaitTime(
+    context,
+    { walletAddressUrl },
+    DEFAULT_CONTINUE_WAIT_MS,
+  );
 
   const revokeInfo = await test.step('adds key to wallet', async () => {
     const { resolve, reject, promise } = withResolvers<{

--- a/tests/e2e/helpers/common.ts
+++ b/tests/e2e/helpers/common.ts
@@ -1,4 +1,6 @@
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+import type { ConnectDetails } from '../pages/popup';
+import { getWalletInformation } from '@/shared/helpers';
 
 const OPEN_PAYMENTS_REDIRECT_URL = `https://webmonetization.org/welcome`;
 
@@ -8,4 +10,34 @@ export async function waitForWelcomePage(page: Page) {
       url.href.startsWith(OPEN_PAYMENTS_REDIRECT_URL) &&
       url.searchParams.get('result') === 'grant_success',
   );
+}
+
+export async function getContinueWaitTime(
+  context: BrowserContext,
+  params: Pick<ConnectDetails, 'walletAddressUrl'>,
+  defaultWaitMs = 2000,
+) {
+  defaultWaitMs += 10;
+  const continueWaitMs = await (async () => {
+    if (process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1') {
+      return Promise.resolve(defaultWaitMs);
+    }
+    const walletInfo = await getWalletInformation(params.walletAddressUrl);
+    return await new Promise<number>((resolve) => {
+      const authServer = new URL(walletInfo.authServer).href;
+      context.on('requestfinished', async function intercept(req) {
+        if (!req.serviceWorker()) return;
+        if (new URL(req.url()).href !== authServer) return;
+
+        const res = await req.response();
+        const json = await res?.json();
+        context.off('requestfinished', intercept);
+        if (typeof json?.continue?.wait !== 'number') {
+          return resolve(defaultWaitMs);
+        }
+        return resolve(json.continue.wait * 1000);
+      });
+    });
+  })();
+  return continueWaitMs;
 }

--- a/tests/e2e/helpers/common.ts
+++ b/tests/e2e/helpers/common.ts
@@ -15,7 +15,8 @@ export async function waitForWelcomePage(page: Page) {
 export async function getContinueWaitTime(
   context: BrowserContext,
   params: Pick<ConnectDetails, 'walletAddressUrl'>,
-  defaultWaitMs = 2000,
+  // https://github.com/interledger/rafiki/blob/5de6208fad4c73fba81db56bd7174609e5f76ed5/packages/auth/src/config/app.ts#L62
+  defaultWaitMs = 5000,
 ) {
   defaultWaitMs += 10;
   const continueWaitMs = await (async () => {

--- a/tests/e2e/helpers/fynbos.ts
+++ b/tests/e2e/helpers/fynbos.ts
@@ -1,10 +1,9 @@
-import type { BrowserContext, Page } from '@playwright/test';
-import type { ConnectDetails } from '../pages/popup';
+import type { Page } from '@playwright/test';
 import { waitForWelcomePage } from './common';
-import { getWalletInformation } from '@/shared/helpers';
 
 export const KEYS_PAGE_URL = `https://eu1.fynbos.dev/settings/keys`;
 export const LOGIN_PAGE_URL = `https://eu1.fynbos.dev/login?returnTo=%2Fsettings%2Fkeys`;
+export const DEFAULT_CONTINUE_WAIT_MS = 5000;
 
 export async function completeGrant(page: Page, continueWaitMs: number) {
   await waitForGrantConsentPage(page);
@@ -21,36 +20,6 @@ export async function waitForGrantConsentPage(page: Page) {
       url.searchParams.has('clientUri')
     );
   });
-}
-
-export async function getContinueWaitTime(
-  context: BrowserContext,
-  params: Pick<ConnectDetails, 'walletAddressUrl'>,
-) {
-  const continueWaitMs = await (async () => {
-    const defaultWaitMs = 5001;
-    if (process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1') {
-      return Promise.resolve(defaultWaitMs);
-    }
-    const walletInfo = await getWalletInformation(params.walletAddressUrl);
-    return await new Promise<number>((resolve) => {
-      const authServer = new URL(walletInfo.authServer).href;
-      context.on('requestfinished', async function intercept(req) {
-        if (!req.serviceWorker()) return;
-        if (new URL(req.url()).href !== authServer) return;
-
-        const res = await req.response();
-        if (!res) return;
-        const json = await res.json();
-        context.off('requestfinished', intercept);
-        if (typeof json?.continue?.wait !== 'number') {
-          return resolve(defaultWaitMs);
-        }
-        return resolve(json.continue.wait * 1000);
-      });
-    });
-  })();
-  return continueWaitMs;
 }
 
 export async function acceptGrant(page: Page, continueWaitMs: number) {

--- a/tests/e2e/helpers/fynbos.ts
+++ b/tests/e2e/helpers/fynbos.ts
@@ -3,7 +3,6 @@ import { waitForWelcomePage } from './common';
 
 export const KEYS_PAGE_URL = `https://eu1.fynbos.dev/settings/keys`;
 export const LOGIN_PAGE_URL = `https://eu1.fynbos.dev/login?returnTo=%2Fsettings%2Fkeys`;
-export const DEFAULT_CONTINUE_WAIT_MS = 5000;
 
 export async function completeGrant(page: Page, continueWaitMs: number) {
   await waitForGrantConsentPage(page);


### PR DESCRIPTION
Only difference was in defaultWaitMs, which we now pass as parameter.