### PR TITLE
chore(tests/e2e): make `env.d.ts` source of truth for env vars

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -49,7 +49,6 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
-          TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
           TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
           TEST_WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
           TEST_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -50,7 +50,6 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
           PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
-          TEST_WALLET_ORIGIN: ${{ vars.E2E_WALLET_URL_ORIGIN }}
           TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
           TEST_WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
           TEST_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -38,7 +38,7 @@ To get the `TEST_WALLET_KEY_ID`, `TEST_WALLET_PRIVATE_KEY` and `TEST_WALLET_PUBL
        .join('\n'),
    );
    ```
-1. Then copy `TEST_WALLET_PUBLIC_KEY` key to https://rafiki.money/settings/developer-keys under your wallet address.
+1. Then copy `TEST_WALLET_PUBLIC_KEY` key to https://wallet.interledger-test.dev/settings/developer-keys under your wallet address.
 1. Now you're ready to run the tests.
 
 ### How to run in end-to-end tests in GitHub

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,24 +15,9 @@ Make sure you run `pnpm build chrome` before running tests.
 1. Copy `tests/e2e/.env.example` to `tests/e2e/.env`
 2. Update `tests/e2e/.env` with your secrets.
 
-| Environment Variable          | Description                                                 | Secret? | Optional? |
-| ----------------------------- | ----------------------------------------------------------- | ------- | --------- |
-| `TEST_WALLET_ORIGIN`          | URL origin of the test wallet                               | -       | -         |
-| `TEST_WALLET_USERNAME`        | -- Login email for the test wallet                          | -       | -         |
-| `TEST_WALLET_PASSWORD`        | -- Login password for the test wallet                       | Yes     | -         |
-| `TEST_WALLET_ADDRESS_URL`     | Your wallet address URL that will be connected to extension | -       | -         |
-| `TEST_WALLET_KEY_ID`          | ID of the key that will be connected to extension (UUID v4) | -       | -         |
-| `TEST_WALLET_PRIVATE_KEY`     | Private key (hex-encoded Ed25519 private key)               | Yes     | -         |
-| `TEST_WALLET_PUBLIC_KEY`      | Public key (base64-encoded Ed25519 public key)              | -       | -         |
-| `FYNBOS_WALLET_ADDRESS_URL`   | Fynbos wallet address (used for Fynbos specific tests only) | -       | Yes       |
-| `FYNBOS_USERNAME`             | -- Login email for Fynbos wallet                            | -       | Yes       |
-| `FYNBOS_PASSWORD`             | -- Login password for Fynbos wallet                         | Yes     | Yes       |
-| `CHIMONEY_WALLET_ORIGIN`      | Chimoney wallet dashboard URL (for Chimoney specific tests) | -       | Yes       |
-| `CHIMONEY_WALLET_ADDRESS_URL` | -- Chimoney wallet address                                  | -       | Yes       |
-| `CHIMONEY_USERNAME`           | -- Login email for Chimoney wallet                          | -       | Yes       |
-| `CHIMONEY_PASSWORD`           | -- Login password for Chimoney wallet                       | Yes     | Yes       |
+Environment variables for test are defined in [`env.d.ts` as `TestEnvVars`](../tests/e2e/env.d.ts).
 
-To get the `TEST_WALLET_KEY_ID`, `TEST_WALLET_PRIVATE_KEY` and `TEST_WALLET_PUBLIC_KEY`:
+To get the `TEST_WALLET_KEY_ID`, `TEST_WALLET_PRIVATE_KEY` and `TEST_WALLET_PUBLIC_KEY` vars, follow these steps:
 
 1. Load the extension in browser (via `chrome://extensions/`)
    - Once the extension is loaded, it'll generate a key-pair that we will need to connect with our wallet.

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -1,9 +1,8 @@
 # Used when running tests locally.
 # In CI, we pass these in via the environment variables directly.
+# See TestEnvVars in tests/e2e/env.d.ts for details of each variable
 PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1
 
-# Can replace with a localhost instance if needed. Ensure doesn't end with /
-TEST_WALLET_ORIGIN=https://wallet.interledger-test.dev
 TEST_WALLET_USERNAME=user@email.com
 TEST_WALLET_PASSWORD=some-password
 

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { test as setup, expect } from './fixtures/base';
 import { authFile } from './fixtures/helpers';
+import { TEST_WALLET_ORIGIN } from './helpers/testWallet';
 import { getJWKS } from '@/shared/helpers';
 import type { JWK } from '@interledger/open-payments';
 
