### PR TITLE
fix(bg/paymentSession): prefix logs per instance

### DIFF
--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -20,7 +20,7 @@ import {
   Heartbeat,
   Deduplicator,
 } from './services';
-import { createLogger, type Logger } from '@/shared/logger';
+import { createLogger, type Logger, type RootLogger } from '@/shared/logger';
 import { LOG_LEVEL } from '@/shared/defines';
 import {
   getBrowserName,
@@ -39,6 +39,7 @@ import {
 
 export interface Cradle {
   logger: Logger;
+  rootLogger: RootLogger;
   browser: Browser;
   browserName: BrowserName;
   appName: string;
@@ -69,6 +70,7 @@ export const configureContainer = () => {
 
   container.register({
     logger: asValue(logger),
+    rootLogger: asValue(logger),
     browser: asValue(browser),
     browserName: asValue(getBrowserName(browser, navigator.userAgent)),
     appName: asValue(browser.runtime.getManifest().name),

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -27,6 +27,7 @@ import type { Cradle } from '@/background/container';
 
 export class MonetizationService {
   private logger: Cradle['logger'];
+  private rootLogger: Cradle['rootLogger'];
   private t: Cradle['t'];
   private openPaymentsService: Cradle['openPaymentsService'];
   private outgoingPaymentGrantService: Cradle['outgoingPaymentGrantService'];
@@ -38,6 +39,7 @@ export class MonetizationService {
 
   constructor({
     logger,
+    rootLogger,
     t,
     openPaymentsService,
     outgoingPaymentGrantService,
@@ -49,6 +51,7 @@ export class MonetizationService {
   }: Cradle) {
     Object.assign(this, {
       logger,
+      rootLogger,
       t,
       openPaymentsService,
       outgoingPaymentGrantService,
@@ -92,16 +95,6 @@ export class MonetizationService {
       return;
     }
 
-    const deps = {
-      storage: this.storage,
-      openPaymentsService: this.openPaymentsService,
-      outgoingPaymentGrantService: this.outgoingPaymentGrantService,
-      events: this.events,
-      tabState: this.tabState,
-      logger: this.logger,
-      message: this.message,
-    };
-
     const { tabId, frameId, url: fullUrl } = getSender(sender);
     const url = removeQueryParams(fullUrl!);
 
@@ -125,7 +118,15 @@ export class MonetizationService {
           tabId,
           frameId,
           url,
-          deps,
+          {
+            storage: this.storage,
+            openPaymentsService: this.openPaymentsService,
+            outgoingPaymentGrantService: this.outgoingPaymentGrantService,
+            events: this.events,
+            tabState: this.tabState,
+            logger: this.rootLogger.getLogger(`payment-session/${requestId}`),
+            message: this.message,
+          },
         );
         sessions.set(requestId, session);
       }

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -252,7 +252,7 @@ export class PaymentSession {
 
   private debug(message: string) {
     this.logger.debug(
-      `[PAYMENT SESSION] requestId=${this.requestId}; receiver=${this.receiver.id}\n\n`,
+      `[PAYMENT SESSION] receiver=${this.receiver.id}\n\n`,
       `   ${message}`,
     );
   }

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -251,10 +251,7 @@ export class PaymentSession {
   }
 
   private debug(message: string) {
-    this.logger.debug(
-      `[PAYMENT SESSION] receiver=${this.receiver.id}\n\n`,
-      `   ${message}`,
-    );
+    this.logger.debug(`[receiver=${this.receiver.id}]`, message);
   }
 
   async start(source: PaymentSessionSource) {

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -32,7 +32,8 @@ export const createLogger = (level: log.LogLevelDesc = 'DEBUG') => {
   return log;
 };
 
-export type Logger = log.RootLogger;
+export type Logger = log.Logger;
+export type RootLogger = log.RootLogger;
 
 export type RemoteLoggerMessage = {
   msg: unknown[];


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Found useful when working on payment streams.

## Changes proposed in this pull request

Create an instance of logger per `PaymentSession`.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ea78af68-09ee-4060-b5d9-e72510976b93) | ![image](https://github.com/user-attachments/assets/78492344-3ac7-43c2-a60d-562193a18ad2) |


Might make `requestId` shorter in future 😄 