### PR TITLE
fix(keyAutoAdd): revert abort on tab navigated away

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -193,9 +193,6 @@
   "connectWallet_error_tabClosed": {
     "message": "Wallet connection cancelled. The tab was closed before completion."
   },
-  "connectWallet_error_tabNavigatedAway": {
-    "message": "Wallet connection cancelled. You switched to some other website before completion."
-  },
   "connectWallet_error_grantRejected": {
     "message": "Wallet connection cancelled. The request was not authorized."
   },

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -390,8 +390,7 @@ export class WalletService {
       await keyAutoAdd.addPublicKeyToWallet(walletAddress, tabId);
     } catch (error) {
       const isTabClosed = error.key === 'connectWallet_error_tabClosed';
-      const isTabNavAway = error.key === 'connectWallet_error_tabNavigatedAway';
-      if (tabId && (!isTabClosed || isTabNavAway)) {
+      if (tabId && !isTabClosed) {
         await redirectToWelcomeScreen(
           this.browser,
           tabId,

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -513,8 +513,7 @@ function isAutoKeyAddFailed(state: ConnectTransientState) {
   if (state?.status === 'error') {
     return (
       isErrorWithKey(state.error) &&
-      state.error.key !== 'connectWallet_error_tabClosed' &&
-      state.error.key !== 'connectWallet_error_tabNavigatedAway'
+      state.error.key !== 'connectWallet_error_tabClosed'
     );
   } else if (state?.status === 'error:key') {
     return (


### PR DESCRIPTION
## Context

Fixes https://github.com/interledger/web-monetization-extension/issues/952
Reverts https://github.com/interledger/web-monetization-extension/pull/943

## Changes proposed in this pull request

It didn't account for Firefox new tab being opened without a URL.
Removing "abort on tab navigate away" feature in favor of other things we added (like highlight tab, message in popup) and the overall connect timeout (https://github.com/interledger/web-monetization-extension/issues/948) that we'll add soon.
Not handling by adding "new tab" URLs into account, as different browsers can have different "new tab" URLs that we can't keep taking into account. Also, if user has extension for new tab, they can change new tab URL too.

This is a hotfix. We may come back to this in future some day when it's most stable.
