### PR TITLE
fix(ConnectWalletForm): handle input autocomplete

### DIFF
--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -159,8 +159,8 @@ export const ConnectWalletForm = ({
     (event) => {
       const input = event.currentTarget;
       const ev = event.nativeEvent as InputEvent;
-      const value = ev.data;
-      if (!value || ev.inputType !== 'insertReplacementText') {
+      const value = ev.data ?? input.value; // Chrome doesn't fire InputEvent on autocomplete!
+      if (!value || (ev.data && ev.inputType !== 'insertReplacementText')) {
         return; // not autocomplete
       }
       if (validateWalletAddressUrl(value)) {

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -35,6 +35,10 @@ type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'walletAddressUrl' | 'amount' | 'keyPair' | 'connect';
 type Errors = Record<ErrorsParams, ErrorInfo | null>;
 
+type OnInputHandler = NonNullable<
+  React.DOMAttributes<HTMLInputElement>['onInput']
+>;
+
 interface ConnectWalletFormProps {
   publicKey: string;
   defaultValues: Partial<Inputs>;
@@ -149,6 +153,31 @@ export const ConnectWalletForm = ({
       return false;
     },
     [saveValue, getWalletInformation, toErrorInfo],
+  );
+
+  const onWalletAddressInput: OnInputHandler = React.useCallback(
+    (event) => {
+      const input = event.currentTarget;
+      const ev = event.nativeEvent as InputEvent;
+      const value = ev.data;
+      if (!value || ev.inputType !== 'insertReplacementText') {
+        return; // not autocomplete
+      }
+      if (validateWalletAddressUrl(value)) {
+        return; // not valid data from autocomplete, fallback to input blur based behavior
+      }
+      if (value === walletAddressUrl) {
+        if (value || !input.required) {
+          return;
+        }
+      }
+      // use as autocompleted value
+      void handleWalletAddressUrlChange(value, input).then((ok) => {
+        resetState();
+        if (ok) document.getElementById('connectAmount')?.focus();
+      });
+    },
+    [handleWalletAddressUrlChange, resetState, walletAddressUrl],
   );
 
   const handleAmountChange = React.useCallback(
@@ -274,6 +303,7 @@ export const ConnectWalletForm = ({
         spellCheck={false}
         enterKeyHint="go"
         readOnly={isSubmitting}
+        onInput={onWalletAddressInput}
         onPaste={async (ev) => {
           const input = ev.currentTarget;
           let value = ev.clipboardData.getData('text');

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -160,7 +160,10 @@ export const ConnectWalletForm = ({
       const input = event.currentTarget;
       const ev = event.nativeEvent as InputEvent;
       const value = ev.data ?? input.value; // Chrome doesn't fire InputEvent on autocomplete!
-      if (!value || (ev.data && ev.inputType !== 'insertReplacementText')) {
+      if (
+        !value ||
+        (ev.inputType && ev.inputType !== 'insertReplacementText')
+      ) {
         return; // not autocomplete
       }
       if (validateWalletAddressUrl(value)) {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Closes https://github.com/interledger/web-monetization-extension/issues/746

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
Using `InputEvent` with `inputType` `insertReplacementText`. Tested works as intended in Firefox. We consider autocompleted input only if `ev.data` contains a well formed input.

In Chrome, autocomplete menu didn't appear for me. Someone please verify it works ok.
