### PR TITLE
refactor(bg): split create & complete outgoing payment grant

### DIFF
--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -129,7 +129,6 @@ export class OutgoingPaymentGrantService {
   async completeOutgoingPaymentGrant(
     walletAmount: WalletAmount,
     walletAddress: WalletAddress,
-    recurring: boolean,
     intent: InteractionIntent,
     existingTabId?: number,
   ): Promise<GrantDetails> {
@@ -169,7 +168,7 @@ export class OutgoingPaymentGrantService {
       );
     }
 
-    this.grant = this.buildGrantDetails(continuation, recurring, walletAmount);
+    this.grant = this.buildGrantDetails(continuation, walletAmount);
     await this.persistGrantDetails(this.grant);
 
     await redirectToWelcomeScreen(
@@ -402,9 +401,9 @@ export class OutgoingPaymentGrantService {
 
   private buildGrantDetails(
     continuation: Grant,
-    recurring: boolean,
     amount: WalletAmount,
   ): GrantDetails {
+    const recurring = !!amount.interval;
     return {
       type: recurring ? 'recurring' : 'one-time',
       amount: amount as Required<WalletAmount>,

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -129,17 +129,11 @@ export class OutgoingPaymentGrantService {
   async completeOutgoingPaymentGrant(
     walletAmount: WalletAmount,
     walletAddress: WalletAddress,
+    grant: PendingGrant,
+    clientNonce: ReturnType<Crypto['randomUUID']>,
     intent: InteractionIntent,
     existingTabId?: number,
   ): Promise<GrantDetails> {
-    const clientNonce = crypto.randomUUID();
-    const grant = await this.createOutgoingPaymentGrant(
-      clientNonce,
-      walletAddress,
-      walletAmount,
-      intent,
-    );
-
     const { interactRef, hash, tabId } = await this.getInteractionInfo(
       grant.interact.redirect,
       existingTabId,
@@ -223,7 +217,7 @@ export class OutgoingPaymentGrantService {
     return newToken;
   }
 
-  private async createOutgoingPaymentGrant(
+  async createOutgoingPaymentGrant(
     clientNonce: string,
     walletAddress: WalletAddress,
     amount: WalletAmount,

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -129,8 +129,10 @@ export class OutgoingPaymentGrantService {
   async completeOutgoingPaymentGrant(
     walletAmount: WalletAmount,
     walletAddress: WalletAddress,
-    grant: PendingGrant,
-    clientNonce: ReturnType<Crypto['randomUUID']>,
+    {
+      grant,
+      clientNonce,
+    }: { grant: PendingGrant; clientNonce: ReturnType<Crypto['randomUUID']> },
     intent: InteractionIntent,
     existingTabId?: number,
   ): Promise<GrantDetails> {
@@ -218,11 +220,11 @@ export class OutgoingPaymentGrantService {
   }
 
   async createOutgoingPaymentGrant(
-    clientNonce: string,
     walletAddress: WalletAddress,
     amount: WalletAmount,
     intent: InteractionIntent,
   ) {
+    const clientNonce = crypto.randomUUID();
     try {
       const grant = await this.openPaymentsService.client.grant.request(
         { url: walletAddress.authServer },
@@ -265,7 +267,10 @@ export class OutgoingPaymentGrantService {
         );
       }
 
-      return grant;
+      return {
+        grant,
+        clientNonce,
+      };
     } catch (error) {
       if (isInvalidClientError(error)) {
         if (intent !== InteractionIntent.FUNDS) {

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -25,7 +25,6 @@ import {
   GrantResult,
   InteractionIntent,
   redirectToWelcomeScreen,
-  toAmount,
 } from '@/background/utils';
 
 interface InteractionParams {
@@ -128,18 +127,13 @@ export class OutgoingPaymentGrantService {
   }
 
   async completeOutgoingPaymentGrant(
-    amount: string,
+    walletAmount: WalletAmount,
     walletAddress: WalletAddress,
     recurring: boolean,
     intent: InteractionIntent,
     existingTabId?: number,
   ): Promise<GrantDetails> {
     const clientNonce = crypto.randomUUID();
-    const walletAmount = toAmount({
-      value: amount,
-      recurring,
-      assetScale: walletAddress.assetScale,
-    });
     const grant = await this.createOutgoingPaymentGrant(
       clientNonce,
       walletAddress,

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -129,10 +129,7 @@ export class OutgoingPaymentGrantService {
   async completeOutgoingPaymentGrant(
     walletAmount: WalletAmount,
     walletAddress: WalletAddress,
-    {
-      grant,
-      clientNonce,
-    }: { grant: PendingGrant; clientNonce: ReturnType<Crypto['randomUUID']> },
+    { grant, nonce }: Awaited<ReturnType<this['createOutgoingPaymentGrant']>>,
     intent: InteractionIntent,
     existingTabId?: number,
   ): Promise<GrantDetails> {
@@ -142,7 +139,7 @@ export class OutgoingPaymentGrantService {
     );
 
     await this.verifyInteractionHash(
-      clientNonce,
+      nonce,
       grant.interact.finish,
       interactRef,
       hash,
@@ -224,7 +221,7 @@ export class OutgoingPaymentGrantService {
     amount: WalletAmount,
     intent: InteractionIntent,
   ) {
-    const clientNonce = crypto.randomUUID();
+    const nonce = crypto.randomUUID();
     try {
       const grant = await this.openPaymentsService.client.grant.request(
         { url: walletAddress.authServer },
@@ -255,7 +252,7 @@ export class OutgoingPaymentGrantService {
             finish: {
               method: 'redirect',
               uri: OPEN_PAYMENTS_REDIRECT_URL,
-              nonce: clientNonce,
+              nonce: nonce,
             },
           },
         },
@@ -267,10 +264,7 @@ export class OutgoingPaymentGrantService {
         );
       }
 
-      return {
-        grant,
-        clientNonce,
-      };
+      return { grant, nonce };
     } catch (error) {
       if (isInvalidClientError(error)) {
         if (intent !== InteractionIntent.FUNDS) {

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -147,7 +147,6 @@ export class OutgoingPaymentGrantService {
       intent,
     );
 
-    this.events.emit('request_popup_close');
     const { interactRef, hash, tabId } = await this.getInteractionInfo(
       grant.interact.redirect,
       existingTabId,
@@ -305,6 +304,7 @@ export class OutgoingPaymentGrantService {
       reject(new Error('Could not create/update tab'));
       return promise;
     }
+    this.events.emit('request_popup_close');
 
     const tabCloseListener: TabRemovedCallback = (tabId) => {
       if (tabId !== tab.id) return;

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -105,10 +105,8 @@ export class WalletService {
     });
     const intent = InteractionIntent.CONNECT;
     try {
-      const clientNonce = crypto.randomUUID();
       const grant =
         await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
-          clientNonce,
           walletAddress,
           walletAmount,
           intent,
@@ -117,7 +115,6 @@ export class WalletService {
         walletAmount,
         walletAddress,
         grant,
-        clientNonce,
         intent,
         existingTab?.id,
       );
@@ -145,10 +142,8 @@ export class WalletService {
             existingTab?.id,
           );
           this.setConnectState('connecting');
-          const clientNonce = crypto.randomUUID();
           const grant =
             await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
-              clientNonce,
               walletAddress,
               walletAmount,
               intent,
@@ -157,7 +152,6 @@ export class WalletService {
             walletAmount,
             walletAddress,
             grant,
-            clientNonce,
             intent,
             tabId,
           );
@@ -253,11 +247,9 @@ export class WalletService {
       recurring,
       assetScale: walletAddress.assetScale,
     });
-    const clientNonce = crypto.randomUUID();
     const intent = InteractionIntent.FUNDS;
     const grant =
       await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
-        clientNonce,
         walletAddress,
         walletAmount,
         intent,
@@ -266,7 +258,6 @@ export class WalletService {
       walletAmount,
       walletAddress,
       grant,
-      clientNonce,
       intent,
     );
 
@@ -299,11 +290,9 @@ export class WalletService {
       recurring,
       assetScale: walletAddress.assetScale,
     });
-    const clientNonce = crypto.randomUUID();
     const intent = InteractionIntent.UPDATE_BUDGET;
     const grant =
       await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
-        clientNonce,
         walletAddress,
         walletAmount,
         intent,
@@ -312,7 +301,6 @@ export class WalletService {
       walletAmount,
       walletAddress,
       grant,
-      clientNonce,
       intent,
     );
 

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -103,11 +103,22 @@ export class WalletService {
       recurring,
       assetScale: walletAddress.assetScale,
     });
+    const intent = InteractionIntent.CONNECT;
     try {
+      const clientNonce = crypto.randomUUID();
+      const grant =
+        await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
+          clientNonce,
+          walletAddress,
+          walletAmount,
+          intent,
+        );
       await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
         walletAmount,
         walletAddress,
-        InteractionIntent.CONNECT,
+        grant,
+        clientNonce,
+        intent,
         existingTab?.id,
       );
     } catch (error) {
@@ -134,10 +145,20 @@ export class WalletService {
             existingTab?.id,
           );
           this.setConnectState('connecting');
+          const clientNonce = crypto.randomUUID();
+          const grant =
+            await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
+              clientNonce,
+              walletAddress,
+              walletAmount,
+              intent,
+            );
           await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
             walletAmount,
             walletAddress,
-            InteractionIntent.CONNECT,
+            grant,
+            clientNonce,
+            intent,
             tabId,
           );
         } catch (error) {
@@ -232,10 +253,21 @@ export class WalletService {
       recurring,
       assetScale: walletAddress.assetScale,
     });
+    const clientNonce = crypto.randomUUID();
+    const intent = InteractionIntent.FUNDS;
+    const grant =
+      await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
+        clientNonce,
+        walletAddress,
+        walletAmount,
+        intent,
+      );
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
       walletAmount,
       walletAddress,
-      InteractionIntent.FUNDS,
+      grant,
+      clientNonce,
+      intent,
     );
 
     await this.storage.setState({ out_of_funds: false });
@@ -267,10 +299,21 @@ export class WalletService {
       recurring,
       assetScale: walletAddress.assetScale,
     });
+    const clientNonce = crypto.randomUUID();
+    const intent = InteractionIntent.UPDATE_BUDGET;
+    const grant =
+      await this.outgoingPaymentGrantService.createOutgoingPaymentGrant(
+        clientNonce,
+        walletAddress,
+        walletAmount,
+        intent,
+      );
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
       walletAmount,
       walletAddress,
-      InteractionIntent.UPDATE_BUDGET,
+      grant,
+      clientNonce,
+      intent,
     );
 
     // Revoke all existing grants.

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -25,6 +25,7 @@ import {
   GrantResult,
   redirectToWelcomeScreen,
   ensureTabExists,
+  toAmount,
 } from '@/background/utils';
 import { KeyAutoAddService } from '@/background/services/keyAutoAdd';
 import { generateEd25519KeyPair, exportJWK } from '@/shared/crypto';
@@ -97,9 +98,14 @@ export class WalletService {
     const [existingTab] = await this.browser.tabs.query({
       url: this.browser.runtime.getURL(APP_URL),
     });
+    const walletAmount = toAmount({
+      value: amount,
+      recurring,
+      assetScale: walletAddress.assetScale,
+    });
     try {
       await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
-        amount,
+        walletAmount,
         walletAddress,
         recurring,
         InteractionIntent.CONNECT,
@@ -130,7 +136,7 @@ export class WalletService {
           );
           this.setConnectState('connecting');
           await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
-            amount,
+            walletAmount,
             walletAddress,
             recurring,
             InteractionIntent.CONNECT,
@@ -219,10 +225,18 @@ export class WalletService {
       'oneTimeGrant',
       'recurringGrant',
     ]);
+    if (!walletAddress) {
+      throw new Error('Unexpected: walletAddress not found');
+    }
 
+    const walletAmount = toAmount({
+      value: amount,
+      recurring,
+      assetScale: walletAddress.assetScale,
+    });
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
-      amount,
-      walletAddress!,
+      walletAmount,
+      walletAddress,
       recurring,
       InteractionIntent.FUNDS,
     );
@@ -247,10 +261,18 @@ export class WalletService {
       'oneTimeGrant',
       'recurringGrant',
     ]);
+    if (!walletAddress) {
+      throw new Error('Unexpected: walletAddress not found');
+    }
 
+    const walletAmount = toAmount({
+      value: amount,
+      recurring,
+      assetScale: walletAddress.assetScale,
+    });
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
-      amount,
-      walletAddress!,
+      walletAmount,
+      walletAddress,
       recurring,
       InteractionIntent.UPDATE_BUDGET,
     );

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -107,7 +107,6 @@ export class WalletService {
       await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
         walletAmount,
         walletAddress,
-        recurring,
         InteractionIntent.CONNECT,
         existingTab?.id,
       );
@@ -138,7 +137,6 @@ export class WalletService {
           await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
             walletAmount,
             walletAddress,
-            recurring,
             InteractionIntent.CONNECT,
             tabId,
           );
@@ -237,7 +235,6 @@ export class WalletService {
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
       walletAmount,
       walletAddress,
-      recurring,
       InteractionIntent.FUNDS,
     );
 
@@ -273,7 +270,6 @@ export class WalletService {
     await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
       walletAmount,
       walletAddress,
-      recurring,
       InteractionIntent.UPDATE_BUDGET,
     );
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

Seems counterintuitive, but:
- Helps with https://github.com/interledger/web-monetization-extension/pull/944 to show correct step (when initial create grant fails, and then we switch to adding key).
- Helps with https://github.com/interledger/web-monetization-extension/pull/946 as we open tab at right time, instead of before `createOutgoingPaymentGrant` (as create grant doesn't rely on browser tabs, only complete grant does).

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
