### PR TITLE
chore(ci/build-previews): encode shields.io badge URL so it loads

### DIFF
--- a/.github/actions/constants.cjs
+++ b/.github/actions/constants.cjs
@@ -4,8 +4,6 @@
  * @typedef {'chrome' | 'firefox'} Browser
  */
 
-const BADGE =
-  '<img src="https://img.shields.io/badge/{{ CONCLUSION }}-{{ BADGE_COLOR }}?style=for-the-badge&label={{ BADGE_LABEL }}" alt="Badge" />';
 /** @type {Browser[]} */
 const BROWSERS = ['chrome', 'firefox'];
 const COLORS = {
@@ -16,13 +14,10 @@ const TEMPLATE_VARS = {
   tableBody: '{{ TABLE_BODY }}',
   sha: '{{ SHA }}',
   conclusion: '{{ CONCLUSION }}',
-  badgeColor: '{{ BADGE_COLOR }}',
-  badgeLabel: '{{ BADGE_LABEL }}',
   jobLogs: '{{ JOB_LOGS }}',
 };
 
 module.exports = {
-  BADGE,
   BROWSERS,
   COLORS,
   TEMPLATE_VARS,

--- a/.github/actions/get-workflow-artifacts.cjs
+++ b/.github/actions/get-workflow-artifacts.cjs
@@ -28,7 +28,7 @@ const ARTIFACTS_DATA = {
  */
 function getBadge(conclusion, badgeColor, badgeLabel) {
   const url = new URL(
-    `/badge/${conclusion}-${badgeColor}`,
+    `/badge/${conclusion}-${COLORS[badgeColor]}`,
     'https://img.shields.io',
   );
   url.searchParams.set('style', 'for-the-badge');

--- a/.github/actions/get-workflow-artifacts.cjs
+++ b/.github/actions/get-workflow-artifacts.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const fs = require('node:fs/promises');
-const { COLORS, TEMPLATE_VARS, BADGE } = require('./constants.cjs');
+const { COLORS, TEMPLATE_VARS } = require('./constants.cjs');
 
 /**
  * @typedef {import('./constants.cjs').Browser} Browser
@@ -21,14 +21,19 @@ const ARTIFACTS_DATA = {
 };
 
 /**
- * @param {string} conclusion
- * @param {string} badgeColor
+ * @param {'failure' | 'success'} conclusion
+ * @param {keyof typeof COLORS} badgeColor
  * @param {string} badgeLabel
+ * @returns {string} HTML for badge image
  */
 function getBadge(conclusion, badgeColor, badgeLabel) {
-  return BADGE.replace(TEMPLATE_VARS.conclusion, conclusion)
-    .replace(TEMPLATE_VARS.badgeColor, badgeColor)
-    .replace(TEMPLATE_VARS.badgeLabel, badgeLabel);
+  const url = new URL(
+    `/badge/${conclusion}-${badgeColor}`,
+    'https://img.shields.io',
+  );
+  url.searchParams.set('style', 'for-the-badge');
+  url.searchParams.set('label', badgeLabel);
+  return `<img src="${url}" alt="${badgeLabel}" />`;
 }
 
 /**
@@ -84,12 +89,12 @@ module.exports = async ({ github, context, core }) => {
   for (const k of Object.keys(ARTIFACTS_DATA)) {
     const { name, url, size } = ARTIFACTS_DATA[/** @type {Browser} */ (k)];
     if (!url && !size) {
-      const badgeUrl = getBadge('failure', COLORS.red, name);
+      const badge = getBadge('failure', 'red', name);
       tableRows.push(
-        `<tr><td align="center">${badgeUrl}</td><td align="center">N/A</td></tr>`,
+        `<tr><td align="center">${badge}</td><td align="center">N/A</td></tr>`,
       );
     } else {
-      const badgeUrl = getBadge('success', COLORS.green, `${name} (${size})`);
+      const badgeUrl = getBadge('success', 'green', `${name} (${size})`);
       tableRows.push(
         `<tr><td align="center">${badgeUrl}</td><td align="center"><a href="${url}">Download</a></td></tr>`,
       );


### PR DESCRIPTION
## Context

Badges not loading:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/e7230ed2-c3bd-4a87-bb9d-898e3a5be039" />


## Changes proposed in this pull request

- Create shields.io badge URL properly
- Some TypeScript improvements, cleanups, less string manipulation
- Improve alt text for the badge.

**To reviewer**: You won't see them loading in this PR either, as CI checks out `main` branch when running badge-generation script, instead of PR branch.