### PR TITLE
refactor(bg/utils): keep single helper for `getExchangeRates`

### DIFF
--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -19,7 +19,7 @@ import {
   bigIntMax,
   convert,
   convertWithExchangeRate,
-  getExchangeRatesMemoized,
+  getExchangeRates,
   getNextSendableAmount,
 } from '@/background/utils';
 import type {
@@ -129,7 +129,7 @@ export class PaymentSession {
 
     if (isCrossCurrency) {
       try {
-        const exchangeRates = await getExchangeRatesMemoized();
+        const exchangeRates = await getExchangeRates();
         amountToSend = convertWithExchangeRate(
           amountToSend,
           this.receiver,

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -75,25 +75,23 @@ interface ExchangeRates {
   rates: Record<string, number>;
 }
 
-export const getExchangeRates = async (): Promise<ExchangeRates> => {
-  const response = await fetch(EXCHANGE_RATES_URL);
-  if (!response.ok) {
-    throw new Error(
-      `Could not fetch exchange rates. [Status code: ${response.status}]`,
-    );
-  }
-  const rates = await response.json();
-  if (!rates.base || !rates.rates) {
-    throw new Error('Invalid rates format');
-  }
+export const getExchangeRates = memoize(
+  async (): Promise<ExchangeRates> => {
+    const response = await fetch(EXCHANGE_RATES_URL);
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch exchange rates. [Status code: ${response.status}]`,
+      );
+    }
+    const rates = await response.json();
+    if (!rates.base || !rates.rates) {
+      throw new Error('Invalid rates format');
+    }
 
-  return rates;
-};
-
-export const getExchangeRatesMemoized = memoize(getExchangeRates, {
-  maxAge: 15 * 60 * 1000,
-  mechanism: 'stale-while-revalidate',
-});
+    return rates;
+  },
+  { maxAge: 15 * 60 * 1000, mechanism: 'stale-while-revalidate' },
+);
 
 export const getExchangeRate = (
   rates: ExchangeRates,


### PR DESCRIPTION
## Context

Just making code simpler. We are ok using only the memoized version.

## Changes proposed in this pull request

