### PR TITLE
refactor(popup): use valtio external store for state management

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -43,6 +43,7 @@ awilix
 httpbis
 loglevel
 openapi
+valtio
 apidevtools
 tailwindcss
 msedge

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-router-dom": "^7.0.2",
     "safe-buffer": "5.2.1",
     "tailwind-merge": "^2.5.5",
+    "valtio": "^2.1.2",
     "webextension-polyfill": "^0.12.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
+      valtio:
+        specifier: ^2.1.2
+        version: 2.1.2(@types/react@18.3.12)(react@18.3.1)
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
@@ -3580,6 +3583,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-compare@3.0.1:
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
+
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
 
@@ -4180,6 +4186,18 @@ packages:
   v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
+
+  valtio@2.1.2:
+    resolution: {integrity: sha512-fhekN5Rq7dvHULHHBlJeXHrQDl0Jj9GXfNavCm3gkD06crGchaG1nf/J7gSlfZU2wPcRdVS5jBKWHtE2NNz97A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8137,6 +8155,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proxy-compare@3.0.1: {}
+
   psl@1.9.0: {}
 
   public-encrypt@4.0.3:
@@ -8808,6 +8828,13 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.24
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  valtio@2.1.2(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      proxy-compare: 3.0.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+      react: 18.3.1
 
   vary@1.1.2: {}
 

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -3,7 +3,7 @@ import {
   BrowserContextProvider,
   TranslationContextProvider,
 } from '@/pages/shared/lib/context';
-import { MessageContextProvider, PopupContextProvider } from './lib/context';
+import { MessageContextProvider, WaitForStateLoad } from './lib/context';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import React from 'react';
 import browser from 'webextension-polyfill';
@@ -77,9 +77,9 @@ export const Popup = () => {
       <BrowserContextProvider browser={browser}>
         <MessageContextProvider>
           <TranslationContextProvider>
-            <PopupContextProvider>
+            <WaitForStateLoad>
               <RouterProvider router={router} />
-            </PopupContextProvider>
+            </WaitForStateLoad>
           </TranslationContextProvider>
         </MessageContextProvider>
       </BrowserContextProvider>

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/shared/helpers';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { ConnectWalletPayload, Response } from '@/shared/messages';
-import type { PopupTransientState } from '@/shared/types';
+import type { DeepReadonly, PopupTransientState } from '@/shared/types';
 
 interface Inputs {
   walletAddressUrl: string;
@@ -29,6 +29,7 @@ interface Inputs {
   autoKeyAddConsent: boolean;
 }
 
+type ConnectTransientState = DeepReadonly<PopupTransientState['connect']>;
 type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'walletAddressUrl' | 'amount' | 'keyPair' | 'connect';
 type Errors = Record<ErrorsParams, ErrorInfo | null>;
@@ -36,7 +37,7 @@ type Errors = Record<ErrorsParams, ErrorInfo | null>;
 interface ConnectWalletFormProps {
   publicKey: string;
   defaultValues: Partial<Inputs>;
-  state?: PopupTransientState['connect'];
+  state?: ConnectTransientState;
   saveValue?: (key: keyof Inputs, val: Inputs[typeof key]) => void;
   getWalletInfo: (walletAddressUrl: string) => Promise<WalletAddress>;
   connectWallet: (data: ConnectWalletPayload) => Promise<Response>;
@@ -81,9 +82,12 @@ export const ConnectWalletForm = ({
   }, [clearConnectState]);
 
   const toErrorInfo = React.useCallback(
-    (err?: string | ErrorWithKeyLike | null): ErrorInfo | null => {
+    (
+      err?: string | DeepReadonly<ErrorWithKeyLike> | null,
+    ): ErrorInfo | null => {
       if (!err) return null;
       if (typeof err === 'string') return { message: err };
+      // @ts-expect-error readonly, it's ok
       return { message: t(err), info: err };
     },
     [t],
@@ -477,7 +481,7 @@ const ManualKeyPairNeeded: React.FC<{
   );
 };
 
-function isAutoKeyAddFailed(state: PopupTransientState['connect']) {
+function isAutoKeyAddFailed(state: ConnectTransientState) {
   if (state?.status === 'error') {
     return (
       isErrorWithKey(state.error) &&

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { AnimatePresence, m } from 'framer-motion';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
-import { cn, type ErrorWithKeyLike } from '@/shared/helpers';
-import { useMessage, usePopupState, useTranslation } from '@/popup/lib/context';
 import { roundWithPrecision } from '@/pages/shared/lib/utils';
+import { cn, type ErrorWithKeyLike } from '@/shared/helpers';
+import { useMessage, useTranslation } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
 
 type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'amount' | 'pay';
@@ -13,9 +14,7 @@ type Errors = Record<ErrorsParams, ErrorInfo | null>;
 export const PayWebsiteForm = () => {
   const t = useTranslation();
   const message = useMessage();
-  const {
-    state: { walletAddress, tab },
-  } = usePopupState();
+  const { walletAddress, tab } = usePopupState();
 
   const toErrorInfo = React.useCallback(
     (err?: string | ErrorWithKeyLike | null): ErrorInfo | null => {

--- a/src/pages/popup/components/ProtectedRoute.tsx
+++ b/src/pages/popup/components/ProtectedRoute.tsx
@@ -1,10 +1,10 @@
-import { usePopupState } from '@/popup/lib/context';
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
+import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '../Popup';
 
 export const ProtectedRoute = () => {
-  const { state } = usePopupState();
+  const state = usePopupState();
 
   if (state.state.missing_host_permissions) {
     return <Navigate to={ROUTES_PATH.MISSING_HOST_PERMISSION} />;

--- a/src/pages/popup/components/ProtectedRoute.tsx
+++ b/src/pages/popup/components/ProtectedRoute.tsx
@@ -4,18 +4,18 @@ import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '../Popup';
 
 export const ProtectedRoute = () => {
-  const state = usePopupState();
+  const { state, connected } = usePopupState();
 
-  if (state.state.missing_host_permissions) {
+  if (state.missing_host_permissions) {
     return <Navigate to={ROUTES_PATH.MISSING_HOST_PERMISSION} />;
   }
-  if (state.state.key_revoked) {
+  if (state.key_revoked) {
     return <Navigate to={ROUTES_PATH.ERROR_KEY_REVOKED} />;
   }
-  if (state.state.out_of_funds) {
+  if (state.out_of_funds) {
     return <Navigate to={ROUTES_PATH.OUT_OF_FUNDS} />;
   }
-  if (state.connected === false) {
+  if (connected === false) {
     return <Navigate to={ROUTES_PATH.CONNECT_WALLET} />;
   }
 

--- a/src/pages/popup/components/Settings/Budget.tsx
+++ b/src/pages/popup/components/Settings/Budget.tsx
@@ -10,12 +10,9 @@ import {
   transformBalance,
 } from '@/shared/helpers';
 import { getCurrencySymbol } from '@/pages/shared/lib/utils';
-import {
-  useMessage,
-  useTranslation,
-  type PopupState,
-} from '@/popup/lib/context';
+import { useMessage, useTranslation } from '@/popup/lib/context';
 import type { Response, UpdateBudgetPayload } from '@/shared/messages';
+import type { PopupState } from '@/popup/lib/store';
 
 type Props = Pick<PopupState, 'balance' | 'grants' | 'walletAddress'>;
 

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -3,25 +3,11 @@ import { Switch } from '@/pages/shared/components/ui/Switch';
 import { InputAmountMemoized as InputAmount } from '@/pages/shared/components/InputAmount';
 import { debounceAsync } from '@/shared/helpers';
 import { formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
-import {
-  useMessage,
-  usePopupState,
-  useTranslation,
-  type PopupState,
-} from '@/popup/lib/context';
+import { useMessage, useTranslation } from '@/popup/lib/context';
+import { dispatch, usePopupState, type PopupState } from '@/popup/lib/store';
 
 export const RateOfPayScreen = () => {
   const message = useMessage();
-  const {
-    dispatch,
-    state: {
-      continuousPaymentsEnabled,
-      rateOfPay,
-      minRateOfPay,
-      maxRateOfPay,
-      walletAddress,
-    },
-  } = usePopupState();
 
   const updateRateOfPay = React.useRef(
     debounceAsync(async (rateOfPay: string) => {
@@ -43,38 +29,22 @@ export const RateOfPayScreen = () => {
     dispatch({ type: 'TOGGLE_WM', data: {} });
   };
 
-  return (
-    <RateOfPayComponent
-      continuousPaymentsEnabled={continuousPaymentsEnabled}
-      rateOfPay={rateOfPay}
-      minRateOfPay={minRateOfPay}
-      maxRateOfPay={maxRateOfPay}
-      walletAddress={walletAddress}
-      onRateChange={onRateChange}
-      toggleWM={toggleWM}
-    />
-  );
+  return <RateOfPayComponent onRateChange={onRateChange} toggleWM={toggleWM} />;
 };
 
 interface Props {
-  continuousPaymentsEnabled: PopupState['continuousPaymentsEnabled'];
-  rateOfPay: PopupState['rateOfPay'];
-  minRateOfPay: PopupState['minRateOfPay'];
-  maxRateOfPay: PopupState['maxRateOfPay'];
-  walletAddress: PopupState['walletAddress'];
   onRateChange: (rate: string) => Promise<void>;
   toggleWM: () => void | Promise<void>;
 }
 
-export const RateOfPayComponent = ({
-  continuousPaymentsEnabled,
-  rateOfPay,
-  minRateOfPay,
-  maxRateOfPay,
-  walletAddress,
-  onRateChange,
-  toggleWM,
-}: Props) => {
+export const RateOfPayComponent = ({ onRateChange, toggleWM }: Props) => {
+  const {
+    continuousPaymentsEnabled,
+    rateOfPay,
+    minRateOfPay,
+    maxRateOfPay,
+    walletAddress,
+  } = usePopupState();
   return (
     <div className="space-y-8">
       <RateOfPayInput

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -26,7 +26,7 @@ export const RateOfPayScreen = () => {
 
   const toggleWM = () => {
     message.send('TOGGLE_WM');
-    dispatch({ type: 'TOGGLE_WM', data: {} });
+    dispatch({ type: 'TOGGLE_WM' });
   };
 
   return <RateOfPayComponent onRateChange={onRateChange} toggleWM={toggleWM} />;

--- a/src/pages/popup/components/layout/Header.tsx
+++ b/src/pages/popup/components/layout/Header.tsx
@@ -3,13 +3,13 @@ import { Link, useLocation } from 'react-router-dom';
 import { ArrowBack, Settings } from '@/pages/shared/components/Icons';
 import { HeaderEmpty } from './HeaderEmpty';
 import { ROUTES_PATH } from '@/popup/Popup';
-import { useBrowser, usePopupState } from '@/popup/lib/context';
+import { useBrowser } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
 
 const NavigationButton = () => {
   const location = useLocation();
-  const {
-    state: { connected },
-  } = usePopupState();
+  const { connected } = usePopupState();
+
   return React.useMemo(() => {
     if (!connected) return null;
 

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -1,6 +1,6 @@
 import './index.css';
 
-// import './lib/react-scan'; // uncomment this to check performance or re-renders
+import '@/pages/shared/lib/react-scan'; // uncomment this to check performance or re-renders
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -1,6 +1,6 @@
 import './index.css';
 
-import '@/pages/shared/lib/react-scan'; // uncomment this to check performance or re-renders
+// import '@/pages/shared/lib/react-scan'; // uncomment this to check performance or re-renders
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 

--- a/src/pages/popup/lib/context.tsx
+++ b/src/pages/popup/lib/context.tsx
@@ -1,6 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
-
-import type { DeepNonNullable, PopupStore } from '@/shared/types';
+import React from 'react';
 import {
   BACKGROUND_TO_POPUP_CONNECTION_NAME as CONNECTION_NAME,
   MessageManager,
@@ -8,92 +6,13 @@ import {
   type BackgroundToPopupMessage,
 } from '@/shared/messages';
 import { useBrowser } from '@/pages/shared/lib/context';
+import { dispatch } from './store';
 
 export { useBrowser, useTranslation } from '@/pages/shared/lib/context';
 
-// #region PopupState
-
-export type PopupState = Required<
-  DeepNonNullable<Omit<PopupStore, 'state'>> & Pick<PopupStore, 'state'>
->;
-
-export interface PopupContext {
-  state: Required<NonNullable<PopupState>>;
-  dispatch: React.Dispatch<ReducerActions>;
-}
-
-interface ReducerActionMock {
-  type: string;
-  data?: any;
-}
-
-interface SetDataAction extends ReducerActionMock {
-  type: 'SET_DATA';
-  data: PopupState;
-}
-
-interface ToggleWMAction extends ReducerActionMock {
-  type: 'TOGGLE_WM';
-}
-
-interface SetConnected extends ReducerActionMock {
-  type: 'SET_CONNECTED';
-  data: { connected: boolean };
-}
-
-interface UpdateRateOfPayAction extends ReducerActionMock {
-  type: 'UPDATE_RATE_OF_PAY';
-  data: { rateOfPay: string };
-}
-
-type BackgroundToPopupAction = BackgroundToPopupMessage;
-
-export type ReducerActions =
-  | SetDataAction
-  | ToggleWMAction
-  | SetConnected
-  | UpdateRateOfPayAction
-  | BackgroundToPopupAction;
-
-const PopupStateContext = React.createContext<PopupContext>({} as PopupContext);
-
-export const usePopupState = () => React.useContext(PopupStateContext);
-
-const reducer = (state: PopupState, action: ReducerActions): PopupState => {
-  switch (action.type) {
-    case 'SET_DATA':
-      return action.data;
-    case 'TOGGLE_WM':
-      return {
-        ...state,
-        continuousPaymentsEnabled: !state.continuousPaymentsEnabled,
-      };
-    case 'SET_CONNECTED':
-      return { ...state, connected: action.data.connected };
-    case 'UPDATE_RATE_OF_PAY':
-      return { ...state, rateOfPay: action.data.rateOfPay };
-    case 'SET_STATE':
-      return { ...state, state: action.data.state };
-    case 'SET_TAB_DATA':
-      return { ...state, tab: action.data };
-    case 'SET_BALANCE':
-      return { ...state, balance: action.data.total };
-    case 'SET_TRANSIENT_STATE':
-      return { ...state, transientState: action.data };
-    default:
-      return state;
-  }
-};
-
-interface PopupContextProviderProps {
-  children: React.ReactNode;
-}
-
-export function PopupContextProvider({ children }: PopupContextProviderProps) {
-  const browser = useBrowser();
+export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   const message = useMessage();
   const [isLoading, setIsLoading] = React.useState(true);
-  const [state, dispatch] = React.useReducer(reducer, {} as PopupState);
 
   React.useEffect(() => {
     async function get() {
@@ -107,6 +26,25 @@ export function PopupContextProvider({ children }: PopupContextProviderProps) {
 
     get();
   }, [message]);
+
+  if (isLoading) {
+    return <>Loading</>;
+  }
+
+  return <>{children}</>;
+}
+
+const MessageContext = React.createContext<
+  MessageManager<PopupToBackgroundMessage>
+>({} as MessageManager<PopupToBackgroundMessage>);
+
+export const useMessage = () => React.useContext(MessageContext);
+
+export const MessageContextProvider = ({
+  children,
+}: React.PropsWithChildren) => {
+  const browser = useBrowser();
+  const message = new MessageManager<PopupToBackgroundMessage>({ browser });
 
   React.useEffect(() => {
     const port = browser.runtime.connect({ name: CONNECTION_NAME });
@@ -127,33 +65,9 @@ export function PopupContextProvider({ children }: PopupContextProviderProps) {
     };
   }, [browser]);
 
-  if (isLoading) {
-    return <>Loading</>;
-  }
-
-  return (
-    <PopupStateContext.Provider value={{ state, dispatch }}>
-      {children}
-    </PopupStateContext.Provider>
-  );
-}
-// #endregion
-
-// #region Message
-const MessageContext = React.createContext<
-  MessageManager<PopupToBackgroundMessage>
->({} as MessageManager<PopupToBackgroundMessage>);
-
-export const useMessage = () => React.useContext(MessageContext);
-
-export const MessageContextProvider = ({ children }: PropsWithChildren) => {
-  const browser = useBrowser();
-  const message = new MessageManager<PopupToBackgroundMessage>({ browser });
-
   return (
     <MessageContext.Provider value={message}>
       {children}
     </MessageContext.Provider>
   );
 };
-// #endregion

--- a/src/pages/popup/lib/store.ts
+++ b/src/pages/popup/lib/store.ts
@@ -1,0 +1,108 @@
+import { proxy, useSnapshot } from 'valtio';
+import type { DeepNonNullable, PopupStore } from '@/shared/types';
+import type { BackgroundToPopupMessage } from '@/shared/messages';
+
+export type PopupState = Required<
+  DeepNonNullable<Omit<PopupStore, 'state'>> & Pick<PopupStore, 'state'>
+>;
+
+export const store = proxy<PopupState>({} as PopupState);
+
+// easier than importing valtio and store (single import)
+export const usePopupState = () => useSnapshot(store);
+
+// This exists so we don't have to update all dispatch calls everywhere. Also
+// keeps all actions together. Can move to better strategies in future.
+export const dispatch = ({ type, data }: ReducerActions) => {
+  switch (type) {
+    case 'SET_DATA': {
+      for (const key of Object.keys(data) as Array<keyof PopupState>) {
+        // @ts-expect-error we know TypeScript
+        store[key] = data[key];
+      }
+      break;
+    }
+    case 'TOGGLE_WM': {
+      return TOGGLE_WM(data);
+    }
+    case 'SET_CONNECTED':
+      return SET_CONNECTED(data);
+    case 'UPDATE_RATE_OF_PAY':
+      return UPDATE_RATE_OF_PAY(data);
+    case 'SET_STATE':
+      return SET_STATE(data);
+    case 'SET_TAB_DATA':
+      return SET_TAB_DATA(data);
+    case 'SET_BALANCE':
+      return SET_BALANCE(data);
+    case 'SET_TRANSIENT_STATE':
+      return SET_TRANSIENT_STATE(data);
+    default:
+      throw new Error('Unknown action');
+  }
+};
+
+interface ReducerActionMock {
+  type: string;
+  data?: any;
+}
+
+interface SetDataAction extends ReducerActionMock {
+  type: 'SET_DATA';
+  data: PopupState;
+}
+
+interface ToggleWMAction extends ReducerActionMock {
+  type: 'TOGGLE_WM';
+}
+
+interface SetConnected extends ReducerActionMock {
+  type: 'SET_CONNECTED';
+  data: { connected: boolean };
+}
+
+interface UpdateRateOfPayAction extends ReducerActionMock {
+  type: 'UPDATE_RATE_OF_PAY';
+  data: { rateOfPay: string };
+}
+
+type BackgroundToPopupAction = BackgroundToPopupMessage;
+
+export type ReducerActions =
+  | SetDataAction
+  | ToggleWMAction
+  | SetConnected
+  | UpdateRateOfPayAction
+  | BackgroundToPopupAction;
+
+type ActionMap = {
+  [T in ReducerActions['type']]: Extract<ReducerActions, { type: T }>['data'];
+};
+
+const TOGGLE_WM: ActionMap['TOGGLE_WM'] = () => {
+  store.continuousPaymentsEnabled = !store.continuousPaymentsEnabled;
+};
+
+const SET_CONNECTED = (data: ActionMap['SET_CONNECTED']) => {
+  store.connected = data.connected;
+};
+
+const UPDATE_RATE_OF_PAY = (data: ActionMap['UPDATE_RATE_OF_PAY']) => {
+  store.rateOfPay = data.rateOfPay;
+};
+
+const SET_STATE = (data: ActionMap['SET_STATE']) => {
+  store.state = data.state;
+};
+
+const SET_TAB_DATA = (data: ActionMap['SET_TAB_DATA']) => {
+  store.tab = data;
+};
+
+const SET_BALANCE = (data: ActionMap['SET_BALANCE']) => {
+  store.balance = data.total;
+};
+
+const SET_TRANSIENT_STATE = (data: ActionMap['SET_TRANSIENT_STATE']) => {
+  store.transientState = data;
+};

--- a/src/pages/popup/lib/store.ts
+++ b/src/pages/popup/lib/store.ts
@@ -13,7 +13,7 @@ export const usePopupState = () => useSnapshot(store);
 
 // This exists so we don't have to update all dispatch calls everywhere. Also
 // keeps all actions together. Can move to better strategies in future.
-export const dispatch = ({ type, data }: ReducerActions) => {
+export const dispatch = ({ type, data }: Actions) => {
   switch (type) {
     case 'SET_DATA': {
       for (const key of Object.keys(data) as Array<keyof PopupState>) {
@@ -23,86 +23,35 @@ export const dispatch = ({ type, data }: ReducerActions) => {
       break;
     }
     case 'TOGGLE_WM': {
-      return TOGGLE_WM(data);
+      store.continuousPaymentsEnabled = !store.continuousPaymentsEnabled;
+      return;
     }
     case 'SET_CONNECTED':
-      return SET_CONNECTED(data);
+      store.connected = data.connected;
+      break;
     case 'UPDATE_RATE_OF_PAY':
-      return UPDATE_RATE_OF_PAY(data);
+      store.rateOfPay = data.rateOfPay;
+      break;
     case 'SET_STATE':
-      return SET_STATE(data);
+      store.state = data.state;
+      break;
     case 'SET_TAB_DATA':
-      return SET_TAB_DATA(data);
+      store.tab = data;
+      break;
     case 'SET_BALANCE':
-      return SET_BALANCE(data);
+      store.balance = data.total;
+      break;
     case 'SET_TRANSIENT_STATE':
-      return SET_TRANSIENT_STATE(data);
+      store.transientState = data;
+      break;
     default:
       throw new Error('Unknown action');
   }
 };
 
-interface ReducerActionMock {
-  type: string;
-  data?: any;
-}
-
-interface SetDataAction extends ReducerActionMock {
-  type: 'SET_DATA';
-  data: PopupState;
-}
-
-interface ToggleWMAction extends ReducerActionMock {
-  type: 'TOGGLE_WM';
-}
-
-interface SetConnected extends ReducerActionMock {
-  type: 'SET_CONNECTED';
-  data: { connected: boolean };
-}
-
-interface UpdateRateOfPayAction extends ReducerActionMock {
-  type: 'UPDATE_RATE_OF_PAY';
-  data: { rateOfPay: string };
-}
-
-type BackgroundToPopupAction = BackgroundToPopupMessage;
-
-export type ReducerActions =
-  | SetDataAction
-  | ToggleWMAction
-  | SetConnected
-  | UpdateRateOfPayAction
-  | BackgroundToPopupAction;
-
-type ActionMap = {
-  [T in ReducerActions['type']]: Extract<ReducerActions, { type: T }>['data'];
-};
-
-const TOGGLE_WM: ActionMap['TOGGLE_WM'] = () => {
-  store.continuousPaymentsEnabled = !store.continuousPaymentsEnabled;
-};
-
-const SET_CONNECTED = (data: ActionMap['SET_CONNECTED']) => {
-  store.connected = data.connected;
-};
-
-const UPDATE_RATE_OF_PAY = (data: ActionMap['UPDATE_RATE_OF_PAY']) => {
-  store.rateOfPay = data.rateOfPay;
-};
-
-const SET_STATE = (data: ActionMap['SET_STATE']) => {
-  store.state = data.state;
-};
-
-const SET_TAB_DATA = (data: ActionMap['SET_TAB_DATA']) => {
-  store.tab = data;
-};
-
-const SET_BALANCE = (data: ActionMap['SET_BALANCE']) => {
-  store.balance = data.total;
-};
-
-const SET_TRANSIENT_STATE = (data: ActionMap['SET_TRANSIENT_STATE']) => {
-  store.transientState = data;
-};
+type Actions =
+  | { type: 'SET_DATA'; data: PopupState }
+  | { type: 'TOGGLE_WM'; data?: never }
+  | { type: 'SET_CONNECTED'; data: { connected: boolean } }
+  | { type: 'UPDATE_RATE_OF_PAY'; data: { rateOfPay: string } }
+  | BackgroundToPopupMessage;

--- a/src/pages/popup/pages/ConnectWallet.tsx
+++ b/src/pages/popup/pages/ConnectWallet.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
-import { useMessage, usePopupState } from '@/popup/lib/context';
+import { useMessage } from '@/popup/lib/context';
 import { getWalletInformation } from '@/shared/helpers';
+import { usePopupState } from '@/popup/lib/store';
 
 export const Component = () => {
-  const { state } = usePopupState();
+  const { transientState, publicKey } = usePopupState();
   const message = useMessage();
 
-  const connectState = state.transientState['connect'];
+  const connectState = transientState['connect'];
   return (
     <ConnectWalletForm
-      publicKey={state.publicKey}
+      publicKey={publicKey}
       state={connectState}
       defaultValues={{
         recurring:

--- a/src/pages/popup/pages/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/pages/ErrorKeyRevoked.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { ErrorKeyRevoked } from '@/popup/components/ErrorKeyRevoked';
-import { useMessage, usePopupState } from '@/popup/lib/context';
 import { useNavigate } from 'react-router-dom';
+import { ErrorKeyRevoked } from '@/popup/components/ErrorKeyRevoked';
+import { useMessage } from '@/popup/lib/context';
 import { ROUTES_PATH } from '@/popup/Popup';
+import { dispatch, usePopupState } from '@/popup/lib/store';
 
 export const Component = () => {
   const message = useMessage();
-  const {
-    state: { publicKey, walletAddress },
-    dispatch,
-  } = usePopupState();
+  const { publicKey, walletAddress } = usePopupState();
   const navigate = useNavigate();
 
   const onReconnect = () => {

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import { usePopupState, useTranslation } from '@/popup/lib/context';
+import { formatCurrency } from '@/shared/helpers';
 import { Settings } from '@/pages/shared/components/Icons';
 import { formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { PayWebsiteForm } from '@/popup/components/PayWebsiteForm';
 import { NotMonetized } from '@/popup/components/NotMonetized';
-import { formatCurrency } from '@/shared/helpers';
+import { useTranslation } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
 
 export const Component = () => {
   const t = useTranslation();
-  const {
-    state: { tab },
-  } = usePopupState();
+  const { tab } = usePopupState();
 
   if (tab.status !== 'monetized') {
     switch (tab.status) {
@@ -48,9 +47,7 @@ export const Component = () => {
 };
 
 const InfoBanner = () => {
-  const {
-    state: { rateOfPay, balance, walletAddress },
-  } = usePopupState();
+  const { rateOfPay, balance, walletAddress } = usePopupState();
 
   const rate = React.useMemo(() => {
     const r = Number(rateOfPay) / 10 ** walletAddress.assetScale;

--- a/src/pages/popup/pages/OutOfFunds.tsx
+++ b/src/pages/popup/pages/OutOfFunds.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { OutOfFunds } from '@/popup/components/OutOfFunds';
-import { usePopupState } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '@/popup/Popup';
 import type { State } from '@/popup/pages/OutOfFunds_AddFunds';
 
 export const Component = () => {
-  const {
-    state: { grants, walletAddress },
-  } = usePopupState();
+  const { grants, walletAddress } = usePopupState();
   const navigate = useNavigate();
 
   return (

--- a/src/pages/popup/pages/OutOfFunds_AddFunds.tsx
+++ b/src/pages/popup/pages/OutOfFunds_AddFunds.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { AddFunds } from '@/popup/components/OutOfFunds';
-import { usePopupState, useMessage } from '@/popup/lib/context';
+import { useMessage } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
 
 export type State = { recurring: boolean };
 
 export const Component = () => {
   const message = useMessage();
-  const {
-    state: { grants, walletAddress },
-  } = usePopupState();
+  const { grants, walletAddress } = usePopupState();
   const location = useLocation();
 
   const state: State = { recurring: false, ...location.state };

--- a/src/pages/popup/pages/Settings.tsx
+++ b/src/pages/popup/pages/Settings.tsx
@@ -5,8 +5,8 @@ import { WalletInformation } from '@/popup/components/Settings/WalletInformation
 import { BudgetScreen } from '@/popup/components/Settings/Budget';
 import { RateOfPayScreen } from '@/popup/components/Settings/RateOfPay';
 import { cn } from '@/shared/helpers';
-import { usePopupState } from '@/popup/lib/context';
 import { useLocalStorage } from '@/pages/shared/lib/hooks';
+import { usePopupState } from '@/popup/lib/store';
 
 const TABS = [
   { id: 'wallet', title: 'Wallet' },
@@ -19,9 +19,7 @@ const isValidTabId = (id: string) => {
 };
 
 export const Component = () => {
-  const {
-    state: { balance, grants, publicKey, walletAddress },
-  } = usePopupState();
+  const { balance, grants, publicKey, walletAddress } = usePopupState();
   const location = useLocation();
   const [storedTabId, setStoredTabId] = useLocalStorage(
     'settings.tabId',

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -5,7 +5,7 @@ import type {
 import type { Browser } from 'webextension-polyfill';
 import type { AmountValue, PopupTransientState, Storage } from '@/shared/types';
 import type { ErrorWithKeyLike } from '@/shared/helpers';
-import type { PopupState } from '@/popup/lib/context';
+import type { PopupState } from '@/popup/lib/store';
 
 // #region MessageManager
 export interface SuccessResponse<TPayload = void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -140,6 +140,10 @@ export type DeepNonNullable<T> = {
   [P in keyof T]?: NonNullable<T[P]>;
 };
 
+export type DeepReadonly<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
 export type RequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
 export type Tab = RequiredFields<Tabs.Tab, 'id' | 'url'>;


### PR DESCRIPTION
Uses valtio for better render performance, and moves state out of context into a store in file.

- Turn `PopupContextProvider` to `WaitForStateLoad` to initialize store.
- Keep `usePopupState` as helper, even though it won't return dispatch now (only readonly state will be returned)
- Move state related things from `context.tsx` to `store.tsx`.
- Improve performance of RateOfPay screen as a test (we had too many props, not enough state)
- Kept `dispatch` mechanism for actions to update state. We don't need to change this right away.
- Tried to keep PR as small as possible. Most files just ±N line changes.

Adds +3KB to zip and +6KB to popup.js