### PR TITLE
perf(bg/monetization): reuse `PaymentSession` when link added

### DIFF
--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -561,7 +561,7 @@ export class MonetizationService {
       return true;
     } catch (err) {
       if (err.name === 'AbortError') {
-        this.logger.debug('adjustAmount aborted due to new call');
+        this.logger.debug('setRate aborted due to new call', { err });
         return false;
       } else {
         throw err;

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -557,11 +557,11 @@ export class MonetizationService {
     rate: AmountValue,
   ): Promise<boolean> {
     try {
-      await Promise.all(sessions.map((session) => session.setRate(rate)));
+      await Promise.all(sessions.map((session) => session.adjustAmount(rate)));
       return true;
     } catch (err) {
       if (err.name === 'AbortError') {
-        this.logger.debug('setRate aborted due to new call', { err });
+        this.logger.debug('adjustAmount aborted due to new call');
         return false;
       } else {
         throw err;

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -557,7 +557,7 @@ export class MonetizationService {
     rate: AmountValue,
   ): Promise<boolean> {
     try {
-      await Promise.all(sessions.map((session) => session.adjustAmount(rate)));
+      await Promise.all(sessions.map((session) => session.setRate(rate)));
       return true;
     } catch (err) {
       if (err.name === 'AbortError') {

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -85,8 +85,10 @@ export class PaymentSession {
     Object.assign(this, this.deps);
   }
 
-  #minSendAmount = 0n;
+  // We keep setting #minSendAmount to non-zero values as we probe. Instead of
+  // checking #minSendAmount > 0, use this boolean to know if probing completed.
   #minSendAmountFound = false;
+  #minSendAmount = 0n;
   get minSendAmount(): bigint {
     if (!this.#minSendAmountFound) {
       throw new Error('minSendAmount not figured out yet');

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -107,6 +107,12 @@ export class PaymentSession {
     // The amount that needs to be sent every second.
     // In senders asset scale already.
     await this.findMinSendAmount();
+    if (this.rate !== hourlyRate) {
+      throw new DOMException(
+        `Aborting existing probing for rate=${hourlyRate}`,
+        'AbortError',
+      );
+    }
     const amount = bigIntMax(BigInt(this.rate) / 3600n, this.#minSendAmount);
     this.setAmount(amount);
   }

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -89,17 +89,18 @@ export class PaymentSession {
   // checking #minSendAmount > 0, use this boolean to know if probing completed.
   #minSendAmountFound = false;
   #minSendAmount = 0n;
+  #minSendAmountPromise: ReturnType<typeof this._findMinSendAmount>;
+
+  findMinSendAmount(): Promise<void> {
+    this.#minSendAmountPromise ??= this._findMinSendAmount();
+    return this.#minSendAmountPromise;
+  }
+
   get minSendAmount(): bigint {
     if (!this.#minSendAmountFound) {
       throw new Error('minSendAmount not figured out yet');
     }
     return this.#minSendAmount;
-  }
-
-  #minSendAmountPromise: ReturnType<typeof this._findMinSendAmount>;
-  findMinSendAmount(): Promise<void> {
-    this.#minSendAmountPromise ??= this._findMinSendAmount();
-    return this.#minSendAmountPromise;
   }
 
   async adjustAmount(hourlyRate: AmountValue) {

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -85,21 +85,6 @@ export class PaymentSession {
     Object.assign(this, this.deps);
   }
 
-  async adjustAmount(hourlyRate: AmountValue) {
-    this.rate = hourlyRate;
-    // The amount that needs to be sent every second.
-    // In senders asset scale already.
-    await this.findMinSendAmount();
-    if (this.rate !== hourlyRate) {
-      throw new DOMException(
-        `Aborting existing probing for rate=${hourlyRate}`,
-        'AbortError',
-      );
-    }
-    const amount = bigIntMax(BigInt(this.rate) / 3600n, this.#minSendAmount);
-    this.setAmount(amount);
-  }
-
   // We keep setting #minSendAmount to non-zero values as we probe. Instead of
   // checking #minSendAmount > 0, use this boolean to know if probing completed.
   #minSendAmountFound = false;
@@ -115,6 +100,21 @@ export class PaymentSession {
   findMinSendAmount(): Promise<void> {
     this.#minSendAmountPromise ??= this._findMinSendAmount();
     return this.#minSendAmountPromise;
+  }
+
+  async adjustAmount(hourlyRate: AmountValue) {
+    this.rate = hourlyRate;
+    // The amount that needs to be sent every second.
+    // In senders asset scale already.
+    await this.findMinSendAmount();
+    if (this.rate !== hourlyRate) {
+      throw new DOMException(
+        `Aborting existing probing for rate=${hourlyRate}`,
+        'AbortError',
+      );
+    }
+    const amount = bigIntMax(BigInt(this.rate) / 3600n, this.#minSendAmount);
+    this.setAmount(amount);
   }
 
   private async _findMinSendAmount(signal?: AbortSignal): Promise<void> {
@@ -277,8 +277,8 @@ export class PaymentSession {
     };
 
     if (!this.rate) {
-      // this.rate is set when setRate begins. this.amount is set only after first successful setRate
-      throw new Error('Unexpected: setRate not yet ready');
+      // this.rate is set when adjustAmount begins. this.amount is set only after first successful adjustAmount
+      throw new Error('Unexpected: adjustAmount not yet ready');
     }
     if (this.canContinuePayment) {
       this.timeout = setTimeout(async () => {

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -102,7 +102,7 @@ export class PaymentSession {
     return this.#minSendAmountPromise;
   }
 
-  async setRate(hourlyRate: AmountValue) {
+  async adjustAmount(hourlyRate: AmountValue) {
     this.rate = hourlyRate;
     // The amount that needs to be sent every second.
     // In senders asset scale already.
@@ -283,7 +283,7 @@ export class PaymentSession {
     if (this.canContinuePayment) {
       this.timeout = setTimeout(async () => {
         if (!this.amount) {
-          await this.setRate(this.rate);
+          await this.adjustAmount(this.rate);
         }
         if (!this.amount) {
           // if still not set, fail


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/976
The goal is to efficiently find the `minSendAmount` for a `PaymentSession`.

## Changes proposed in this pull request

Reuse PaymentSession instead of starting a new one.

<details>
<summary>Original PR summary</summary>

- In the first commit (https://github.com/interledger/web-monetization-extension/pull/1046/commits/e4a8ae51ec998fe3d2829198d429d58e2c4b4088), it won't have the desired effect, as we have an `AbortSignal` that makes the probing restart.
- In the next commit (https://github.com/interledger/web-monetization-extension/pull/1046/commits/c5de59ff43e6572a62637b7099096d0536062a7a), we replace `adjustAmount(rate)` with `findMinSendAmount()` (which is independent of rate). Extracted into [1048](https://github.com/interledger/web-monetization-extension/pull/1048).
- When a new link tag is added, we want to keep using older `minSendAmount`, even if the `adjustAmount` may change due to splits. `adjustAmount` resulting rate is >= `minSendAmount`, so it makes sense to find `minSendAmount` first, and not find it ever again.
   - Currency fluctuations can change this `minSendAmount` in future, but then we'd need to probe/`findMinSendAmount` again (existing bug, will fix some time later).


~Also updated the constructor type for `PaymentSession` a bit.~ Moved to [#1047](https://github.com/interledger/web-monetization-extension/pull/1047). I was thinking of adding a static `PaymentSession.from()`, but we don't need it right now. The new constructor format will help there as well. 

</details>

---

Before (see quotes requests increasing as link tags added to page, including for existing tags):

https://github.com/user-attachments/assets/ba9aeb97-c9ed-4722-ac5e-ed0b35f98cca

After (see quotes requests for link tags already added are skipped; fewer requests): 

https://github.com/user-attachments/assets/167e95a4-2e02-4127-b776-833e7a076e28




