### PR TITLE
refactor(tests/e2e): add `setupPlayground` helper

### DIFF
--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -14,6 +14,7 @@ import {
   getContinueWaitTime,
   waitForWelcomePage,
   waitForReconnectWelcomePage,
+  setupPlayground,
 } from './helpers/common';
 import { disconnectWallet, fillPopup } from './pages/popup';
 
@@ -25,7 +26,6 @@ test('Reconnect to test wallet with automatic key addition', async ({
   i18n,
 }) => {
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
-  const monetizationCallback = spy<[Event], void>();
   const revokeInfo = await test.step('connect wallet', async () => {
     const connectButton = await test.step('fill popup', async () => {
       const connectButton = await fillPopup(popup, i18n, {
@@ -126,20 +126,8 @@ test('Reconnect to test wallet with automatic key addition', async ({
     expect(keys.find((key) => key.kid === revokeInfo.keyId)).toBeUndefined();
   });
 
+  const monetizationCallback = await setupPlayground(page, walletAddressUrl);
   await test.step('start monetization', async () => {
-    const playgroundUrl = 'https://webmonetization.org/play/';
-    await page.goto(playgroundUrl);
-
-    await page.exposeFunction('monetizationCallback', monetizationCallback);
-    await page.evaluate(() => {
-      window.addEventListener('monetization', monetizationCallback);
-    });
-
-    await page
-      .getByLabel('Wallet address/Payment pointer')
-      .fill(walletAddressUrl);
-    await page.getByRole('button', { name: 'Add monetization link' }).click();
-
     await expect(monetizationCallback).toHaveBeenCalledTimes(0);
   });
 

--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -9,7 +9,6 @@ import {
   waitForGrantConsentPage,
 } from './helpers/testWallet';
 import { getStorage } from './fixtures/helpers';
-import { spy } from 'tinyspy';
 import {
   getContinueWaitTime,
   waitForWelcomePage,

--- a/tests/e2e/simple.spec.ts
+++ b/tests/e2e/simple.spec.ts
@@ -5,7 +5,7 @@ test.beforeEach(async ({ popup }) => {
   await popup.reload();
 });
 
-test.skip('should monetize site with single wallet address', async ({
+test('should monetize site with single wallet address', async ({
   page,
   popup,
 }) => {

--- a/tests/e2e/simple.spec.ts
+++ b/tests/e2e/simple.spec.ts
@@ -1,34 +1,16 @@
-import { spy } from 'tinyspy';
 import { test, expect } from './fixtures/connected';
+import { setupPlayground } from './helpers/common';
 
 test.beforeEach(async ({ popup }) => {
   await popup.reload();
 });
 
-test('should monetize site with single wallet address', async ({
+test.skip('should monetize site with single wallet address', async ({
   page,
   popup,
 }) => {
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
-  const playgroundUrl = 'https://webmonetization.org/play/';
-
-  await page.goto(playgroundUrl);
-
-  const monetizationCallback = spy<[Event], void>();
-  await page.exposeFunction('monetizationCallback', monetizationCallback);
-  await page.evaluate(() => {
-    window.addEventListener('monetization', monetizationCallback);
-  });
-
-  await page
-    .getByLabel('Wallet address/Payment pointer')
-    .fill(walletAddressUrl);
-  await page.getByRole('button', { name: 'Add monetization link' }).click();
-
-  await expect(page.locator('link[rel=monetization]')).toHaveAttribute(
-    'href',
-    walletAddressUrl,
-  );
+  const monetizationCallback = await setupPlayground(page, walletAddressUrl);
 
   await page.waitForSelector('#link-events .log-header');
   await page.waitForSelector('#link-events ul.events li');
@@ -60,7 +42,6 @@ test('does not monetize when continuous payments are disabled', async ({
   background,
 }) => {
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
-  const playgroundUrl = 'https://webmonetization.org/play/';
 
   await test.step('disable continuous payments', async () => {
     await expect(background).toHaveStorage({ continuousPaymentsEnabled: true });
@@ -83,28 +64,12 @@ test('does not monetize when continuous payments are disabled', async ({
     });
   });
 
-  await page.goto(playgroundUrl);
-
-  const monetizationCallback = spy<[Event], void>();
-  await page.exposeFunction('monetizationCallback', monetizationCallback);
-  await page.evaluate(() => {
-    window.addEventListener('monetization', monetizationCallback);
-  });
+  const monetizationCallback = await setupPlayground(page, walletAddressUrl);
 
   await test.step('check continuous payments do not go through', async () => {
     await expect(background).toHaveStorage({
       continuousPaymentsEnabled: false,
     });
-
-    await page
-      .getByLabel('Wallet address/Payment pointer')
-      .fill(walletAddressUrl);
-    await page.getByRole('button', { name: 'Add monetization link' }).click();
-
-    await expect(page.locator('link[rel=monetization]')).toHaveAttribute(
-      'href',
-      walletAddressUrl,
-    );
 
     await page.waitForSelector('#link-events .log-header');
     await page.waitForSelector('#link-events ul.events li');
@@ -123,9 +88,7 @@ test('does not monetize when continuous payments are disabled', async ({
     await popup.getByRole('textbox').fill('1.5');
     await popup.getByRole('button', { name: 'Send now' }).click();
 
-    await expect(monetizationCallback).toHaveBeenCalledTimes(1, {
-      timeout: 1000,
-    });
+    await expect(monetizationCallback).toHaveBeenCalledTimes(1);
     await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
       paymentPointer: walletAddressUrl,
       amountSent: {

--- a/tests/e2e/special.spec.ts
+++ b/tests/e2e/special.spec.ts
@@ -1,4 +1,3 @@
-import { spy } from 'tinyspy';
 import { test, expect } from './fixtures/connected';
 import { setupPlayground } from './helpers/common';
 

--- a/tests/e2e/special.spec.ts
+++ b/tests/e2e/special.spec.ts
@@ -1,35 +1,17 @@
 import { spy } from 'tinyspy';
 import { test, expect } from './fixtures/connected';
+import { setupPlayground } from './helpers/common';
 
 test('iframe add/remove does not de-monetize main page', async ({
   page,
   popup,
 }) => {
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
-  const playgroundUrl = 'https://webmonetization.org/play/';
 
   await test.step('prepare', async () => {
     await expect(popup.getByTestId('not-monetized-message')).toBeVisible();
 
-    await page.goto(playgroundUrl);
-
-    const monetizationCallback = spy<[Event], void>();
-    await page.exposeFunction('monetizationCallback', monetizationCallback);
-    await page.evaluate(() => {
-      window.addEventListener('monetization', monetizationCallback);
-    });
-
-    await page
-      .getByLabel('Wallet address/Payment pointer')
-      .fill(walletAddressUrl);
-    await page.getByRole('button', { name: 'Add monetization link' }).click();
-
-    await page.$eval(
-      'link[rel="monetization"]',
-      (el) => new Promise((res) => el.addEventListener('load', res)),
-    );
-
-    await page.waitForTimeout(2000);
+    const monetizationCallback = await setupPlayground(page, walletAddressUrl);
     await expect(monetizationCallback).toHaveBeenCalledTimes(1);
     await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
       paymentPointer: walletAddressUrl,
@@ -72,30 +54,12 @@ test('iframe navigate does not de-monetize main page', async ({
   popup,
 }) => {
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
-  const playgroundUrl = 'https://webmonetization.org/play/';
 
   await test.step('prepare', async () => {
     await expect(popup.getByTestId('not-monetized-message')).toBeVisible();
 
-    await page.goto(playgroundUrl);
+    const monetizationCallback = await setupPlayground(page, walletAddressUrl);
 
-    const monetizationCallback = spy<[Event], void>();
-    await page.exposeFunction('monetizationCallback', monetizationCallback);
-    await page.evaluate(() => {
-      window.addEventListener('monetization', monetizationCallback);
-    });
-
-    await page
-      .getByLabel('Wallet address/Payment pointer')
-      .fill(walletAddressUrl);
-    await page.getByRole('button', { name: 'Add monetization link' }).click();
-
-    await page.$eval(
-      'link[rel="monetization"]',
-      (el) => new Promise((res) => el.addEventListener('load', res)),
-    );
-
-    await page.waitForTimeout(2000);
     await expect(monetizationCallback).toHaveBeenCalledTimes(1);
     await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
       paymentPointer: walletAddressUrl,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Part of https://github.com/interledger/web-monetization-extension/issues/610
As mentioned in https://github.com/interledger/web-monetization-extension/pull/835#discussion_r1917857341

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Add `setupPlayground` helper which loads playground with wallet addresses added, and sets up `monetization` event listener spy (`monetizationCallback`).