### PR TITLE
test(e2e): add tests for editing budget

### DIFF
--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -275,7 +275,7 @@ export class WalletService {
         existingGrants.oneTimeGrant.continue,
       );
       if (recurring) {
-        this.storage.set({
+        await this.storage.set({
           oneTimeGrant: null,
           oneTimeGrantSpentAmount: '0',
         });
@@ -286,7 +286,7 @@ export class WalletService {
         existingGrants.recurringGrant.continue,
       );
       if (!recurring) {
-        this.storage.set({
+        await this.storage.set({
           recurringGrant: null,
           recurringGrantSpentAmount: '0',
         });

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -271,26 +271,26 @@ export class WalletService {
     // Note: Clear storage only if new grant type is not same as previous grant
     // type (as completeGrant already sets new grant state)
     if (existingGrants.oneTimeGrant) {
-      await this.outgoingPaymentGrantService.cancelGrant(
-        existingGrants.oneTimeGrant.continue,
-      );
       if (recurring) {
         await this.storage.set({
           oneTimeGrant: null,
           oneTimeGrantSpentAmount: '0',
         });
       }
+      await this.outgoingPaymentGrantService.cancelGrant(
+        existingGrants.oneTimeGrant.continue,
+      );
     }
     if (existingGrants.recurringGrant) {
-      await this.outgoingPaymentGrantService.cancelGrant(
-        existingGrants.recurringGrant.continue,
-      );
       if (!recurring) {
         await this.storage.set({
           recurringGrant: null,
           recurringGrantSpentAmount: '0',
         });
       }
+      await this.outgoingPaymentGrantService.cancelGrant(
+        existingGrants.recurringGrant.continue,
+      );
     }
   }
 

--- a/src/pages/popup/components/Settings/Budget.tsx
+++ b/src/pages/popup/components/Settings/Budget.tsx
@@ -170,7 +170,7 @@ const BudgetAmount = ({
         </div>
       </div>
       {renewDate && (
-        <p className="px-2 text-xs">
+        <p className="px-2 text-xs" data-testid="renew-date-msg">
           Your budget will renew on{' '}
           <time
             dateTime={renewDate.toISOString()}

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -55,53 +55,34 @@ const InfoBanner = () => {
   const rate = React.useMemo(() => {
     const r = Number(rateOfPay) / 10 ** walletAddress.assetScale;
     const roundedR = roundWithPrecision(r, walletAddress.assetScale);
-    return formatNumber(roundedR, walletAddress.assetScale, true);
-  }, [rateOfPay, walletAddress.assetScale]);
 
-  const rateFormatted = React.useMemo(() => {
     return formatCurrency(
-      rate,
+      formatNumber(roundedR, walletAddress.assetScale, true),
       walletAddress.assetCode,
       walletAddress.assetScale,
     );
-  }, [rate, walletAddress.assetCode, walletAddress.assetScale]);
+  }, [rateOfPay, walletAddress.assetCode, walletAddress.assetScale]);
 
   const remainingBalance = React.useMemo(() => {
     const val = Number(balance) / 10 ** walletAddress.assetScale;
     const rounded = roundWithPrecision(val, walletAddress.assetScale);
-    return formatNumber(rounded, walletAddress.assetScale, true);
-  }, [balance, walletAddress.assetScale]);
-
-  const remainingBalanceFormatted = React.useMemo(() => {
     return formatCurrency(
-      remainingBalance,
+      formatNumber(rounded, walletAddress.assetScale, true),
       walletAddress.assetCode,
       walletAddress.assetScale,
     );
-  }, [remainingBalance, walletAddress.assetCode, walletAddress.assetScale]);
+  }, [balance, walletAddress.assetCode, walletAddress.assetScale]);
 
   return (
     <div className="space-y-2 rounded-md bg-button-base p-4 text-white">
       <dl className="flex items-center justify-between px-10">
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Hourly rate</dt>
-          <dd
-            className="font-medium tabular-nums"
-            data-testid="hourly-rate"
-            data-value={rate}
-          >
-            {rateFormatted}
-          </dd>
+          <dd className="font-medium tabular-nums">{rate}</dd>
         </div>
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Balance</dt>
-          <dd
-            className="font-medium tabular-nums"
-            data-testid="remaining-balance"
-            data-value={remainingBalance}
-          >
-            {remainingBalanceFormatted}
-          </dd>
+          <dd className="font-medium tabular-nums">{remainingBalance}</dd>
         </div>
       </dl>
 

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -55,34 +55,53 @@ const InfoBanner = () => {
   const rate = React.useMemo(() => {
     const r = Number(rateOfPay) / 10 ** walletAddress.assetScale;
     const roundedR = roundWithPrecision(r, walletAddress.assetScale);
+    return formatNumber(roundedR, walletAddress.assetScale, true);
+  }, [rateOfPay, walletAddress.assetScale]);
 
+  const rateFormatted = React.useMemo(() => {
     return formatCurrency(
-      formatNumber(roundedR, walletAddress.assetScale, true),
+      rate,
       walletAddress.assetCode,
       walletAddress.assetScale,
     );
-  }, [rateOfPay, walletAddress.assetCode, walletAddress.assetScale]);
+  }, [rate, walletAddress.assetCode, walletAddress.assetScale]);
 
   const remainingBalance = React.useMemo(() => {
     const val = Number(balance) / 10 ** walletAddress.assetScale;
     const rounded = roundWithPrecision(val, walletAddress.assetScale);
+    return formatNumber(rounded, walletAddress.assetScale, true);
+  }, [balance, walletAddress.assetScale]);
+
+  const remainingBalanceFormatted = React.useMemo(() => {
     return formatCurrency(
-      formatNumber(rounded, walletAddress.assetScale, true),
+      remainingBalance,
       walletAddress.assetCode,
       walletAddress.assetScale,
     );
-  }, [balance, walletAddress.assetCode, walletAddress.assetScale]);
+  }, [remainingBalance, walletAddress.assetCode, walletAddress.assetScale]);
 
   return (
     <div className="space-y-2 rounded-md bg-button-base p-4 text-white">
       <dl className="flex items-center justify-between px-10">
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Hourly rate</dt>
-          <dd className="font-medium tabular-nums">{rate}</dd>
+          <dd
+            className="font-medium tabular-nums"
+            data-testid="hourly-rate"
+            data-value={rate}
+          >
+            {rateFormatted}
+          </dd>
         </div>
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Balance</dt>
-          <dd className="font-medium tabular-nums">{remainingBalance}</dd>
+          <dd
+            className="font-medium tabular-nums"
+            data-testid="remaining-balance"
+            data-value={remainingBalance}
+          >
+            {remainingBalanceFormatted}
+          </dd>
         </div>
       </dl>
 

--- a/src/pages/shared/components/ui/Button.tsx
+++ b/src/pages/shared/components/ui/Button.tsx
@@ -51,7 +51,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant,
       size,
       fullWidth,
-      loading,
+      loading = false,
       className,
       type = 'button',
       children,
@@ -67,6 +67,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           buttonVariants({ variant, size, fullWidth, loading }),
           className,
         )}
+        data-progress={loading.toString()}
         disabled={props.disabled ?? loading ?? false}
         aria-disabled={props.disabled ?? loading ?? false}
         {...props}

--- a/tests/e2e/connect.spec.ts
+++ b/tests/e2e/connect.spec.ts
@@ -21,12 +21,7 @@ test('connects with correct details provided', async ({
 
   await expect(background).toHaveStorage({ connected: false });
 
-  const keyInfo = {
-    keyId: TEST_WALLET_KEY_ID,
-    privateKey: TEST_WALLET_PRIVATE_KEY,
-    publicKey: TEST_WALLET_PUBLIC_KEY,
-  };
-  await connectWallet(persistentContext, background, i18n, keyInfo, popup, {
+  await connectWallet(persistentContext, background, popup, i18n, {
     walletAddressUrl: TEST_WALLET_ADDRESS_URL,
     amount: '10',
     recurring: false,

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -6,12 +6,7 @@ import { connectWallet, disconnectWallet, type Popup } from '../pages/popup';
 export const test = base.extend<{ page: Page }, { popup: Popup }>({
   popup: [
     async ({ persistentContext: context, background, popup, i18n }, use) => {
-      const keyInfo = {
-        keyId: process.env.TEST_WALLET_KEY_ID,
-        privateKey: process.env.TEST_WALLET_PRIVATE_KEY,
-        publicKey: process.env.TEST_WALLET_PUBLIC_KEY,
-      };
-      await connectWallet(context, background, i18n, keyInfo, popup, {
+      await connectWallet(context, background, popup, i18n, {
         walletAddressUrl: process.env.TEST_WALLET_ADDRESS_URL,
         amount: '10',
         recurring: false,

--- a/tests/e2e/helpers/testWallet.ts
+++ b/tests/e2e/helpers/testWallet.ts
@@ -15,13 +15,22 @@ export const LOGIN_PAGE_URL =
 export const API_URL_ORIGIN = 'https://api.wallet.interledger-test.dev';
 export const DEFAULT_CONTINUE_WAIT_MS = 1000;
 
+export const DEFAULT_KEY_INFO: KeyInfo = {
+  keyId: process.env.TEST_WALLET_KEY_ID,
+  privateKey: process.env.TEST_WALLET_PRIVATE_KEY,
+  publicKey: process.env.TEST_WALLET_PUBLIC_KEY,
+};
+
+/**
+ * @param keyInfo required if not using default {@linkcode params['walletAddressUrl']}
+ */
 export async function connectWallet(
   context: BrowserContext,
   background: Background,
-  i18n: BrowserIntl,
-  keyInfo: KeyInfo,
   popup: Popup,
+  i18n: BrowserIntl,
   params: ConnectDetails,
+  keyInfo: KeyInfo = DEFAULT_KEY_INFO,
 ) {
   await loadKeysToExtension(background, keyInfo);
 

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -93,7 +93,16 @@ export function getPopupFields(popup: Popup, i18n: BrowserIntl) {
   };
 }
 
-export async function sendOneTimePayment(popup: Popup, amount: string) {
+export async function sendOneTimePayment(
+  popup: Popup,
+  amount: string,
+  waitForComplete = false,
+) {
   await popup.getByRole('textbox').fill(amount);
   await popup.getByRole('button', { name: 'Send now' }).click();
+  if (waitForComplete) {
+    await popup.waitForSelector('button[data-progress="false"]', {
+      timeout: 10_000,
+    });
+  }
 }

--- a/tests/e2e/walletBudget.spec.ts
+++ b/tests/e2e/walletBudget.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect } from './fixtures/base';
+import { getStorage } from './fixtures/helpers';
+import {
+  connectWallet,
+  disconnectWallet,
+  sendOneTimePayment,
+} from './pages/popup';
+import {
+  getContinueWaitTime,
+  getWalletInfoCached,
+  setupPlayground,
+} from './helpers/common';
+import { completeGrant, DEFAULT_CONTINUE_WAIT_MS } from './helpers/testWallet';
+import { transformBalance } from '@/shared/helpers';
+import { addMonths } from 'date-fns';
+import type { WalletAddress } from '@interledger/open-payments';
+import type { AmountValue } from '@/shared/types';
+
+const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
+
+const INITIAL_AMOUNT = 10;
+const NEW_AMOUNT = 15;
+const TEST_CASES = [
+  {
+    name: 'from one-time to recurring',
+    from: { recurring: false },
+    to: { recurring: true },
+  },
+  {
+    name: 'from recurring to one-time',
+    from: { recurring: true },
+    to: { recurring: false },
+  },
+  {
+    name: 'from one-time to one-time',
+    from: { recurring: false },
+    to: { recurring: false },
+  },
+  {
+    name: 'from recurring to recurring',
+    from: { recurring: true },
+    to: { recurring: true },
+  },
+];
+
+for (const testCase of TEST_CASES) {
+  test.describe('edit wallet budget', () => {
+    let walletAddress: WalletAddress;
+    let initialAmount: AmountValue;
+    let initialAmountFormatted: string;
+    let newAmount: AmountValue;
+    let newAmountFormatted: string;
+
+    test.beforeAll('get wallet info', async () => {
+      walletAddress = await getWalletInfoCached(walletAddressUrl);
+      const assetScale = walletAddress.assetScale;
+      initialAmount = (INITIAL_AMOUNT * 10 ** assetScale).toString();
+      initialAmountFormatted = transformBalance(initialAmount, assetScale);
+      newAmount = (NEW_AMOUNT * 10 ** assetScale).toString();
+      newAmountFormatted = transformBalance(newAmount, assetScale);
+    });
+
+    test.beforeEach(
+      'connectWallet',
+      async ({ persistentContext: context, background, popup, i18n }) => {
+        await connectWallet(context, background, popup, i18n, {
+          walletAddressUrl,
+          amount: String(INITIAL_AMOUNT),
+          recurring: testCase.from.recurring,
+        });
+      },
+    );
+
+    test.afterEach('disconnectWallet', async ({ popup }) => {
+      await disconnectWallet(popup);
+    });
+
+    test(testCase.name, async ({
+      persistentContext: context,
+      background,
+      popup,
+      page,
+    }) => {
+      const settingsLink = popup.locator(`[href="/settings"]`);
+      const budgetTab = popup.getByRole('tab', { name: 'Budget' });
+
+      const remainingBalanceInput = popup.getByLabel('Remaining balance');
+      const budgetAmountInput = popup.getByLabel('Budget amount');
+      const recurringInput = popup.getByRole('switch', { name: 'Monthly' });
+      const renewDateMsg = popup.getByTestId('renew-date-msg');
+
+      const fromRecurring = testCase.from.recurring;
+      const toRecurring = testCase.to.recurring;
+
+      await test.step('validate initial state', async () => {
+        await expect(background).toHaveStorage({
+          oneTimeGrantSpentAmount: '0',
+          recurringGrantSpentAmount: '0',
+        });
+
+        const { oneTimeGrant, recurringGrant } = await getStorage(background, [
+          'oneTimeGrant',
+          'recurringGrant',
+        ]);
+        // we only test "type" to avoid logging sensitive info about tokens
+        if (fromRecurring) {
+          expect(recurringGrant?.type, 'recurring grant exists').toBeDefined();
+          expect(
+            oneTimeGrant?.type,
+            'one-time grant not exists',
+          ).toBeUndefined();
+        } else {
+          expect(oneTimeGrant?.type, 'one-time grant exists').toBeDefined();
+          expect(
+            recurringGrant?.type,
+            'recurring grant not exists',
+          ).toBeUndefined();
+        }
+
+        await settingsLink.click();
+        await budgetTab.click();
+        await expect(remainingBalanceInput).toHaveValue(initialAmountFormatted);
+        await expect(budgetAmountInput).toHaveValue(initialAmountFormatted);
+        await expect(recurringInput).toBeChecked({ checked: fromRecurring });
+
+        await expect(renewDateMsg).toBeVisible({ visible: fromRecurring });
+      });
+
+      await test.step('make payment to reduce remaining balance', async () => {
+        await setupPlayground(page, walletAddressUrl);
+
+        await popup.reload();
+        await sendOneTimePayment(popup, '2.00', true);
+        // Make an extra payment to update balance:
+        // https://github.com/interledger/web-monetization-extension/issues/737
+        await sendOneTimePayment(popup, '0.50', true);
+
+        const remainingBalance = await popup
+          .getByTestId('remaining-balance')
+          .getAttribute('data-value');
+        expect(Number(remainingBalance)).toBeLessThan(INITIAL_AMOUNT);
+
+        await page.close(); // so no new payments get made
+      });
+
+      const submitButton = await test.step('edit budget amount', async () => {
+        await settingsLink.click();
+        await budgetTab.click();
+
+        const submitButton = popup.getByRole('button', {
+          name: 'Submit changes',
+        });
+        await expect(submitButton).toBeDisabled();
+
+        await budgetAmountInput.fill(newAmountFormatted);
+        await recurringInput.setChecked(toRecurring, { force: true });
+
+        await expect(submitButton).toBeEnabled();
+
+        await expect(renewDateMsg).toBeVisible({ visible: toRecurring });
+        if (toRecurring) {
+          await expect(renewDateMsg.locator('time')).toHaveAttribute(
+            'datetime',
+            expect.stringContaining(
+              addMonths(new Date(), 1).toISOString().slice(0, 16),
+            ),
+          );
+        }
+
+        return submitButton;
+      });
+
+      await test.step('sets new grant on budget edit', async () => {
+        const continueWaitMsPromise = getContinueWaitTime(
+          context,
+          { walletAddressUrl },
+          DEFAULT_CONTINUE_WAIT_MS,
+        );
+        await submitButton.click();
+        const newPage = await context.waitForEvent('page', (page) =>
+          page.url().includes('/grant-interactions'),
+        );
+        const continueWaitMs = await continueWaitMsPromise;
+        await completeGrant(newPage, continueWaitMs);
+        expect(newPage.url()).toContain('intent=update_budget');
+        await newPage.close();
+
+        const newGrants = await getStorage(background, [
+          'oneTimeGrant',
+          'recurringGrant',
+          'recurringGrantSpentAmount',
+          'oneTimeGrantSpentAmount',
+        ]);
+        expect(newGrants.oneTimeGrantSpentAmount).toBe('0');
+        expect(newGrants.recurringGrantSpentAmount).toBe('0');
+
+        // intentionally comparing amount only to prevent displaying secret tokens
+        // if this expectation fails
+        if (toRecurring) {
+          expect(newGrants.recurringGrant?.amount).toEqual({
+            value: newAmount,
+            interval: expect.stringMatching(/^R\/\d{4}-\d{2}-\d{2}.+\/P1M$/),
+          });
+          expect(newGrants.oneTimeGrant?.amount).toBeUndefined();
+        } else {
+          expect(newGrants.oneTimeGrant?.amount).toEqual({
+            value: newAmount,
+            // no interval here
+          });
+          expect(newGrants.recurringGrant?.amount).toBeUndefined();
+        }
+      });
+
+      await test.step('shows new budget', async () => {
+        await popup.reload();
+        await settingsLink.click();
+        await budgetTab.click();
+
+        await expect(remainingBalanceInput).toHaveValue(newAmountFormatted);
+        await expect(budgetAmountInput).toHaveValue(newAmountFormatted);
+        await expect(recurringInput).toBeChecked({ checked: toRecurring });
+        await expect(renewDateMsg).toBeVisible({ visible: toRecurring });
+        await expect(submitButton).toBeDisabled();
+      });
+    });
+  });
+}

--- a/tests/e2e/walletBudget.spec.ts
+++ b/tests/e2e/walletBudget.spec.ts
@@ -135,18 +135,18 @@ for (const testCase of TEST_CASES) {
         // https://github.com/interledger/web-monetization-extension/issues/737
         await sendOneTimePayment(popup, '0.50', true);
 
-        const remainingBalance = await popup
-          .getByTestId('remaining-balance')
-          .getAttribute('data-value');
-        expect(Number(remainingBalance)).toBeLessThan(INITIAL_AMOUNT);
+        await settingsLink.click();
+        await budgetTab.click();
+
+        const remainingBalance = Number(
+          await remainingBalanceInput.getAttribute('value'),
+        );
+        expect(remainingBalance).toBeLessThan(INITIAL_AMOUNT);
 
         await page.close(); // so no new payments get made
       });
 
       const submitButton = await test.step('edit budget amount', async () => {
-        await settingsLink.click();
-        await budgetTab.click();
-
         const submitButton = popup.getByRole('button', {
           name: 'Submit changes',
         });


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/610

## Changes proposed in this pull request

- Add tests for editing wallet budget (4 budget scenarios)
- Update markup a bit to make testing easier
- Add missing await in background/wallet: `updateBudget`
- Update signature of `connectWallet` test util to make `keyInfo` optional and call-site simpler.
- Add caching to `getWalletInfo` in tests as it gets called by some tests more than once - less network is less noise & more reliability.