### PR TITLE
chore(ci): lock `softprops/action-gh-release` action

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -122,7 +122,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create GH Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: |
             dist/*.zip

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -48,7 +48,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: |
             dist/*.zip

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -64,7 +64,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: |
             dist/*.zip


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Action failing to upload files: [run 1](https://github.com/interledger/web-monetization-extension/actions/runs/15561155826/job/43813517943), [run 2](https://github.com/interledger/web-monetization-extension/actions/runs/15561178444/job/43813594812).
See https://github.com/softprops/action-gh-release/issues/627, https://github.com/softprops/action-gh-release/issues/628


## Changes proposed in this pull request

Lock version to last working version.