### PR TITLE
perf(popup): remove framer-motion, add custom `FadeInOut`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "class-variance-authority": "^0.7.1",
     "crypto-browserify": "^3.12.1",
     "date-fns": "^4.1.0",
-    "framer-motion": "^11.11.17",
     "http-message-signatures": "^1.0.4",
     "httpbis-digest-headers": "^1.0.0",
     "iso8601-duration": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      framer-motion:
-        specifier: ^11.11.17
-        version: 11.11.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       http-message-signatures:
         specifier: ^1.0.4
         version: 1.0.4
@@ -2244,20 +2241,6 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-
-  framer-motion@11.11.17:
-    resolution: {integrity: sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0
-      react-dom: ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -5988,13 +5971,6 @@ snapshots:
       mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
-
-  framer-motion@11.11.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      tslib: 2.6.2
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
 

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -4,7 +4,6 @@ import {
   TranslationContextProvider,
 } from '@/pages/shared/lib/context';
 import { MessageContextProvider, WaitForStateLoad } from '@/popup/lib/context';
-import { LazyMotion, domAnimation } from 'framer-motion';
 import React from 'react';
 import browser from 'webextension-polyfill';
 import { ProtectedRoute } from '@/popup/components/ProtectedRoute';
@@ -73,7 +72,7 @@ const router = createMemoryRouter(routes);
 
 export const Popup = () => {
   return (
-    <LazyMotion features={domAnimation} strict>
+    <>
       <BrowserContextProvider browser={browser}>
         <MessageContextProvider>
           <TranslationContextProvider>
@@ -83,6 +82,6 @@ export const Popup = () => {
           </TranslationContextProvider>
         </MessageContextProvider>
       </BrowserContextProvider>
-    </LazyMotion>
+    </>
   );
 };

--- a/src/pages/popup/components/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/components/ErrorKeyRevoked.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { AnimatePresence, m } from 'framer-motion';
 import { AutoKeyAddConsent } from '@/pages/shared/components/AutoKeyAddConsent';
 import { WarningSign } from '@/pages/shared/components/Icons';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { Code } from '@/pages/shared/components/ui/Code';
+import { FadeInOut } from '@/pages/shared/components/FadeInOut';
 import { useTranslation } from '@/pages/shared/lib/context';
 import { useLocalStorage } from '@/pages/shared/lib/hooks';
 import type { PopupStore } from '@/shared/types';
@@ -34,17 +34,17 @@ export const ErrorKeyRevoked = ({
 
   if (screen === 'main') {
     return (
-      <AnimatePresence mode="sync">
+      <>
         <MainScreen
           disconnectWallet={disconnectWallet}
           onDisconnect={onDisconnect}
           setScreen={setScreen}
         />
-      </AnimatePresence>
+      </>
     );
   } else if (screen === 'consent-reconnect') {
     return (
-      <AnimatePresence mode="sync">
+      <>
         <AutoKeyAddConsent
           onAccept={async () => {
             try {
@@ -59,11 +59,11 @@ export const ErrorKeyRevoked = ({
           onDecline={() => setScreen('manual-reconnect')}
           intent="RECONNECT_WALLET"
         />
-      </AnimatePresence>
+      </>
     );
   } else {
     return (
-      <AnimatePresence mode="sync">
+      <>
         <ManualReconnectScreen
           info={info}
           reconnectWallet={reconnectWallet}
@@ -72,7 +72,7 @@ export const ErrorKeyRevoked = ({
             onReconnect?.();
           }}
         />
-      </AnimatePresence>
+      </>
     );
   }
 };
@@ -105,7 +105,7 @@ const MainScreen = ({
   };
 
   return (
-    <m.div exit={{ opacity: 0 }} className="space-y-4 text-sm">
+    <div className="space-y-4 text-sm">
       <div className="flex gap-2 rounded-md bg-error p-2">
         <WarningSign className="size-6 text-error" />
         <h3 className="text-base font-medium text-error">
@@ -114,26 +114,22 @@ const MainScreen = ({
       </div>
       <p className="text-sm text-medium">{t('keyRevoked_error_text')}</p>
 
-      {errorMsg && (
-        <m.div
-          animate={{ opacity: 1 }}
-          initial={{ opacity: 0 }}
-          transition={{ duration: 0.5 }}
-          className="rounded-sm px-2 text-sm text-error"
-        >
-          {errorMsg}
-        </m.div>
-      )}
+      <FadeInOut
+        visible={!!errorMsg}
+        className="rounded-sm px-2 text-sm text-error"
+      >
+        {errorMsg}
+      </FadeInOut>
 
-      <m.form className="flex flex-col items-stretch gap-4">
+      <form className="flex flex-col items-stretch gap-4">
         <Button onClick={() => requestDisconnect()} loading={loading}>
           {t('keyRevoked_action_disconnect')}
         </Button>
         <Button onClick={() => setScreen('consent-reconnect')}>
           {t('keyRevoked_action_reconnect')}
         </Button>
-      </m.form>
-    </m.div>
+      </form>
+    </div>
   );
 };
 
@@ -174,10 +170,9 @@ const ManualReconnectScreen = ({
   };
 
   return (
-    <m.form
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
+    <FadeInOut
+      as="form"
+      visible={true}
       className="flex flex-col items-stretch gap-4"
       onSubmit={(ev) => {
         ev.preventDefault();
@@ -196,20 +191,16 @@ const ManualReconnectScreen = ({
         <Code className="text-xs" value={info.publicKey} />
       </div>
 
-      {errors?.root?.message && (
-        <m.div
-          animate={{ opacity: 1 }}
-          initial={{ opacity: 0 }}
-          transition={{ duration: 0.5 }}
-          className="rounded-sm px-2 text-sm text-error"
-        >
-          {errors.root.message}
-        </m.div>
-      )}
+      <FadeInOut
+        visible={!!errors.root?.message}
+        className="rounded-sm px-2 text-sm text-error"
+      >
+        {errors.root?.message}
+      </FadeInOut>
 
       <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
         {t('keyRevoked_action_reconnectBtn')}
       </Button>
-    </m.form>
+    </FadeInOut>
   );
 };

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { AnimatePresence, m } from 'framer-motion';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
+import { FadeInOut } from '@/pages/shared/components/FadeInOut';
 import { roundWithPrecision } from '@/pages/shared/lib/utils';
 import { cn, type ErrorWithKeyLike } from '@/shared/helpers';
 import { useMessage, useTranslation } from '@/popup/lib/context';
@@ -72,31 +72,20 @@ export const PayWebsiteForm = () => {
       onSubmit={onSubmit}
       data-testid="pay-form"
     >
-      <AnimatePresence mode="sync">
-        {errors.pay || !!payStatus ? (
-          <m.div
-            transition={{ duration: 0.3, bounce: 0 }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="overflow-hidden"
-          >
-            <div
-              className={cn(
-                'break-word flex items-center gap-2 rounded-xl border px-3 py-2',
-                errors.pay
-                  ? errors.pay?.info?.key.includes('_warn_')
-                    ? 'border-orange-600 bg-orange-100 text-orange-800'
-                    : 'border-red-300 bg-red-500/10'
-                  : 'border-green-500 bg-green-500/10 text-secondary-dark',
-              )}
-              role="alert"
-            >
-              <div>{payStatus?.message || errors.pay?.message}</div>
-            </div>
-          </m.div>
-        ) : null}
-      </AnimatePresence>
+      <FadeInOut
+        visible={!!errors.pay || !!payStatus}
+        className={cn(
+          'break-word flex items-center gap-2 rounded-xl border px-3 py-2',
+          errors.pay
+            ? errors.pay?.info?.key.includes('_warn_')
+              ? 'border-orange-600 bg-orange-100 text-orange-800'
+              : 'border-red-300 bg-red-500/10'
+            : 'border-green-500 bg-green-500/10 text-secondary-dark',
+        )}
+        role="alert"
+      >
+        <div>{payStatus?.message || errors.pay?.message}</div>
+      </FadeInOut>
 
       <InputAmount
         id="payAmount"
@@ -134,16 +123,7 @@ export const PayWebsiteForm = () => {
         loading={isSubmitting}
         aria-label={t('pay_action_pay')}
       >
-        <AnimatePresence mode="popLayout" initial={false}>
-          <m.span
-            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
-            initial={{ opacity: 0, y: -25 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 25 }}
-          >
-            {t('pay_action_pay')}
-          </m.span>
-        </AnimatePresence>
+        {t('pay_action_pay')}
       </Button>
     </form>
   );

--- a/src/pages/shared/components/FadeInOut.tsx
+++ b/src/pages/shared/components/FadeInOut.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { cn } from '@/shared/helpers';
+
+type ElementType = keyof React.JSX.IntrinsicElements;
+const defaultElem: ElementType = 'div';
+
+type Props<T extends ElementType> = {
+  visible: boolean;
+  as?: T;
+} & React.HTMLAttributes<T>;
+
+export const FadeInOut = <T extends ElementType = typeof defaultElem>({
+  as: El = defaultElem as T,
+  visible: visibleInitial,
+  children,
+  className = '',
+  ...restProps
+}: Props<T>) => {
+  const [visible, setVisible] = React.useState<null | boolean>(null);
+  React.useEffect(() => {
+    setTimeout(() => setVisible(visibleInitial), 0);
+  }, [visibleInitial]);
+
+  return (
+    // @ts-expect-error idk anymore
+    <El
+      className={cn(
+        'duration-300',
+        className,
+        'transition-opacity',
+        visible ? 'opacity-100' : 'opacity-0 sr-only',
+      )}
+      {...restProps}
+    >
+      {visible && children}
+    </El>
+  );
+};


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/817

## Changes proposed in this pull request

- Add FadeInOut component
   - Takes element props & `as`, to avoid unnecessary nesting (div-soup) in final HTML output
- Remove framer-motion
- Replaced some JSX with Fragment, to avoid too many nesting/whitespace updates

```diff
-  dist/chrome/popup/popup.js                               400.6kb
+  dist/chrome/popup/popup.js                               321.6kb

- chrome.zip   1.02 MB
+ chrome.zip 996.43 KB
```
