### PR TITLE
test(e2e/out-of-funds): don't wait payment complete to deplete funds

### DIFF
--- a/tests/e2e/out-of-funds.spec.ts
+++ b/tests/e2e/out-of-funds.spec.ts
@@ -115,15 +115,10 @@ for (const testCase of TEST_CASES) {
         // Send two payments so grantSpentAmount changes. Ideally, we'd send a single
         // payment with full amount, but:
         // https://github.com/interledger/web-monetization-extension/issues/737
-        await sendOneTimePayment(popup, amountToSend, true);
-        await expect(popup.getByRole('alert')).toHaveText(
-          i18n.getMessage('pay_state_success'),
-        );
-        await popup.reload(); // XXX: not able to send two consecutive payments in tests
-        await sendOneTimePayment(popup, amountToSend, true);
-        await expect(popup.getByRole('alert')).toHaveText(
-          i18n.getMessage('pay_state_success'),
-        );
+        await sendOneTimePayment(popup, amountToSend, false);
+        await popup.reload(); // XXX: not able to send two consecutive payments in tests, as slow
+        await sendOneTimePayment(popup, amountToSend, false);
+        await popup.reload();
         await expect(monetizationCallback).toHaveBeenCalledTimes(2);
       });
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Sometimes, depending on test wallet status, payments go complete quickly, or take long. So our tests sometimes time out.
Also, payment may not complete during polling period, so we end up showing "taking too long" message while expecting a success message.

## Changes proposed in this pull request

Don't wait for payments made to deplete funds to complete. Reduces upto 16s delay in tests, making them timeout less often.
Could've increased test timeout, but that's unnecessary as we're testing one-time payment messages separately anyway.