### PR TITLE
fix(popup): remove amount from OTP msg

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -78,10 +78,7 @@
     "message": "This website is not monetized."
   },
   "pay_state_success": {
-    "message": "Thank you for your $AMOUNT$ support!",
-    "placeholders": {
-      "AMOUNT": { "content": "$1", "example": "$2.05" }
-    }
+    "message": "Thank you for your support!"
   },
   "outOfFunds_error_title": {
     "message": "Out of funds"

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -15,11 +15,9 @@ import {
 } from '@/background/config';
 import {
   ErrorWithKey,
-  formatCurrency,
   isErrorWithKey,
   isOkState,
   removeQueryParams,
-  transformBalance,
 } from '@/shared/helpers';
 import type { AmountValue, PopupStore, Storage } from '@/shared/types';
 import type { OutgoingPayment } from '@interledger/open-payments';
@@ -327,7 +325,6 @@ export class MonetizationService {
     if (!walletAddress) {
       throw new Error('Unexpected: wallet address not found.');
     }
-    const { assetCode, assetScale } = walletAddress;
 
     const splitAmount = Number(amount) / payableSessions.length;
     // TODO: handle paying across two grants (when one grant doesn't have enough funds)
@@ -382,12 +379,7 @@ export class MonetizationService {
         // This permission request to read outgoing payments was added at a
         // later time, so existing connected wallets won't have this permission.
         // Assume as success for backward compatibility.
-        const sentAmount = transformBalance(totalDebitAmount, assetScale);
-        return {
-          type: 'full',
-          sentAmount: sentAmount,
-          sentAmountFormatted: formatCurrency(sentAmount, assetCode),
-        };
+        return { type: 'full' };
       }
 
       const isNotEnoughFunds = results
@@ -409,11 +401,8 @@ export class MonetizationService {
       throw new ErrorWithKey('pay_error_general');
     }
 
-    const sentAmount = transformBalance(totalSentAmount, assetScale);
     return {
       type: totalSentAmount < totalDebitAmount ? 'partial' : 'full',
-      sentAmount: sentAmount,
-      sentAmountFormatted: formatCurrency(sentAmount, assetCode),
     };
   }
 

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -55,9 +55,8 @@ export const PayWebsiteForm = () => {
       }));
     } else {
       setAmount('');
-      const { type, sentAmountFormatted } = response.payload;
-      const msg = t('pay_state_success', [sentAmountFormatted]);
-      setPayStatus({ type, message: msg });
+      const { type } = response.payload;
+      setPayStatus({ type, message: t('pay_state_success') });
       form.current?.reset();
     }
     setIsSubmitting(false);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -113,6 +113,7 @@ export interface PayWebsitePayload {
 
 export interface PayWebsiteResponse {
   type: 'full' | 'partial';
+  sentAmount: string;
 }
 
 export interface UpdateRateOfPayPayload {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -113,8 +113,6 @@ export interface PayWebsitePayload {
 
 export interface PayWebsiteResponse {
   type: 'full' | 'partial';
-  sentAmount: string;
-  sentAmountFormatted: string;
 }
 
 export interface UpdateRateOfPayPayload {


### PR DESCRIPTION
## Context

Closes #859.

## Changes proposed in this pull request

- Remove amount from payment confirmation message, keeping it limited to: "Thank you for your support".
