### PR TITLE
fix(bg/storage): store user provided wallet URL as well

### DIFF
--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -203,7 +203,7 @@ export class WalletService {
     }
 
     await this.storage.set({
-      walletAddress,
+      walletAddress: { url: walletAddressUrl, ...walletAddress },
       rateOfPay,
       minRateOfPay,
       maxRateOfPay,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,4 @@
-import type { WalletAddress } from '@interledger/open-payments/dist/types';
+import type { WalletAddress } from '@interledger/open-payments';
 import type { Tabs } from 'webextension-polyfill';
 import type { ErrorWithKeyLike } from './helpers';
 
@@ -40,6 +40,16 @@ export interface RecurringGrant extends GrantDetailsBase {
 }
 export type GrantDetails = OneTimeGrant | RecurringGrant;
 
+export type WalletInfo = WalletAddress & {
+  /**
+   * The (normalized) wallet URL provided by user. Sometimes, wallets URLs have
+   * redirects, and in those cases, we want to preserve what user has provided.
+   *
+   * @since Available only if wallet connected after this feature was released.
+   */
+  url?: string;
+};
+
 export type ExtensionState =
   | never // just added for code formatting
   /** Extension can't inject scripts and fetch resources from all hosts */
@@ -70,7 +80,7 @@ export interface Storage {
   maxRateOfPay?: string | undefined | null;
 
   /** User wallet address information */
-  walletAddress?: WalletAddress | undefined | null;
+  walletAddress?: WalletInfo | undefined | null;
 
   recurringGrant?: RecurringGrant | undefined | null;
   recurringGrantSpentAmount?: AmountValue | undefined | null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,7 +40,7 @@ export interface RecurringGrant extends GrantDetailsBase {
 }
 export type GrantDetails = OneTimeGrant | RecurringGrant;
 
-export type WalletInfo = WalletAddress & {
+export interface WalletInfo extends WalletAddress {
   /**
    * The (normalized) wallet URL provided by user. Sometimes, wallets URLs have
    * redirects, and in those cases, we want to preserve what user has provided.
@@ -48,7 +48,7 @@ export type WalletInfo = WalletAddress & {
    * @since Available only if wallet connected after this feature was released.
    */
   url?: string;
-};
+}
 
 export type ExtensionState =
   | never // just added for code formatting


### PR DESCRIPTION
## Context

Useful with https://github.com/interledger/web-monetization-extension/issues/1029
Some wallet URLs have redirects, and the resulting `resourceServer` could be something that corresponds to a different wallet as well.

With this info stored, we can:
- help distinguish those redirect wallets (MMAON, ilp.dev) from their _managing wallets_
- display the wallet address that user entered in UI - like UI showing ilp.dev instead of ilp.interledger.cards address (not done yet)

## Changes proposed in this pull request

- Store `walletAddressUrl` as `walletAddress.url` in extension storage.
   - The `url` property isn't part of standard [`WalletAddress` response](https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address/), so it's safe to add to storage within this object. 
   - The field is marked optional as it doesn't exist on already connected wallets.

---
**Example:** User input `$ilp.interledger-test.dev/sid` at `connectWallet` gets stored like this:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/a47633a4-cbf6-4e47-a84c-ca65b8303e36" />

