### PR TITLE
refactor(tests/e2e): simplify spy `toHaveBeenCalled` matchers

### DIFF
--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -128,14 +128,13 @@ export const expect = test.expect.extend({
   async toHaveBeenCalledTimes(
     fn: SpyFn,
     expected: number,
-    { timeout = 5000, wait = 1000 }: { timeout?: number; wait?: number } = {},
+    { timeout = 5000 }: { timeout?: number } = {},
   ) {
     const name = 'toHaveBeenCalledTimes';
 
     let pass: boolean;
     let result: { actual: number } | undefined;
 
-    await sleep(wait);
     let remainingTime = timeout;
     do {
       try {
@@ -162,14 +161,13 @@ export const expect = test.expect.extend({
   async toHaveBeenLastCalledWithMatching(
     fn: SpyFn,
     expected: Record<string, unknown>,
-    { timeout = 5000, wait = 1000 }: { timeout?: number; wait?: number } = {},
+    { timeout = 5000 }: { timeout?: number } = {},
   ) {
     const name = 'toHaveBeenLastCalledWithMatching';
 
     let pass: boolean;
     let result: { actual: unknown } | undefined;
 
-    await sleep(wait);
     let remainingTime = timeout;
     do {
       try {

--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -37,7 +37,7 @@ test('Reconnect to test wallet with automatic key addition', async ({
 
     await test.step('asks for key-add consent', async () => {
       await connectButton.click();
-      expect(
+      await expect(
         popup.getByTestId('connect-wallet-auto-key-consent'),
       ).toBeVisible();
       await popup


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Avoiding flaky custom implementations!

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

- Rewrite `toHaveBeenCalledTimes` and `toHaveBeenLastCalledWithMatching` with `expect.poll`
- Remove `wait` option from above matchers - as timeout acts as wait, and when needed, we can `page.waitForTimeout(wait)` as wait.
- Add a missing await in reconnect test.
- Fixed default message (for use with `.not` modifier)