@@ -13,8 +14,7 @@ import type { JWK } from '@interledger/open-payments';
 setup('authenticate', async ({ page }) => {
   setup.skip(existsSync(authFile), 'Already authenticated');
 
-  const { TEST_WALLET_ORIGIN, TEST_WALLET_USERNAME, TEST_WALLET_PASSWORD } =
-    process.env;
+  const { TEST_WALLET_USERNAME, TEST_WALLET_PASSWORD } = process.env;
 
   expect(TEST_WALLET_ORIGIN).toBeDefined();
   expect(TEST_WALLET_USERNAME).toBeDefined();

--- a/tests/e2e/env.d.ts
+++ b/tests/e2e/env.d.ts
@@ -1,35 +1,40 @@
+interface TestEnvVars {
+  /** Login email for the test wallet */
+  TEST_WALLET_USERNAME: string;
+  /** Login password for the test wallet @secret */
+  TEST_WALLET_PASSWORD: string;
+  /** Wallet address that we'll use to connect with the extension */
+  TEST_WALLET_ADDRESS_URL: string;
+
+  /** ID of the key that will be connected to extension (UUID v4) */
+  TEST_WALLET_KEY_ID: string;
+  /** Base-64 public key */
+  TEST_WALLET_PUBLIC_KEY: string;
+  /** Hex-encoded private key @secret */
+  TEST_WALLET_PRIVATE_KEY: string;
+
+  // If either of following is not provided, relevant tests will be skipped.
+  /** Fynbos wallet address (used for Fynbos specific tests only) */
+  FYNBOS_WALLET_ADDRESS_URL: string | undefined;
+  /** Login email for Fynbos wallet */
+  FYNBOS_USERNAME: string | undefined;
+  /** Login password for Fynbos wallet @secret */
+  FYNBOS_PASSWORD: string | undefined;
+
+  // If either of following is not provided, relevant tests will be skipped.
+  /** Chimoney wallet address (used for Chimoney specific tests only) */
+  CHIMONEY_WALLET_ADDRESS_URL: string | undefined;
+  /** Chimoney wallet URL origin (without trailing /) */
+  CHIMONEY_WALLET_ORIGIN: string | undefined;
+  /** Login email for Chimoney wallet */
+  CHIMONEY_USERNAME: string | undefined;
+  /** Login password for Chimoney wallet @secret */
+  CHIMONEY_PASSWORD: string | undefined;
+}
+
 declare global {
   namespace NodeJS {
-    interface ProcessEnv {
-      /** Can replace with a localhost instance if needed */
-      TEST_WALLET_ORIGIN: string;
-      TEST_WALLET_USERNAME: string;
-      TEST_WALLET_PASSWORD: string;
-      /** Wallet address that we'll use to connect with the extension */
-      TEST_WALLET_ADDRESS_URL: string;
-      /** UUID v4 */
-      TEST_WALLET_KEY_ID: string;
-      /** Base-64 public key */
-      TEST_WALLET_PUBLIC_KEY: string;
-      /** Hex-encoded private key */
-      TEST_WALLET_PRIVATE_KEY: string;
-
-      /** Fynbos wallet address (used for Fynbos specific tests only) */
-      FYNBOS_WALLET_ADDRESS_URL: string | undefined;
-      /** Login email for Fynbos wallet */
-      FYNBOS_USERNAME: string | undefined;
-      /** Login password for Fynbos wallet*/
-      FYNBOS_PASSWORD: string | undefined;
-
-      /** Chimoney wallet address (used for Chimoney specific tests only) */
-      CHIMONEY_WALLET_ADDRESS_URL: string | undefined;
-      /** Chimoney wallet URL origin (without trailing /) */
-      CHIMONEY_WALLET_ORIGIN: string | undefined;
-      /** Login email for Chimoney wallet */
-      CHIMONEY_USERNAME: string | undefined;
-      /** Login password for Chimoney wallet*/
-      CHIMONEY_PASSWORD: string | undefined;
-    }
+    interface ProcessEnv extends TestEnvVars {}
   }
 
   namespace window {

--- a/tests/e2e/helpers/testWallet.ts
+++ b/tests/e2e/helpers/testWallet.ts
@@ -8,11 +8,11 @@ import {
 import { fillPopup, type Popup, type ConnectDetails } from '../pages/popup';
 import { getContinueWaitTime, waitForWelcomePage } from './common';
 
-export const KEYS_PAGE_URL =
-  'https://wallet.interledger-test.dev/settings/developer-keys';
-export const LOGIN_PAGE_URL =
-  'https://wallet.interledger-test.dev/auth/login?callbackUrl=%2Fsettings%2Fdeveloper-keys';
+export const TEST_WALLET_ORIGIN = 'https://wallet.interledger-test.dev';
 export const API_URL_ORIGIN = 'https://api.wallet.interledger-test.dev';
+export const KEYS_PAGE_URL = `${TEST_WALLET_ORIGIN}/settings/developer-keys`;
+export const LOGIN_PAGE_URL = `${TEST_WALLET_ORIGIN}/auth/login?callbackUrl=%2Fsettings%2Fdeveloper-keys`;
+
 export const DEFAULT_CONTINUE_WAIT_MS = 1000;
 
 export const DEFAULT_KEY_INFO: KeyInfo = {

--- a/tests/e2e/helpers/testWallet.ts
+++ b/tests/e2e/helpers/testWallet.ts
@@ -11,7 +11,7 @@ import { getContinueWaitTime, waitForWelcomePage } from './common';
 export const TEST_WALLET_ORIGIN = 'https://wallet.interledger-test.dev';
 export const API_URL_ORIGIN = 'https://api.wallet.interledger-test.dev';
 export const KEYS_PAGE_URL = `${TEST_WALLET_ORIGIN}/settings/developer-keys`;
-export const LOGIN_PAGE_URL = `${TEST_WALLET_ORIGIN}/auth/login?callbackUrl=%2Fsettings%2Fdeveloper-keys`;
+export const LOGIN_PAGE_URL = `${TEST_WALLET_ORIGIN}/auth/login?callbackUrl=${encodeURIComponent('/settings/developer-keys')}`;
 
 export const DEFAULT_CONTINUE_WAIT_MS = 1000;
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Instead of defining vars twice - once in markdown table, and again in env.d.ts, make env.d.ts source of truth. Defining in both places was getting out of hand.

## Changes proposed in this pull request

- Update details in env.d.ts
- Create separate top-level interface `TestEnvVars`
- Remove unnecessary `TEST_WALLET_ORIGIN` variable (we can't really use localhost, as so many other dependent variables in test)
