### PR TITLE
test(e2e): make timeouts shorter, install browsers

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install chromium ${{ matrix.project }} --with-deps
 
       - name: Run Playwright tests
         run: pnpm test:e2e:${{ matrix.project }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -65,6 +65,7 @@ jobs:
           CHIMONEY_PASSWORD: ${{ secrets.E2E_CHIMONEY_PASSWORD }}
 
       - name: Encrypt report
+        if: always()
         shell: bash
         working-directory: tests/e2e/playwright-report
         run: |

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -43,9 +43,7 @@ jobs:
         run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
-        run: |
-          pnpm exec playwright install --with-deps
-          pnpm exec playwright install ${{ matrix.project }}
+        run: pnpm exec playwright install ${{ matrix.project }} --with-deps
 
       - name: Run Playwright tests
         run: pnpm test:e2e:${{ matrix.project }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - name: Chrome
-          #   project: chrome
-          #   target: chrome
-          #   runs-on: ubuntu-22.04
+          - name: Chrome
+            project: chrome
+            target: chrome
+            runs-on: ubuntu-22.04
           # - name: Firefox
           #   project: firefox
           #   target: firefox
@@ -51,7 +51,6 @@ jobs:
         run: pnpm test:e2e:${{ matrix.project }}
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
-          DEBUG: 'pw:browser'
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
           TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
           TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install ${{ matrix.project }} --with-deps
+        run: pnpm exec playwright install chromium ${{ matrix.project }} --with-deps
 
       - name: Run Playwright tests
         run: pnpm test:e2e:${{ matrix.project }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Chrome
-            project: chrome
-            target: chrome
-            runs-on: ubuntu-22.04
+          # - name: Chrome
+          #   project: chrome
+          #   target: chrome
+          #   runs-on: ubuntu-22.04
           # - name: Firefox
           #   project: firefox
           #   target: firefox
@@ -49,6 +49,7 @@ jobs:
         run: pnpm test:e2e:${{ matrix.project }}
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
+          DEBUG: 'pw:browser'
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
           TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
           TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -43,7 +43,9 @@ jobs:
         run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+        run: |
+          pnpm exec playwright install --with-deps
+          pnpm exec playwright install ${{ matrix.project }}
 
       - name: Run Playwright tests
         run: pnpm test:e2e:${{ matrix.project }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -66,6 +66,7 @@ jobs:
           CHIMONEY_PASSWORD: ${{ secrets.E2E_CHIMONEY_PASSWORD }}
 
       - name: Encrypt report
+        if: always()
         shell: bash
         working-directory: tests/e2e/playwright-report
         run: |

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
       { open: 'never', outputFolder: path.join(testDir, 'playwright-report') },
     ],
   ],
-  use: { trace: 'retain-on-failure' },
+  use: {
+    trace: 'retain-on-failure',
+    actionTimeout: 8_000,
+    navigationTimeout: 10_000,
+  },
 
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     ],
   ],
   use: {
-    trace: 'on',
+    trace: 'retain-on-failure',
     actionTimeout: 8_000,
     navigationTimeout: 10_000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     ],
   ],
   use: {
-    trace: 'retain-on-failure',
+    trace: 'on',
     actionTimeout: 8_000,
     navigationTimeout: 10_000,
   },

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -36,7 +36,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       await use(context);
       await context.close();
     },
-    { scope: 'worker', timeout: 5_000 },
+    { scope: 'worker', timeout: 8_000 },
   ],
 
   // This is the background service worker in Chrome, and background script

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -36,7 +36,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       await use(context);
       await context.close();
     },
-    { scope: 'worker', timeout: 8_000 },
+    { scope: 'worker', timeout: 5_000 },
   ],
 
   // This is the background service worker in Chrome, and background script

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -36,7 +36,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       await use(context);
       await context.close();
     },
-    { scope: 'worker' },
+    { scope: 'worker', timeout: 5_000 },
   ],
 
   // This is the background service worker in Chrome, and background script
@@ -47,7 +47,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       const background = await getBackground(browserName, context);
       await use(background);
     },
