### PR TITLE
perf: use global browser instead of webextension-polyfill

### DIFF
--- a/src/content/container.ts
+++ b/src/content/container.ts
@@ -4,7 +4,7 @@ import {
   createContainer,
   InjectionMode,
 } from 'awilix/browser';
-import browser, { type Browser } from 'webextension-polyfill';
+import browser, { type Browser } from '@/shared/browser';
 import { createLogger, type Logger } from '@/shared/logger';
 import { ContentScript } from './services/contentScript';
 import { MonetizationLinkManager } from './services/monetizationLinkManager';

--- a/src/content/keyAutoAdd/lib/keyAutoAdd.ts
+++ b/src/content/keyAutoAdd/lib/keyAutoAdd.ts
@@ -1,5 +1,5 @@
 // cSpell:ignore allowtransparency
-import browser, { type Runtime } from 'webextension-polyfill';
+import browser, { type Runtime } from '@/shared/browser';
 import { CONNECTION_NAME } from '@/background/services/keyAutoAdd';
 import {
   errorWithKeyToJSON,

--- a/src/pages/app/App.tsx
+++ b/src/pages/app/App.tsx
@@ -3,12 +3,12 @@ import {
   BrowserContextProvider,
   TranslationContextProvider,
 } from '@/pages/shared/lib/context';
-import browser from 'webextension-polyfill';
 import {
   createHashRouter,
   RouterProvider,
   type RouteObject,
 } from 'react-router-dom';
+import browser from '@/shared/browser';
 
 export const ROUTES = {
   DEFAULT: '/',

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -6,7 +6,7 @@ import {
 import { MessageContextProvider, WaitForStateLoad } from './lib/context';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import React from 'react';
-import browser from 'webextension-polyfill';
+import browser from '@/shared/browser';
 import { ProtectedRoute } from '@/popup/components/ProtectedRoute';
 import {
   type RouteObject,

--- a/src/pages/progress-connect/index.tsx
+++ b/src/pages/progress-connect/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import browser from 'webextension-polyfill';
+import browser from '@/shared/browser';
 
 import {
   BrowserContextProvider,

--- a/src/shared/browser.ts
+++ b/src/shared/browser.ts
@@ -1,0 +1,25 @@
+import type { Browser } from 'webextension-polyfill';
+
+/**
+ * This is almost same as browser from webextension-polyfill, but without the
+ * wrapper functions to support async message handler (i.e. we need to use
+ * `sendResponse` callback). See https://stackoverflow.com/questions/44056271
+ *
+ * As the polyfill is helping us with that only, if we don't need async message
+ * handler, use this instead of `browser` from `webextension-polyfill`.
+ *
+ * It'll reduce content script size by around 10KB, more meaningful when there's
+ * multiple content scripts per page. So better for performance overall.
+ */
+// @ts-expect-error we know it may not exist, hence the test
+const globalBrowser = globalThis.browser?.runtime?.id
+  ? // @ts-expect-error we just verified above it exists
+    (globalThis.browser as Browser)
+  : // @ts-expect-error `chrome` API is same as Browser, just different type sources
+    (globalThis.chrome as Browser);
+
+export { globalBrowser as browser };
+
+export default globalBrowser;
+
+export type { Browser, Runtime } from 'webextension-polyfill';


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

We don't need the polyfill except for async message handlers in background.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
Remove polyfilled browser from content scripts and React apps to reduce bundle size, and have less JS in content scripts for better performance.

Keeping it draft until we add more E2E tests.