### PR TITLE
fix(ConnectWalletForm): correctly render error from transientState

### DIFF
--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/pages/shared/components/InputAmount';
 import { toWalletAddressUrl } from '@/pages/shared/lib/utils';
 import { useTranslation } from '@/popup/lib/context';
+import { deepClone } from 'valtio/utils';
 import {
   cn,
   errorWithKey,
@@ -104,8 +105,12 @@ export const ConnectWalletForm = ({
   const [errors, setErrors] = React.useState<Errors>({
     walletAddressUrl: null,
     amount: null,
-    keyPair: state?.status === 'error:key' ? toErrorInfo(state.error) : null,
-    connect: state?.status === 'error' ? toErrorInfo(state.error) : null,
+    keyPair:
+      state?.status === 'error:key'
+        ? toErrorInfo(deepClone(state.error))
+        : null,
+    connect:
+      state?.status === 'error' ? toErrorInfo(deepClone(state.error)) : null,
   });
   const [isValidating, setIsValidating] = React.useState({
     walletAddressUrl: false,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

`state` in `ConnectWalletForm` is a valtio proxy. Running `t()` (via `toErrorInfo`) on it doesn't resolve proxies (`browser.i18n.getMessage` doesn't resolve substitutions), leading to popup showing message like following:

![image](https://github.com/user-attachments/assets/f5f99fac-1e4c-49b6-a2c1-1c9457919477)


## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

`deepClone` to resolve valtio proxies so `t()` works as intended.

![image](https://github.com/user-attachments/assets/315e136d-80e0-4c46-8884-5a1bf8a07893)
