### PR TITLE
fix: remove `minRateOfPay`, make `WalletInfo.url` required

### DIFF
--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -2,7 +2,6 @@ export const DEFAULT_SCALE = 2;
 export const DEFAULT_INTERVAL_MS = 3_600_000;
 
 export const DEFAULT_RATE_OF_PAY = '60';
-export const MIN_RATE_OF_PAY = '1';
 export const MAX_RATE_OF_PAY = '100';
 
 /** Minimum wait time between two consecutive continuous payments */

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -418,7 +418,6 @@ export class MonetizationService {
       'connected',
       'state',
       'rateOfPay',
-      'minRateOfPay',
       'maxRateOfPay',
       'walletAddress',
       'oneTimeGrant',

--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -19,7 +19,7 @@ const defaultStorage = {
    * structural changes would need migrations for keeping compatibility with
    * existing installations.
    */
-  version: 4,
+  version: 5,
   state: {},
   connected: false,
   enabled: true,
@@ -31,7 +31,6 @@ const defaultStorage = {
   oneTimeGrant: null,
   oneTimeGrantSpentAmount: '0',
   rateOfPay: null,
-  minRateOfPay: null,
   maxRateOfPay: null,
 } satisfies Omit<Storage, 'publicKey' | 'privateKey' | 'keyId'>;
 
@@ -286,5 +285,11 @@ const MIGRATIONS: Record<Storage['version'], Migration> = {
     data.continuousPaymentsEnabled = data.enabled;
     data.enabled = true;
     return [data];
+  },
+  5: (data) => {
+    if (data.walletAddress && !data.walletAddress.url) {
+      data.walletAddress.url = data.walletAddress.id;
+    }
+    return [data, ['minRateOfPay']];
   },
 };

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -14,7 +14,6 @@ import type {
 } from '@/shared/messages';
 import {
   DEFAULT_RATE_OF_PAY,
-  MIN_RATE_OF_PAY,
   MAX_RATE_OF_PAY,
   DEFAULT_SCALE,
 } from '@/background/config';
@@ -87,7 +86,6 @@ export class WalletService {
     const exchangeRates = await getExchangeRates();
 
     let rateOfPay = DEFAULT_RATE_OF_PAY;
-    let minRateOfPay = MIN_RATE_OF_PAY;
     let maxRateOfPay = MAX_RATE_OF_PAY;
 
     const getRateOfPay = (rate: AmountValue) => {
@@ -95,7 +93,6 @@ export class WalletService {
       return convertWithExchangeRate(rate, from, walletAddress, exchangeRates);
     };
     rateOfPay = getRateOfPay(DEFAULT_RATE_OF_PAY);
-    minRateOfPay = getRateOfPay(MIN_RATE_OF_PAY);
     maxRateOfPay = getRateOfPay(MAX_RATE_OF_PAY);
 
     await this.openPaymentsService.initClient(walletAddress.id);
@@ -203,9 +200,8 @@ export class WalletService {
     }
 
     await this.storage.set({
-      walletAddress: { url: walletAddressUrl, ...walletAddress },
+      walletAddress,
       rateOfPay,
-      minRateOfPay,
       maxRateOfPay,
       connected: true,
     });

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -44,19 +44,13 @@ interface Props {
 }
 
 export const RateOfPayComponent = ({ onRateChange, toggle }: Props) => {
-  const {
-    continuousPaymentsEnabled,
-    rateOfPay,
-    minRateOfPay,
-    maxRateOfPay,
-    walletAddress,
-  } = usePopupState();
+  const { continuousPaymentsEnabled, rateOfPay, maxRateOfPay, walletAddress } =
+    usePopupState();
   return (
     <div className="space-y-8">
       <RateOfPayInput
         onRateChange={onRateChange}
         rateOfPay={rateOfPay}
-        minRateOfPay={minRateOfPay}
         maxRateOfPay={maxRateOfPay}
         walletAddress={walletAddress}
         disabled={!continuousPaymentsEnabled}
@@ -87,7 +81,6 @@ type RateOfPayInputProps = {
   onRateChange: Props['onRateChange'];
   walletAddress: PopupState['walletAddress'];
   rateOfPay: PopupState['rateOfPay'];
-  minRateOfPay: PopupState['minRateOfPay'];
   maxRateOfPay: PopupState['maxRateOfPay'];
   disabled?: boolean;
 };
@@ -96,7 +89,6 @@ const RateOfPayInput = ({
   onRateChange,
   walletAddress,
   rateOfPay,
-  minRateOfPay,
   maxRateOfPay,
   disabled,
 }: RateOfPayInputProps) => {
@@ -127,7 +119,7 @@ const RateOfPayInput = ({
         }}
         onError={(error) => setErrorMessage(t(error))}
         errorMessage={errorMessage}
-        min={Number(formatAmount(minRateOfPay))}
+        min={Number(formatAmount(1))}
         max={Number(formatAmount(maxRateOfPay))}
         amount={formatAmount(rateOfPay)}
         controls={true}

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -119,7 +119,7 @@ const RateOfPayInput = ({
         }}
         onError={(error) => setErrorMessage(t(error))}
         errorMessage={errorMessage}
-        min={Number(formatAmount(1))}
+        min={1}
         max={Number(formatAmount(maxRateOfPay))}
         amount={formatAmount(rateOfPay)}
         controls={true}

--- a/src/shared/helpers/wallet.ts
+++ b/src/shared/helpers/wallet.ts
@@ -1,4 +1,5 @@
 import type { WalletAddress, JWKS } from '@interledger/open-payments';
+import type { WalletInfo } from '@/shared/types';
 import { ensureEnd } from './misc';
 
 export function toWalletAddressUrl(s: string): string {
@@ -22,7 +23,7 @@ const isWalletAddress = (o: Record<string, unknown>): o is WalletAddress => {
 
 export const getWalletInformation = async (
   walletAddressUrl: string,
-): Promise<WalletAddress> => {
+): Promise<WalletInfo> => {
   const response = await fetch(walletAddressUrl, {
     headers: {
       Accept: 'application/json',
@@ -43,7 +44,7 @@ export const getWalletInformation = async (
     throw new Error(msgInvalidWalletAddress);
   }
 
-  return json;
+  return { ...json, url: walletAddressUrl };
 };
 
 export const getJWKS = async (walletAddressUrl: string) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -45,9 +45,10 @@ export interface WalletInfo extends WalletAddress {
    * The (normalized) wallet URL provided by user. Sometimes, wallets URLs have
    * redirects, and in those cases, we want to preserve what user has provided.
    *
-   * @since Available only if wallet connected after this feature was released.
+   * For wallets that were connected before this property was introduced, this
+   * will be same as {@linkcode WalletAddress.id}.
    */
-  url?: string;
+  url: string;
 }
 
 export type ExtensionState =
@@ -76,7 +77,6 @@ export interface Storage {
   state: Partial<Record<ExtensionState, boolean>>;
 
   rateOfPay?: AmountValue | undefined | null;
-  minRateOfPay?: AmountValue | undefined | null;
   maxRateOfPay?: AmountValue | undefined | null;
 
   /** User wallet address information */


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1084
Helps with https://github.com/interledger/web-monetization-extension/issues/1082

## Changes proposed in this pull request

- Remove `minRateOfPay` from code, storage and UI.
- In Settings > Rate of Pay, set min to 1 unit
- As we're doing a storage structure migration, make `WalletInfo.url` as required. Make it same as `WalletAddress.id` when not available. Helps with [#1082](https://github.com/interledger/web-monetization-extension/issues/1082).
- Return `WalletInfo` from `getWalletInformation` (instead of `WalletAddress`)
