### PR TITLE
refactor(tests/e2e): rename `persistentContext` to `context`

### DIFF
--- a/tests/e2e/connect.spec.ts
+++ b/tests/e2e/connect.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures/base';
 import { connectWallet, disconnectWallet } from './pages/popup';
 
 test('connects with correct details provided', async ({
-  persistentContext,
+  context,
   background,
   popup,
   i18n,
@@ -21,7 +21,7 @@ test('connects with correct details provided', async ({
 
   await expect(background).toHaveStorage({ connected: false });
 
-  await connectWallet(persistentContext, background, popup, i18n, {
+  await connectWallet(context, background, popup, i18n, {
     walletAddressUrl: TEST_WALLET_ADDRESS_URL,
     amount: '10',
     recurring: false,

--- a/tests/e2e/connectAutoKeyChimoney.spec.ts
+++ b/tests/e2e/connectAutoKeyChimoney.spec.ts
@@ -13,7 +13,7 @@ import { getStorage } from './fixtures/helpers';
 test('Connect to Chimoney wallet with automatic key addition when not logged-in to wallet', async ({
   page,
   popup,
-  persistentContext: context,
+  context,
   background,
   i18n,
 }) => {

--- a/tests/e2e/connectAutoKeyFynbos.spec.ts
+++ b/tests/e2e/connectAutoKeyFynbos.spec.ts
@@ -14,7 +14,7 @@ import { getStorage } from './fixtures/helpers';
 test('Connect to Fynbos with automatic key addition when not logged-in to wallet', async ({
   page,
   popup,
-  persistentContext: context,
+  context,
   background,
   i18n,
 }) => {

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -16,7 +16,7 @@ import { getStorage } from './fixtures/helpers';
 test('Connect to test wallet with automatic key addition when not logged-in to wallet', async ({
   page,
   popup,
-  persistentContext: context,
+  context,
   background,
   i18n,
 }) => {

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -17,7 +17,7 @@ import { openPopup, type Popup } from '../pages/popup';
 import type { DeepPartial, Storage } from '@/shared/types';
 
 type Fixtures = {
-  persistentContext: BrowserContext;
+  context: BrowserContext;
   background: Background;
   popup: Popup;
   i18n: BrowserIntl;
@@ -25,7 +25,7 @@ type Fixtures = {
 };
 
 export const test = base.extend<Fixtures>({
-  persistentContext: [
+  context: [
     async ({ browserName, channel }, use, testInfo) => {
       const context = await loadContext({ browserName, channel }, testInfo);
       await use(context);
@@ -38,7 +38,7 @@ export const test = base.extend<Fixtures>({
   // context in Firefox. We can run extension APIs, such as
   // `chrome.storage.local.get` in this context with `background.evaluate()`.
   background: [
-    async ({ persistentContext: context, browserName }, use) => {
+    async ({ context, browserName }, use) => {
       const background = await getBackground(browserName, context);
       await use(background);
     },
@@ -54,8 +54,8 @@ export const test = base.extend<Fixtures>({
   ],
 
   popup: [
-    async ({ background, persistentContext }, use) => {
-      const popup = await openPopup(persistentContext, background);
+    async ({ background, context }, use) => {
+      const popup = await openPopup(context, background);
 
       await use(popup);
       await popup.close();
@@ -63,7 +63,7 @@ export const test = base.extend<Fixtures>({
     { scope: 'test', timeout: 5_000 },
   ],
 
-  page: async ({ persistentContext: context }, use) => {
+  page: async ({ context }, use) => {
     const page = await context.newPage();
     await use(page);
     await page.close();

--- a/tests/e2e/fixtures/connected.ts
+++ b/tests/e2e/fixtures/connected.ts
@@ -5,7 +5,7 @@ import { connectWallet, disconnectWallet, type Popup } from '../pages/popup';
 // With extension connected to the wallet.
 export const test = base.extend<{ page: Page }, { popup: Popup }>({
   popup: [
-    async ({ persistentContext: context, background, popup, i18n }, use) => {
+    async ({ context, background, popup, i18n }, use) => {
       await connectWallet(context, background, popup, i18n, {
         walletAddressUrl: process.env.TEST_WALLET_ADDRESS_URL,
         amount: '10',

--- a/tests/e2e/not-monetized.spec.ts
+++ b/tests/e2e/not-monetized.spec.ts
@@ -11,7 +11,7 @@ test('shows not-monetized status', async ({
   i18n,
   channel,
   background,
-  persistentContext: context,
+  context,
 }) => {
   const warning = popup.getByTestId('not-monetized-message');
   const msg = {

--- a/tests/e2e/overpaying.spec.ts
+++ b/tests/e2e/overpaying.spec.ts
@@ -8,18 +8,14 @@ import {
 import { sendOneTimePayment } from './pages/popup';
 import type { OutgoingPayment } from '@interledger/open-payments';
 
-test.afterEach(({ persistentContext: context }) => {
+test.afterEach(({ context }) => {
   context.removeAllListeners('requestfinished');
 });
 
 const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
 
 test.describe('should not pay immediately when overpaying', () => {
-  test('on page reload', async ({
-    page,
-    popup,
-    persistentContext: context,
-  }) => {
+  test('on page reload', async ({ page, popup, context }) => {
     const outgoingPaymentCreatedCallback = spy<
       [{ id: string; receiver: string }],
       void
@@ -91,7 +87,7 @@ test.describe('should not pay immediately when overpaying', () => {
   test('on page navigation - URL param change', async ({
     page,
     popup,
-    persistentContext: context,
+    context,
   }) => {
     const outgoingPaymentCreatedCallback = spy<
       [{ id: string; receiver: string }],
@@ -163,7 +159,7 @@ test.describe('should not pay immediately when overpaying', () => {
 test('should pay immediately on page navigation (clears overpaying)', async ({
   page,
   popup,
-  persistentContext: context,
+  context,
 }) => {
   const outgoingPaymentCreatedCallback = spy<
     [{ id: string; receiver: string }],

--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -20,7 +20,7 @@ import { disconnectWallet, fillPopup } from './pages/popup';
 test('Reconnect to test wallet with automatic key addition', async ({
   page,
   popup,
-  persistentContext: context,
+  context,
   background,
   i18n,
 }) => {

--- a/tests/e2e/walletBudget.spec.ts
+++ b/tests/e2e/walletBudget.spec.ts
@@ -62,7 +62,7 @@ for (const testCase of TEST_CASES) {
 
     test.beforeEach(
       'connectWallet',
-      async ({ persistentContext: context, background, popup, i18n }) => {
+      async ({ context, background, popup, i18n }) => {
         await connectWallet(context, background, popup, i18n, {
           walletAddressUrl,
           amount: String(INITIAL_AMOUNT),
@@ -75,12 +75,7 @@ for (const testCase of TEST_CASES) {
       await disconnectWallet(popup);
     });
 
-    test(testCase.name, async ({
-      persistentContext: context,
-      background,
-      popup,
-      page,
-    }) => {
+    test(testCase.name, async ({ context, background, popup, page }) => {
       const settingsLink = popup.locator(`[href="/settings"]`);
       const budgetTab = popup.getByRole('tab', { name: 'Budget' });
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

`persistentContext` as identifier was required when we were declaring it on worker scope. With test scope, we can directly call it `context` (overriding default `context`)
i.e. we cannot declare same identifier in different `scope`, but now we use `test` scope only (https://github.com/interledger/web-monetization-extension/pull/879)

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Rename `persistentContext` to `context`