### PR TITLE
test(e2e): use "bot" userAgent to not ruin site analytics

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     actionTimeout: 8_000,
     navigationTimeout: 10_000,
+    userAgent: 'Web Monetization Extension E2E Tests Bot',
   },
 
   projects: [


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

We saw lots of misleading page views on webmonetization.org analytics dashboard - mainly on the /welcome and /play pages - which are extensively used by E2E tests.

## Changes proposed in this pull request

Include "bot" in playright's test runner userAgent, so our analytics agent (Umami) can ignore these page views.
