### PR TITLE
chore(deps): remove prettier-plugin-tailwindcss as unused

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,16 +3,4 @@ export default {
   trailingComma: 'all',
   jsxSingleQuote: false,
   semi: true,
-  plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: [
-    'classnames',
-    'clsx',
-    'ctl',
-    'cva',
-    'tw',
-    'twStyle',
-    'twMerge',
-    'twJoin',
-    'cn',
-  ],
 };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "jsdom": "^26.0.0",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
-    "prettier-plugin-tailwindcss": "^0.6.9",
     "react-scan": "^0.3.3",
     "sade": "^1.8.1",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
-      prettier-plugin-tailwindcss:
-        specifier: ^0.6.9
-        version: 0.6.9(prettier@3.5.3)
       react-scan:
         specifier: ^0.3.3
         version: 0.3.3(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react-router-dom@7.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-router@7.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(rollup@4.20.0)
@@ -3000,61 +2997,6 @@ packages:
 
   preact@10.25.4:
     resolution: {integrity: sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==}
-
-  prettier-plugin-tailwindcss@0.6.9:
-    resolution: {integrity: sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==}
-    engines: {node: '>=14.21.3'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig-melody': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-import-sort: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-multiline-arrays: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-style-order: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig-melody':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-import-sort:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-multiline-arrays:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-style-order:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -6855,10 +6797,6 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.25.4: {}
-
-  prettier-plugin-tailwindcss@0.6.9(prettier@3.5.3):
-    dependencies:
-      prettier: 3.5.3
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
## Context

This was unused since we introduced Biome. Biome will soon have their own replacement for this https://github.com/biomejs/biome/issues/1274, for this plugin as of now is unused.

## Changes proposed in this pull request

Remove the plugin.