### PR TITLE
fix(bg/PaymentSession): don't wait for previous payment

### DIFF
--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -536,6 +536,7 @@ export class PaymentSession {
   }
 
   private async payContinuous() {
+    this.shouldRetryImmediately = false;
     try {
       const outgoingPayment = await this.createOutgoingPayment({
         walletAddress: this.sender,
@@ -568,7 +569,6 @@ export class PaymentSession {
           intervalInMs: this.intervalInMs,
         });
       }
-      this.shouldRetryImmediately = false;
     } catch (e) {
       if (isKeyRevokedError(e)) {
         this.events.emit('open_payments.key_revoked');

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -67,7 +67,6 @@ export class PaymentSession {
   private probingId: number;
   private shouldRetryImmediately = false;
 
-  private interval: ReturnType<typeof setInterval> | null = null;
   private timeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
@@ -213,11 +212,6 @@ export class PaymentSession {
   }
 
   private clearTimers() {
-    if (this.interval) {
-      this.debug(`Clearing interval=${this.timeout}`);
-      clearInterval(this.interval);
-      this.interval = null;
-    }
     if (this.timeout) {
       this.debug(`Clearing timeout=${this.timeout}`);
       clearTimeout(this.timeout);
@@ -257,45 +251,24 @@ export class PaymentSession {
       });
     }
 
-    // Uncomment this after we perform the Rafiki test and remove the leftover
-    // code below.
-    //
-    // if (this.canContinuePayment) {
-    //   this.timeout = setTimeout(() => {
-    //     void this.payContinuous()
-    //
-    //     this.interval = setInterval(() => {
-    //       if (!this.canContinuePayment) {
-    //           this.clearTimers()
-    //           return
-    //       }
-    //       void this.payContinuous()
-    //     }, this.intervalInMs)
-    //   }, waitTime)
-    // }
-
-    // Leftover
     const continuePayment = () => {
       if (!this.canContinuePayment) return;
-      // alternatively (leftover) after we perform the Rafiki test, we can just
-      // skip the `.then()` here and call setTimeout recursively immediately
-      void this.payContinuous().then(() => {
-        this.timeout = setTimeout(
-          () => {
-            continuePayment();
-          },
-          this.shouldRetryImmediately ? 0 : this.intervalInMs,
-        );
+      void this.payContinuous().catch((err) => {
+        this.logger.error('Error while making continuous payment', err);
       });
+      // This recursive call in setTimeout is essentially setInterval here,
+      // except we can have a dynamic interval (immediate vs intervalInMs).
+      this.timeout = setTimeout(
+        continuePayment,
+        this.shouldRetryImmediately ? 0 : this.intervalInMs,
+      );
     };
 
     if (this.canContinuePayment) {
       this.timeout = setTimeout(async () => {
         await this.payContinuous();
         this.timeout = setTimeout(
-          () => {
-            continuePayment();
-          },
+          continuePayment,
           this.shouldRetryImmediately ? 0 : this.intervalInMs,
         );
       }, waitTime);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "allowSyntheticDefaultImports": true,
     "allowUmdGlobalAccess": true,
     "resolveJsonModule": true,
+    "noUnusedLocals": true,
     "noEmit": true,
     "paths": {
       "@/shared/*": ["./shared/*"],


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/375

## Changes proposed in this pull request

- With continuous payments, don't wait for prev payment to complete before sending next payment, to ensure the correct time of payment is followed to keep rate of pay consistent
- Remove `interval` and use recursive timeout, as it'd allow dynamic "interval"
- Tested at `assetScale: 2` at $60 per hour rate (`await chrome.storage.local.set({rateOfPay: '6000'})`) and [3 payment sessions](https://webmonetization.org/play/?wa=https://ilp.interledger-test.dev/sid&wa=https://ilp.interledger-test.dev/sid-mxn-1&wa=https://ilp.interledger-test.dev/sid-usd-1)
   - No performance regressions on test wallet. Outgoing payments take ~150-350ms, typically 200ms.
   - ~Except there was some error once, and it sent hundreds on concurrent requests, so test wallet kinda crashed??~ Fixed in https://github.com/interledger/web-monetization-extension/pull/858/commits/e9d4994daf98488a1dde1369636e181245f85dd5