### PR TITLE
fix(background): avoid duplicate polyfill script warning

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -92,9 +92,13 @@ export class Background {
           js: ['polyfill/polyfill.js'],
           matches: this.browser.runtime.getManifest().host_permissions,
           runAt: 'document_start',
+          persistAcrossSessions: false,
         },
       ]);
     } catch (error) {
+      if (/duplicate/i.test(error.message)) {
+        return;
+      }
       // Firefox <128 will throw saying world: MAIN isn't supported. So, we'll
       // inject via contentScript later. Injection via contentScript is slow,
       // but apart from WM detection on page-load, everything else works fine.


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

On browser start, there was a warning that the polyfill script was already registered.
Also, this warning was incorrectly included in the "Content script execution world `MAIN` not supported by your browser" warning.

![image](https://github.com/user-attachments/assets/eed4a64e-8bdd-40f6-8d57-7505aff84837)


## Changes proposed in this pull request

- Set `persistAcrossSessions: false` to prevent error in first place and for consistency with other content scripts.
- Silence duplicate script error (different browsers may have different error message)