### PR TITLE
fix(tests/e2e): wait for ServiceWorker to be activated

### DIFF
--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -212,6 +212,8 @@ export async function getBackground(
       return new Promise<void>((resolve) => {
         if (chrome.runtime) return resolve();
         // @ts-expect-error self is extension's SW, not TS-defined enough.
+        if (self.serviceWorker?.state === 'activated') return resolve();
+        // @ts-expect-error self is extension's SW, not TS-defined enough.
         self.addEventListener('activate', resolve, { once: true });
       });
     });

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -207,6 +207,14 @@ export async function getBackground(
     if (!background) {
       background = await context.waitForEvent('serviceworker');
     }
+    // wait for Service Worker to be activated
+    await background.evaluate(() => {
+      return new Promise<void>((resolve) => {
+        if (chrome.runtime) return resolve();
+        // @ts-expect-error self is extension's SW, not TS-defined enough.
+        self.addEventListener('activate', resolve, { once: true });
+      });
+    });
   } else if (browserName === 'firefox') {
     // TODO
     // background = context.backgroundPages()[0];

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -146,10 +146,9 @@ export async function loadContext(
   let context: BrowserContext | undefined;
   if (browserName === 'chromium') {
     context = await chromium.launchPersistentContext('', {
-      headless: true,
       channel,
       args: [
-        `--headless=true`,
+        `--headless=new`,
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
       ],


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/735

## Changes proposed in this pull request

Wait for SW to be activated. Should fix the flakiness on Linux CI and absolute-failures on MacOS.
