### PR TITLE
fix(pages): don't crash when not using 3-letter currencies

### DIFF
--- a/src/pages/shared/lib/utils.test.ts
+++ b/src/pages/shared/lib/utils.test.ts
@@ -1,4 +1,8 @@
-import { formatNumber } from '@/pages/shared/lib/utils';
+import {
+  formatNumber,
+  formatCurrency,
+  getCurrencySymbol,
+} from '@/pages/shared/lib/utils';
 
 describe('formatNumber', () => {
   it('should display right format for integers', () => {
@@ -41,5 +45,54 @@ describe('formatNumber', () => {
     expect(formatNumber(0.000010009, 9, true)).toEqual('1.0009e-5');
 
     expect(formatNumber(0.000100009, 9)).toEqual('0.000100009');
+  });
+});
+
+describe('getCurrencySymbol', () => {
+  it('should return currency symbol for common cases', () => {
+    expect(getCurrencySymbol('USD')).toEqual('$');
+    expect(getCurrencySymbol('EUR')).toEqual('€');
+    expect(getCurrencySymbol('MXN')).toEqual('MX$');
+  });
+
+  it('should return currency symbol for non-standard currencies', () => {
+    expect(getCurrencySymbol('abc')).toEqual('ABC');
+    expect(getCurrencySymbol('ZZZ')).toEqual('ZZZ');
+    expect(getCurrencySymbol('AB')).toEqual('AB');
+    expect(getCurrencySymbol('ABCD')).toEqual('ABCD');
+    expect(getCurrencySymbol('ABcDe')).toEqual('ABCDE');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('should display right format for common cases', () => {
+    expect(formatCurrency(5, 'USD')).toEqual('$5.00');
+    expect(formatCurrency(0.5, 'USD')).toEqual('$0.50');
+    expect(formatCurrency(5.34, 'USD')).toEqual('$5.34');
+    expect(formatCurrency(5.34, 'EUR')).toEqual('€5.34');
+    expect(formatCurrency(5.34, 'MXN')).toEqual('MX$5.34');
+  });
+
+  it('should support custom precision', () => {
+    expect(formatCurrency(5.12, 'USD', 2)).toEqual('$5.12');
+    expect(formatCurrency(5.12, 'USD', 4)).toEqual('$5.12');
+    expect(formatCurrency(5.19, 'EUR', 1)).toEqual('€5.2');
+    expect(formatCurrency(5.12058, 'USD', 4)).toEqual('$5.1206');
+  });
+
+  it('should display right format in different locales', () => {
+    expect(formatCurrency(5.12, 'USD', 2, 'en-US')).toEqual('$5.12');
+    expect(formatCurrency(5.12, 'USD', 2, 'en-IN')).toEqual('$5.12');
+    expect(formatCurrency(5.34, 'USD', 2, 'fr')).toEqual('5,34\xa0$US'); // '\xa0' is a normal non-breaking space
+    expect(formatCurrency(5.45, 'EUR', 2, 'en-US')).toEqual('€5.45');
+    expect(formatCurrency(5.67, 'EUR', 2, 'fr-FR')).toEqual('5,67\xa0€');
+    expect(formatCurrency(5.89, 'MXN', 2, 'es-MX')).toEqual('$5.89');
+  });
+
+  it('should support non-standard currencies', () => {
+    expect(formatCurrency(5.12, 'ABC')).toEqual('ABC\xa05.12');
+    expect(formatCurrency(5.12, 'ZZZ')).toEqual('ZZZ\xa05.12');
+    expect(formatCurrency(5.12, 'AB')).toEqual('AB\xa05.12');
+    expect(formatCurrency(5.12, 'ABCDE')).toEqual('ABCDE\xa05.12');
   });
 });


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Fixes https://github.com/interledger/web-monetization-extension/issues/1021

## Changes proposed in this pull request

- Handle the case of not-3-letter currency by using uppercase-currency as code to prevent crash (in `formatCurrency`, `getCurrencySymbol`).
- Add unit tests
