### PR TITLE
chore(ci/labeler): fix typo

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,7 +32,7 @@
 
 'area: documentation':
   - changed-files:
-      - any-globs-to-any-file:
+      - any-glob-to-any-file:
           - '**/*.md'
           - '!.github/actions/**/*.md'
 


### PR DESCRIPTION
If only there was a linter when sending https://github.com/interledger/web-monetization-extension/pull/762.

Ref: https://github.com/actions/labeler?tab=readme-ov-file#match-object

CI fails as its using labeler.yml from main, not this branch. That's why didn't fail in https://github.com/interledger/web-monetization-extension/pull/762.