### PR TITLE
fix(keyAutoAdd/cards): normalize `ilp.dev` wallet addresses

### DIFF
--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -131,9 +131,15 @@ const findWallet: Run<{ accountId: string; walletId: string }> = async (
       //
       // Not all `ilp.interledger.cards` wallet addresses can be used with `ilp.dev`.
       // Manually created wallet addresses cannot be used with `ilp.dev`.
-      const walletAddress = toWalletAddressUrl(wallet.url)
-      const cardWalletAddressUrl = walletAddressUrl.replace('ilp.interledger.cards', 'ilp.dev')
-      if (walletAddress === walletAddressUrl || walletAddress === cardWalletAddressUrl) {
+      const walletAddress = toWalletAddressUrl(wallet.url);
+      const cardWalletAddressUrl = walletAddressUrl.replace(
+        'ilp.interledger.cards',
+        'ilp.dev',
+      );
+      if (
+        walletAddress === walletAddressUrl ||
+        walletAddress === cardWalletAddressUrl
+      ) {
         return { accountId: account.id, walletId: wallet.id };
       }
     }

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -169,8 +169,8 @@ async function revokeKey(accountId: string, walletId: string, keyId: string) {
 }
 
 function normalizeWalletAddress(urlOrPaymentPointer: string) {
-  const url = toWalletAddressUrl(urlOrPaymentPointer);
-  if (IS_INTERLEDGER_CARDS && url.startsWith('https://ilp.dev')) {
+  const url = new URL(toWalletAddressUrl(urlOrPaymentPointer));
+  if (IS_INTERLEDGER_CARDS && url.host === 'ilp.dev') {
     // For Interledger Cards we can have two types of wallet addresses:
     //  - ilp.interledger.cards
     //  - ilp.dev (just a proxy behind ilp.interledger.cards for certain wallet addresses)
@@ -182,9 +182,9 @@ function normalizeWalletAddress(urlOrPaymentPointer: string) {
     //
     // Not all `ilp.interledger.cards` wallet addresses can be used with `ilp.dev`.
     // Manually created wallet addresses cannot be used with `ilp.dev`.
-    return url.replace('ilp.dev', 'ilp.interledger.cards');
+    return url.href.replace('ilp.dev', 'ilp.interledger.cards');
   }
-  return url;
+  return url.href;
 }
 // endregion
 

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -120,7 +120,20 @@ const findWallet: Run<{ accountId: string; walletId: string }> = async (
   const accounts = output(getAccounts);
   for (const account of accounts) {
     for (const wallet of account.walletAddresses) {
-      if (toWalletAddressUrl(wallet.url) === walletAddressUrl) {
+      // For Interledger Cards we can have two types of wallet addresses:
+      //  - ilp.interledger.cards
+      //  - ilp.dev (just a proxy behind ilp.interledger.cards for certain wallet addresses)
+      //
+      // `ilp.dev` wallet addresses are only used for wallet addresses that are
+      // linked to a card.
+      //
+      // `ilp.interledger.cards` used for the other wallet addresses (user created)
+      //
+      // Not all `ilp.interledger.cards` wallet addresses can be used with `ilp.dev`.
+      // Manually created wallet addresses cannot be used with `ilp.dev`.
+      const walletAddress = toWalletAddressUrl(wallet.url)
+      const cardWalletAddressUrl = walletAddressUrl.replace('ilp.interledger.cards', 'ilp.dev')
+      if (walletAddress === walletAddressUrl || walletAddress === cardWalletAddressUrl) {
         return { accountId: account.id, walletId: wallet.id };
       }
     }


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Check for `https://ilp.interledger.cards/<wallet_address_name>` and `https://ilp.dev/<wallet_address_name>` at the same time.

There are collision issues since `ilp.dev` wallet addresses are just a proxy behind some of the `ilp.interledger.cards` wallet addresses.

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
