### PR TITLE
test(e2e): avoid sharing browser instance across workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,10 +9,9 @@ if (!process.env.CI) {
 export default defineConfig({
   testDir,
   outputDir: path.join(testDir, 'test-results'),
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
   reporter: [
     ['list'],
     [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,11 +9,6 @@ if (!process.env.CI) {
 export default defineConfig({
   testDir,
   outputDir: path.join(testDir, 'test-results'),
-  // We don't want this set to true as that would make tests in each file to run
-  // in parallel, which will cause conflicts with the "global state". With this
-  // set to false and workers > 1, multiple test files can run in parallel, but
-  // tests within a file are run at one at a time. We make extensive use of
-  // worker-scope fixtures and beforeAll hooks to achieve best performance.
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/tests/e2e/connect.spec.ts
+++ b/tests/e2e/connect.spec.ts
@@ -1,10 +1,5 @@
-/// <reference types="chrome"/>
 import { test, expect } from './fixtures/base';
 import { connectWallet, disconnectWallet } from './pages/popup';
-
-test.beforeEach(async ({ popup }) => {
-  await popup.reload();
-});
 
 test('connects with correct details provided', async ({
   persistentContext,

--- a/tests/e2e/connectAutoKeyChimoney.spec.ts
+++ b/tests/e2e/connectAutoKeyChimoney.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from './fixtures/base';
 import { withResolvers, getJWKS } from '@/shared/helpers';
-import { fillPopup } from './pages/popup';
+import { disconnectWallet, fillPopup } from './pages/popup';
 import {
   URLS,
   login,
   revokeKey,
   waitForGrantConsentPage,
 } from './helpers/chimoney';
+import { waitForWelcomePage } from './helpers/common';
 import { getStorage } from './fixtures/helpers';
 
 test('Connect to Chimoney wallet with automatic key addition when not logged-in to wallet', async ({
@@ -137,16 +138,15 @@ test('Connect to Chimoney wallet with automatic key addition when not logged-in 
     await expect(
       page.getByRole('button', { name: 'Decline', exact: true }),
     ).toBeVisible();
-
-    await page.getByRole('button', { name: 'Accept', exact: true }).click();
-    expect(page.getByRole('button', { name: 'Get OTP Code' })).toBeVisible();
   });
 
-  // The connect process won't be able to progress further here in tests. It'll
-  // ask for OTP over email, which we can't access. So, we'll assume if that OTP
-  // page is shown, we can connect.
+  await test.step('connects', async () => {
+    await page.getByRole('button', { name: 'Accept', exact: true }).click();
+    await waitForWelcomePage(page);
+    await expect(background).toHaveStorage({ connected: true });
+  });
 
-  await test.step('revoke key', async () => {
+  await test.step('cleanup: revoke key', async () => {
     const res = await revokeKey(page, keyId);
     expect(res).toEqual({ status: 'success', data: 'success' });
 
@@ -154,7 +154,7 @@ test('Connect to Chimoney wallet with automatic key addition when not logged-in 
     expect(keys.find((key) => key.kid === keyId)).toBeUndefined();
   });
 
-  // await test.step('disconnect wallet', async () => {
-  //   await disconnectWallet(popup);
-  // });
+  await test.step('cleanup: disconnect wallet', async () => {
+    await disconnectWallet(popup);
+  });
 });

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -16,27 +16,22 @@ import { getLastCallArg } from '../helpers/common';
 import { openPopup, type Popup } from '../pages/popup';
 import type { DeepPartial, Storage } from '@/shared/types';
 
-type BaseScopeWorker = {
+type Fixtures = {
   persistentContext: BrowserContext;
   background: Background;
-  i18n: BrowserIntl;
-  /**
-   * IMPORTANT: This is created once per test file. Mutating/closing could
-   * impact other tests in same file.
-   */
   popup: Popup;
+  i18n: BrowserIntl;
+  page: Page;
 };
 
-export const test = base.extend<{ page: Page }, BaseScopeWorker>({
-  // Extensions only work with a persistent context.
-  // Ideally we wanted this fixture to be named "context", but it's already defined in default base context under the scope "test".
+export const test = base.extend<Fixtures>({
   persistentContext: [
-    async ({ browserName, channel }, use, workerInfo) => {
-      const context = await loadContext({ browserName, channel }, workerInfo);
+    async ({ browserName, channel }, use, testInfo) => {
+      const context = await loadContext({ browserName, channel }, testInfo);
       await use(context);
       await context.close();
     },
-    { scope: 'worker', timeout: 5_000 },
+    { scope: 'test', timeout: 5_000 },
   ],
 
   // This is the background service worker in Chrome, and background script
@@ -47,7 +42,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       const background = await getBackground(browserName, context);
       await use(background);
     },
-    { scope: 'worker', timeout: 5_000 },
+    { scope: 'test', timeout: 5_000 },
   ],
 
   i18n: [
@@ -55,7 +50,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       const i18n = new BrowserIntl(browserName);
       await use(i18n);
     },
-    { scope: 'worker' },
+    { scope: 'test' },
   ],
 
   popup: [
@@ -65,7 +60,7 @@ export const test = base.extend<{ page: Page }, BaseScopeWorker>({
       await use(popup);
       await popup.close();
     },
-    { scope: 'worker', timeout: 5_000 },
+    { scope: 'test', timeout: 5_000 },
   ],
 
   page: async ({ persistentContext: context }, use) => {

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -16,13 +16,13 @@ export const test = base.extend<{ page: Page }, { popup: Popup }>({
         amount: '10',
         recurring: false,
       });
-      await popup.reload({ waitUntil: 'networkidle' });
+      await popup.reload();
 
       await use(popup);
 
       await disconnectWallet(popup);
     },
-    { scope: 'worker', timeout: 20_000 },
+    { scope: 'test', timeout: 20_000 },
   ],
 });
 

--- a/tests/e2e/not-monetized.spec.ts
+++ b/tests/e2e/not-monetized.spec.ts
@@ -1,133 +1,124 @@
 import { pathToFileURL } from 'node:url';
 import { test, expect } from './fixtures/connected';
-import type { Locator } from '@playwright/test';
 import { setupPlayground } from './helpers/common';
 
 const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
 
-test.beforeEach(async ({ popup, page }) => {
-  await popup.reload();
-  await page.bringToFront();
-});
-
-test('shows not monetized on empty tabs', async ({
-  popup,
-  i18n,
-  persistentContext: context,
-}) => {
-  const warning = popup.getByTestId('not-monetized-message');
-  const msg = i18n.getMessage('notMonetized_text_newTab');
-  await expect(warning).toBeVisible();
-  await expect(warning).toHaveText(msg);
-
-  await context.newPage().then((page) => page.bringToFront());
-  await expect(warning).toBeVisible();
-  await expect(warning).toHaveText(msg);
-});
-
-test('shows not monetized on internal pages', async ({
-  page,
+// We make extensive use of test.step in this test to reuse the same browser
+// instance, as connecting wallet each time for small tests is expensive.
+test('shows not-monetized status', async ({
   popup,
   i18n,
   channel,
+  background,
+  persistentContext: context,
 }) => {
-  const url = channel === 'msedge' ? 'edge://settings' : 'chrome://settings';
-  await page.goto(url);
-
   const warning = popup.getByTestId('not-monetized-message');
-  await expect(warning).toBeVisible();
-  await expect(warning).toHaveText(
-    i18n.getMessage('notMonetized_text_internalPage'),
-  );
-});
+  const msg = {
+    newTab: i18n.getMessage('notMonetized_text_newTab'),
+    internalPage: i18n.getMessage('notMonetized_text_internalPage'),
+    unsupportedScheme: i18n.getMessage('notMonetized_text_unsupportedScheme'),
+    noLinks: i18n.getMessage('notMonetized_text_noLinks'),
+  };
 
-test.describe('shows not monetized on non-https pages', () => {
-  let warning: Locator;
-  let msg: string;
-
-  test.beforeAll(async ({ popup, i18n }) => {
-    warning = popup.getByTestId('not-monetized-message');
-    msg = i18n.getMessage('notMonetized_text_unsupportedScheme');
-  });
-
-  test.beforeEach(async ({ popup, page }) => {
+  const newPage = async () => {
+    const page = await context.newPage();
     await popup.reload();
     await page.bringToFront();
-  });
+    return {
+      goto: page.goto.bind(page), // so we don't have to call `page.page.goto()` every time
+      page: page,
+      [Symbol.asyncDispose]: async () => {
+        await page.close();
+      },
+    };
+  };
 
-  test('http:// URLs', async ({ page }) => {
-    await page.goto('http://example.com');
+  await test.step('shows not monetized on empty tabs', async () => {
     await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
-  });
+    await expect(warning).toHaveText(msg.newTab);
 
-  test('navigating from https:// to http://', async ({ page, i18n }) => {
-    await page.goto('https://example.com');
+    await using _page = await newPage();
     await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(
-      i18n.getMessage('notMonetized_text_noLinks'),
-    );
+    await expect(warning).toHaveText(msg.newTab);
+  });
 
-    await page.goto('http://example.com');
+  await test.step('shows not monetized on internal pages', async () => {
+    await using page = await newPage();
+    const url = channel === 'msedge' ? 'edge://settings' : 'chrome://settings';
+    await page.goto(url);
+
     await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
+    await expect(warning).toHaveText(msg.internalPage);
   });
 
-  test('file:// URLs', async ({ page }) => {
-    await page.goto(pathToFileURL('.').href);
-    await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
+  await test.step('shows not monetized on non-https pages', async () => {
+    await test.step('http:// URLs', async () => {
+      await using page = await newPage();
+      await page.goto('http://httpforever.com/');
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.unsupportedScheme);
+    });
+
+    await test.step('navigating from https:// to http://', async () => {
+      await using page = await newPage();
+      await page.goto('https://example.com');
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.noLinks);
+
+      await page.goto('http://httpforever.com/');
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.unsupportedScheme);
+    });
+
+    await test.step('file:// URLs', async () => {
+      await using page = await newPage();
+      await page.goto(pathToFileURL('.').href);
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.unsupportedScheme);
+    });
+
+    await test.step('extension pages', async () => {
+      await using page = await newPage();
+      const popupUrl = await background.evaluate(() =>
+        chrome.action.getPopup({}),
+      );
+      await page.goto(popupUrl);
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.unsupportedScheme);
+    });
   });
 
-  test('extension pages', async ({ page, background }) => {
-    const popupUrl = await background.evaluate(() =>
-      chrome.action.getPopup({}),
-    );
-    await page.goto(popupUrl);
-    await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
-  });
-});
+  await test.step('shows not monetized on non-monetized pages', async () => {
+    await test.step('no link tags', async () => {
+      await using page = await newPage();
+      await page.goto('https://example.com');
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.noLinks);
+    });
 
-test.describe('shows not monetized on non-monetized pages', () => {
-  let warning: Locator;
-  let msg: string;
+    await test.step('no enabled link tags', async () => {
+      await using page = await newPage();
+      await page.goto('https://example.com');
+      await page.page.evaluate((walletAddressUrl) => {
+        const link = document.createElement('link');
+        link.rel = 'monetization';
+        link.disabled = true;
+        link.href = walletAddressUrl;
+        document.head.appendChild(link);
+      }, walletAddressUrl);
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.noLinks);
+    });
 
-  test.beforeAll(async ({ popup, i18n }) => {
-    warning = popup.getByTestId('not-monetized-message');
-    msg = i18n.getMessage('notMonetized_text_noLinks');
-  });
+    await test.step('navigating from monetized to non-monetized', async () => {
+      await using page = await newPage();
+      await setupPlayground(page.page, walletAddressUrl);
+      await expect(warning).not.toBeVisible();
 
-  test.beforeEach(async ({ page, popup }) => {
-    await popup.reload();
-    await page.bringToFront();
-  });
-
-  test('no link tags', async ({ page }) => {
-    await page.goto('https://example.com');
-    await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
-  });
-
-  test('no enabled link tags', async ({ page }) => {
-    await page.goto('https://example.com');
-    await page.evaluate((walletAddressUrl) => {
-      const link = document.createElement('link');
-      link.rel = 'monetization';
-      link.disabled = true;
-      link.href = walletAddressUrl;
-      document.head.appendChild(link);
-    }, walletAddressUrl);
-    await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
-  });
-
-  test('navigating from monetized to non-monetized', async ({ page }) => {
-    await setupPlayground(page, walletAddressUrl);
-    await expect(warning).not.toBeVisible();
-
-    await page.goto('https://example.com');
-    await expect(warning).toBeVisible();
-    await expect(warning).toHaveText(msg);
+      await page.goto('https://example.com');
+      await expect(warning).toBeVisible();
+      await expect(warning).toHaveText(msg.noLinks);
+    });
   });
 });

--- a/tests/e2e/overpaying.spec.ts
+++ b/tests/e2e/overpaying.spec.ts
@@ -8,10 +8,6 @@ import {
 import { sendOneTimePayment } from './pages/popup';
 import type { OutgoingPayment } from '@interledger/open-payments';
 
-test.beforeEach(async ({ popup }) => {
-  await popup.reload();
-});
-
 test.afterEach(({ persistentContext: context }) => {
   context.removeAllListeners('requestfinished');
 });

--- a/tests/e2e/simple.spec.ts
+++ b/tests/e2e/simple.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from './fixtures/connected';
 import { setupPlayground } from './helpers/common';
 
-test.beforeEach(async ({ popup }) => {
-  await popup.reload();
-});
-
 test('should monetize site with single wallet address', async ({
   page,
   popup,


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/873

Playwright reuses worker wherever possible, which means we can't cleanup browser state in `beforeAll`/`afterAll` hooks as they run at the end of worker. Playwright creates a new worker when test fails, so next test/retry uses fresh state. In our case, we had already connected wallet, and if next test tried to connect wallet again, they will timeout looking for the form. We could've verified & disconnected wallet as a step in each test, but that's not good either - as browser storage & pending API calls can still affect later tests.

I tried various workarounds to run cleanup process in `beforeAll` per file in https://github.com/interledger/web-monetization-extension/pull/864, but nothing gave a clean enough state.

Playwright doesn't have a `file` scope (https://github.com/microsoft/playwright/issues/34519); it has only `worker` (state gets reused across files) or per `test` (new setup in each test within file), so here we decided to use `worker` scope to sacrifice performance/efficiency to avoid test flakiness.

## Changes proposed in this pull request

- Create new browser context for each test, isolating them
- Use `test.step` where it would be too expensive to create new browser instance of each sub-test (See `not-monetized.spec.ts`, ignore whitespace changes)
- For better performance, increased parallelism for tests by not restricting to 1 worker, and enabling `fullyParallel`.