### PR TITLE
chore(ci/nightly): publish build regardless of test status

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -93,6 +93,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-24.04
     needs: test-e2e
+    if: ${{ always() }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Context

https://github.com/interledger/web-monetization-extension/pull/1015#issuecomment-2812224927

## Changes proposed in this pull request

Publish nightly build even if tests fail. But still publish it after tests have run.
