### PR TITLE
fix(background/KeyAutoAdd): invalid tabId in Firefox

### DIFF
--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -91,9 +91,13 @@ export class KeyAutoAddService {
     existingTabId?: TabId,
   ) {
     const { resolve, reject, promise } = withResolvers();
-    const tab = existingTabId
-      ? await this.browser.tabs.update(existingTabId, { url })
-      : await this.browser.tabs.create({ url });
+    let tab: Tabs.Tab;
+    try {
+      tab = await this.browser.tabs.get(existingTabId ?? -1);
+      await this.browser.tabs.update(tab.id, { url });
+    } catch {
+      tab = await this.browser.tabs.create({ url });
+    }
 
     this.tab = tab;
     if (!tab.id) {

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -637,7 +637,7 @@ export class OpenPaymentsService {
    */
   private async addPublicKeyToWallet(
     walletAddress: WalletAddress,
-    tabId?: TabId,
+    existingTabId?: TabId,
   ): Promise<TabId | undefined> {
     const keyAutoAdd = new KeyAutoAddService({
       browser: this.browser,
@@ -647,7 +647,7 @@ export class OpenPaymentsService {
       t: this.t,
     });
     try {
-      await keyAutoAdd.addPublicKeyToWallet(walletAddress, tabId);
+      await keyAutoAdd.addPublicKeyToWallet(walletAddress, existingTabId);
       return keyAutoAdd.tabId;
     } catch (error) {
       const tabId = keyAutoAdd.tabId;

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -92,11 +92,12 @@ export const reuseOrCreateTab = async (
   tabId?: number,
 ): Promise<Tab> => {
   try {
-    const tab = await browser.tabs.get(tabId ?? -1);
+    let tab = await browser.tabs.get(tabId ?? -1);
     if (!tab.id) {
       throw new Error('Could not retrieve tab.');
     }
-    return (await browser.tabs.update(tab.id, { url })) as Tab;
+    tab = await browser.tabs.update(tab.id, { url });
+    return tab as Tab;
   } catch {
     const tab = await browser.tabs.create({ url });
     if (!tab.id) {

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -91,6 +91,26 @@ export const getTab = (sender: Runtime.MessageSender): Tab => {
   return notNullOrUndef(notNullOrUndef(sender.tab, 'sender.tab'), 'tab') as Tab;
 };
 
+export const reuseOrCreateTab = async (
+  browser: Browser,
+  url: string,
+  tabId?: number,
+): Promise<Tab> => {
+  try {
+    const tab = await browser.tabs.get(tabId ?? -1);
+    if (!tab.id) {
+      throw new Error('Unexpected: tab does not have id');
+    }
+    return (await browser.tabs.update(tab.id, { url })) as Tab;
+  } catch {
+    const tab = await browser.tabs.create({ url });
+    if (!tab.id) {
+      throw new Error('Unexpected: tab does not have id');
+    }
+    return tab as Tab;
+  }
+};
+
 export const getSender = (sender: Runtime.MessageSender) => {
   const tabId = getTabId(sender);
   const frameId = notNullOrUndef(sender.frameId, 'sender.frameId');

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -99,13 +99,13 @@ export const reuseOrCreateTab = async (
   try {
     const tab = await browser.tabs.get(tabId ?? -1);
     if (!tab.id) {
-      throw new Error('Unexpected: tab does not have id');
+      throw new Error('Could not retrieve tab.');
     }
     return (await browser.tabs.update(tab.id, { url })) as Tab;
   } catch {
     const tab = await browser.tabs.create({ url });
     if (!tab.id) {
-      throw new Error('Unexpected: tab does not have id');
+      throw new Error('Newly created tab does not have the id property set.');
     }
     return tab as Tab;
   }


### PR DESCRIPTION
## Context
`this.browser.tabs.get()` can throw a synchronous error before returning a promise.

If `this.browser.tabs.get(tabId ?? -1)` throws a synchronous error before returning a promise (Promise.reject), the .catch() won’t catch it, as the error occurs before the promise is created.

Closes #778 

## Proposed change
- use a `try-catch` block to handle  `browser.tabs.get` exception