-    { scope: 'worker' },
+    { scope: 'worker', timeout: 5_000 },
   ],
 
   i18n: [
@@ -65,7 +65,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       await use(popup);
       await popup.close();
     },
-    { scope: 'worker' },
+    { scope: 'worker', timeout: 5_000 },
   ],
 
   page: async ({ persistentContext: context }, use) => {

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -22,7 +22,7 @@ export const test = base.extend<{ page: Page }, { popup: Popup }>({
 
       await disconnectWallet(popup);
     },
-    { scope: 'worker' },
+    { scope: 'worker', timeout: 10_000 },
   ],
 });
 

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -22,7 +22,7 @@ export const test = base.extend<{ page: Page }, { popup: Popup }>({
 
       await disconnectWallet(popup);
     },
-    { scope: 'worker', timeout: 10_000 },
+    { scope: 'worker', timeout: 20_000 },
   ],
 });
 

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -4,7 +4,8 @@ import { Buffer } from 'node:buffer';
 import net from 'node:net';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import {
   chromium,
   firefox,
@@ -149,7 +150,13 @@ export async function loadContext(
   const pathToExtension = getPathToExtension(browserName);
   let context: BrowserContext | undefined;
   if (browserName === 'chromium') {
-    context = await chromium.launchPersistentContext('', {
+    const tmpUserDataDir = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `playwright-user-data-dir-${workerInfo.workerIndex}-`,
+      ),
+    );
+    context = await chromium.launchPersistentContext(tmpUserDataDir, {
       channel,
       args: [
         '--headless=new',

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -153,6 +153,7 @@ export async function loadContext(
       channel,
       args: [
         '--headless=new',
+        '--disable-gpu',
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
       ],

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -4,8 +4,7 @@ import { Buffer } from 'node:buffer';
 import net from 'node:net';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
-import { readFile, mkdtemp } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { readFile } from 'node:fs/promises';
 import {
   chromium,
   firefox,
@@ -150,13 +149,7 @@ export async function loadContext(
   const pathToExtension = getPathToExtension(browserName);
   let context: BrowserContext | undefined;
   if (browserName === 'chromium') {
-    const tmpUserDataDir = await mkdtemp(
-      path.join(
-        tmpdir(),
-        `playwright-user-data-dir-${workerInfo.workerIndex}-`,
-      ),
-    );
-    context = await chromium.launchPersistentContext(tmpUserDataDir, {
+    context = await chromium.launchPersistentContext('', {
       channel,
       args: [
         '--headless=new',

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -55,18 +55,22 @@ export async function fillPopup(
   i18n: BrowserIntl,
   params: Partial<ConnectDetails>,
 ) {
+  const timeout = 1000;
   const fields = getPopupFields(popup, i18n);
   if (typeof params.walletAddressUrl !== 'undefined') {
-    await fields.walletAddressUrl.fill(params.walletAddressUrl);
-    await fields.walletAddressUrl.blur();
+    await fields.walletAddressUrl.fill(params.walletAddressUrl, { timeout });
+    await fields.walletAddressUrl.blur({ timeout });
   }
   if (typeof params.amount !== 'undefined') {
-    await fields.amount.fill(params.amount);
-    await fields.amount.blur();
+    await fields.amount.fill(params.amount, { timeout });
+    await fields.amount.blur({ timeout });
   }
   if (typeof params.recurring !== 'undefined') {
-    await fields.recurring.setChecked(params.recurring, { force: true });
-    await fields.recurring.blur();
+    await fields.recurring.setChecked(params.recurring, {
+      force: true,
+      timeout,
+    });
+    await fields.recurring.blur({ timeout });
   }
 
   return fields.connectButton;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Some times some tests hang for unknown (as of now) reasons. For example, if Chimoney auto-connect test hangs, it takes 1.5min in CI to know if it failed.

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Fail fast. Will help in debugging which parts fail due to actual timeouts and which parts just fail _randomly_.

Also, found we were using browser versions globally installed in GitHub env. Now we install specific browser variants.

Some tests still flaky, will diagnose as follow up.