### PR TITLE
test(e2e): auto close post-install tab to keep tests simpler

### DIFF
--- a/tests/e2e/connectAutoKeyChimoney.spec.ts
+++ b/tests/e2e/connectAutoKeyChimoney.spec.ts
@@ -8,7 +8,7 @@ import {
   waitForGrantConsentPage,
 } from './helpers/chimoney';
 
-test('Connect to test wallet with automatic key addition when not logged-in to wallet', async ({
+test('Connect to Chimoney wallet with automatic key addition when not logged-in to wallet', async ({
   page,
   popup,
   persistentContext: context,


### PR DESCRIPTION
Our tests relied on `waitForEvent('page')` but the page that gets used during connect process was already open (as we reuse post-install screen tab), so E2E tests started to fail.

So, auto-close that post-install tab to keep tests like before, add a comment why it's better to close the tab.