### PR TITLE
fix: make logs easier to read

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -190,6 +190,7 @@ export class Background {
           }
           await this.updateVisualIndicatorsForCurrentTab();
         } else {
+          if (!tabIds.length) continue;
           this.logger.info(
             `[focus change] stop monetization for window=${windowId}, tabIds=${JSON.stringify(tabIds)}`,
           );
@@ -211,7 +212,7 @@ export class Background {
   bindMessageHandler() {
     this.browser.runtime.onMessage.addListener(
       async (message: ToBackgroundMessage, sender: Runtime.MessageSender) => {
-        this.logger.debug('Received message', message);
+        this.logger.debug('Received message', message.action, message.payload);
         try {
           switch (message.action) {
             // region Popup

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -10,6 +10,15 @@ export const createLogger = (level: log.LogLevelDesc = 'DEBUG') => {
   const factory = log.methodFactory;
   log.methodFactory = (methodName, logLevel, loggerName) => {
     const raw = factory(methodName, logLevel, loggerName);
+    if (loggerName?.toString().includes('/')) {
+      const [a, b] = loggerName.toString().split('/', 2);
+      return raw.bind(
+        log,
+        `%c${a}%c${b}`,
+        'font-weight: bold; text-transform: uppercase; background: #2f8785; color: #fff; padding-inline: 5px;',
+        'background: #def4ef; color: #000; padding-inline: 5px;',
+      );
+    }
     return raw.bind(
       log,
       `%c${loggerName as string}`,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Extracted from https://github.com/interledger/web-monetization-extension/pull/1064

## Changes proposed in this pull request

- If loggerName includes a `/`, show the content after `/` differently so it doesn't take too much attention (or look noisy)
- In background's message listener log, log `message.action` followed by `message.payload`, instead of logging `message` as an object which needs clicking to expand its contents.
- Avoid logging when switching windows when there are no `tabIds` to pause monetization for.

<img width="802" alt="Image" src="https://github.com/user-attachments/assets/17bb84e4-5424-4936-b65c-2fb40667bd90" />
