### PR TITLE
fix(Settings/RateOfPay): ensure `AmountValue` is used as rate

### DIFF
--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -5,12 +5,13 @@ import { debounceAsync } from '@/shared/helpers';
 import { formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { useMessage, useTranslation } from '@/popup/lib/context';
 import { dispatch, usePopupState, type PopupState } from '@/popup/lib/store';
+import type { AmountValue } from '@/shared/types';
 
 export const RateOfPayScreen = () => {
   const message = useMessage();
 
   const updateRateOfPay = React.useRef(
-    debounceAsync(async (rateOfPay: string) => {
+    debounceAsync(async (rateOfPay: AmountValue) => {
       const response = await message.send('UPDATE_RATE_OF_PAY', { rateOfPay });
       if (!response.success) {
         // TODO: Maybe reset to old state, but not while user is active (avoid
@@ -19,7 +20,7 @@ export const RateOfPayScreen = () => {
     }, 1000),
   );
 
-  const onRateChange = async (rateOfPay: string) => {
+  const onRateChange = async (rateOfPay: AmountValue) => {
     dispatch({ type: 'UPDATE_RATE_OF_PAY', data: { rateOfPay } });
     void updateRateOfPay.current(rateOfPay);
   };
@@ -38,7 +39,7 @@ export const RateOfPayScreen = () => {
 };
 
 interface Props {
-  onRateChange: (rate: string) => Promise<void>;
+  onRateChange: (rate: AmountValue) => Promise<void>;
   toggle: () => void | Promise<void>;
 }
 
@@ -122,7 +123,7 @@ const RateOfPayInput = ({
         onChange={(value) => {
           setErrorMessage('');
           const rate = Number(value) * 10 ** walletAddress.assetScale;
-          onRateChange(rate.toString());
+          onRateChange(Math.round(rate).toString());
         }}
         onError={(error) => setErrorMessage(t(error))}
         errorMessage={errorMessage}

--- a/src/pages/popup/lib/store.ts
+++ b/src/pages/popup/lib/store.ts
@@ -1,5 +1,5 @@
 import { proxy, useSnapshot } from 'valtio';
-import type { DeepNonNullable, PopupStore } from '@/shared/types';
+import type { AmountValue, DeepNonNullable, PopupStore } from '@/shared/types';
 import type { BackgroundToPopupMessage } from '@/shared/messages';
 
 export type PopupState = Required<
@@ -58,5 +58,5 @@ type Actions =
   | { type: 'TOGGLE_CONTINUOUS_PAYMENTS'; data?: never }
   | { type: 'TOGGLE_PAYMENTS'; data?: never }
   | { type: 'SET_CONNECTED'; data: { connected: boolean } }
-  | { type: 'UPDATE_RATE_OF_PAY'; data: { rateOfPay: string } }
+  | { type: 'UPDATE_RATE_OF_PAY'; data: { rateOfPay: AmountValue } }
   | BackgroundToPopupMessage;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -117,7 +117,7 @@ export interface PayWebsiteResponse {
 }
 
 export interface UpdateRateOfPayPayload {
-  rateOfPay: string;
+  rateOfPay: AmountValue;
 }
 
 export interface UpdateBudgetPayload {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,9 +75,9 @@ export interface Storage {
   /** Extension state */
   state: Partial<Record<ExtensionState, boolean>>;
 
-  rateOfPay?: string | undefined | null;
-  minRateOfPay?: string | undefined | null;
-  maxRateOfPay?: string | undefined | null;
+  rateOfPay?: AmountValue | undefined | null;
+  minRateOfPay?: AmountValue | undefined | null;
+  maxRateOfPay?: AmountValue | undefined | null;
 
   /** User wallet address information */
   walletAddress?: WalletInfo | undefined | null;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Sometimes we ended up storing rate as a string containing decimals, which crashed when we tried to convert it to `BigInt(rateOfPay)`.

## Changes proposed in this pull request

- `Math.round()` rate of pay when parsing from the input, so there are no decimals in it.
- Update types to make it clearer that we want a big-int like string (`AmountValue`) there, instead of any string.
