### PR TITLE
fix: fix regressions caused by `forEach` to `for..of` migration

### DIFF
--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -143,7 +143,7 @@ export class MonetizationService {
       this.canTryPayment(connected, state)
     ) {
       for (const session of sessionsArr) {
-        if (!sessions.get(session.id)) return;
+        if (!sessions.get(session.id)) continue;
         const source = replacedSessions.has(session.id)
           ? 'request-id-reused'
           : 'new-link';
@@ -181,7 +181,7 @@ export class MonetizationService {
       const { requestId } = p;
 
       const session = sessions.get(requestId);
-      if (!session) return;
+      if (!session) continue;
 
       if (p.intent === 'remove') {
         needsAdjustAmount = true;

--- a/src/content/services/frameManager.ts
+++ b/src/content/services/frameManager.ts
@@ -124,7 +124,7 @@ export class FrameManager {
   private onWholeDocumentObserved(records: MutationRecord[]) {
     for (const record of records) {
       if (record.type === 'childList') {
-        for (const node of record.addedNodes) {
+        for (const node of record.removedNodes) {
           this.check('removed', node);
         }
       }


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Extracted from https://github.com/interledger/web-monetization-extension/pull/882
Handles regressions from migrating from `forEach` to `for..of` loops in #814 (thankfully not in stores yet)

## Changes proposed in this pull request

- stray return when should've been a continue
- refactor(MonetizationLinkManager): add `onRemovedNode` consistent with `onAddedNode`; replace some `for..of` with Array filter/map
- `addedNodes` in frameManager should've been `removedNodes` ([ref](https://github.com/interledger/web-monetization-extension/pull/882#pullrequestreview-2585790443))
- stronger, more consistent types