### PR TITLE
fix: better handle state clearing on page refresh/unload

### DIFF
--- a/esbuild/dev.ts
+++ b/esbuild/dev.ts
@@ -22,7 +22,7 @@ export const getDevOptions = ({
     ]),
     define: {
       NODE_ENV: JSON.stringify('development'),
-      CONFIG_LOG_LEVEL: JSON.stringify('DEBUG'),
+      CONFIG_LOG_LEVEL: JSON.stringify('TRACE'),
       CONFIG_OPEN_PAYMENTS_REDIRECT_URL: JSON.stringify(
         'https://webmonetization.org/welcome',
       ),

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -306,6 +306,10 @@ export class Background {
               await this.tabEvents.onFocussedTab(getTab(sender));
               return;
 
+            case 'PAGE_HIDE':
+              await this.tabEvents.onPageHide(sender);
+              return;
+
             case 'START_MONETIZATION':
               await this.monetizationService.startPaymentSession(
                 message.payload,

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -1,6 +1,6 @@
 import { isOkState, removeQueryParams } from '@/shared/helpers';
 import type { PopupTabInfo, Storage, TabId } from '@/shared/types';
-import type { Browser, Tabs } from 'webextension-polyfill';
+import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import type { Cradle } from '@/background/container';
 
 type IconPath = Record<number, string>;
@@ -92,6 +92,10 @@ export class TabEvents {
         // Navigating to new URL. Clear overpaying state if any.
         this.tabState.clearSessionsByTabId(tabId); // for sanity
         this.tabState.clearOverpayingByTabId(tabId);
+      } else {
+        // Treat this as page refresh, on non-Chrome browsers.
+        // Also see onPageHide below
+        this.tabState.clearSessionsByTabId(tabId); // for sanity
       }
 
       void this.updateVisualIndicators(tab);
@@ -125,6 +129,16 @@ export class TabEvents {
     const updated = this.windowState.setCurrentTabId(tab.windowId!, tab.id);
     if (!updated) return;
     await this.updateVisualIndicators(tab);
+  };
+
+  // In Chrome, we cannot rely on `onUpdatedTab` to detect page refresh, as
+  // `changeInfo.url` is unset during refreshes in Chrome. So, based on a
+  // message from content script (top-frame), we detect page unload to clear
+  // payment sessions/managers.
+  onPageHide = async (sender: Runtime.MessageSender) => {
+    const tabId = sender?.tab?.id;
+    if (!tabId) return; // Firefox doesn't have sender.tab after tab close
+    this.tabState.clearSessionsByTabId(tabId);
   };
 
   updateVisualIndicators = async (tab: Tabs.Tab) => {

--- a/src/background/services/tabState.ts
+++ b/src/background/services/tabState.ts
@@ -156,6 +156,7 @@ export class TabState {
   }
 
   clearSessionsByTabId(tabId: TabId) {
+    this.logger.trace('clearSessionsByTabId', tabId);
     this.currentIcon.delete(tabId);
     this.paymentManagers.destroy(tabId);
   }

--- a/src/content/__tests__/monetizationLinkManager.test.ts
+++ b/src/content/__tests__/monetizationLinkManager.test.ts
@@ -61,6 +61,7 @@ const msg: MessageMocks = {
   START_MONETIZATION: jest.fn(),
   STOP_MONETIZATION: jest.fn(),
   TAB_FOCUSED: jest.fn(),
+  PAGE_HIDE: jest.fn(),
 };
 const messageMock = jest.spyOn(messageManager, 'send');
 // @ts-expect-error let it go
@@ -1194,12 +1195,14 @@ describe('document events', () => {
 
     linkManager.start();
     await nextTick();
+    expect(msg.PAGE_HIDE).not.toHaveBeenCalled();
 
     window.dispatchEvent(new window.Event('pagehide'));
 
     expect(msg.STOP_MONETIZATION).toHaveBeenCalledWith([
       { requestId: 'uuid-1', intent: 'remove' },
     ]);
+    expect(msg.PAGE_HIDE).toHaveBeenCalled();
   });
 
   test('passes back focus events', async () => {

--- a/src/content/services/monetizationLinkManager.ts
+++ b/src/content/services/monetizationLinkManager.ts
@@ -26,6 +26,7 @@ export class MonetizationLinkManager {
   private documentObserver: MutationObserver;
   private monetizationLinkAttrObserver: MutationObserver;
   private id: string;
+  private _destroyed = false;
   // only entries corresponding to valid wallet addresses are here
   private monetizationLinks = new Map<
     HTMLLinkElement,
@@ -338,6 +339,7 @@ export class MonetizationLinkManager {
     if (this.document.visibilityState === 'visible') {
       await this.resumeMonetization();
     } else {
+      if (this._destroyed) return;
       await this.stopMonetization('pause');
     }
   };
@@ -349,7 +351,16 @@ export class MonetizationLinkManager {
   };
 
   private onPageHide = async () => {
-    await this.stopMonetization('remove');
+    if (this._destroyed) return;
+    this._destroyed = true;
+
+    void this.stopMonetization('remove');
+
+    if (this.isTopFrame) {
+      this.window.removeEventListener('pagehide', this.onPageHide);
+      await this.message.send('PAGE_HIDE');
+    }
+    this.end();
   };
 
   private async onWholeDocumentObserved(records: MutationRecord[]) {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -224,6 +224,10 @@ export type ContentToBackgroundMessage = {
     input: never;
     output: never;
   };
+  PAGE_HIDE: {
+    input: never;
+    output: never;
+  };
   STOP_MONETIZATION: {
     input: StopMonetizationPayload;
     output: never;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

On page refreshes/unloads, we were not clearing paymentManager correctly. We made use of individual `STOP_MONETIZATION` events to destroy/reset `paymentManger`, which was flaky, specially if a pause was emitted after stop, leading to state not being reset correctly.

## Changes proposed in this pull request

- Add a `PAGE_HIDE` message (only from top-level frame) to so we can use it to destroy `paymentManager` on page unload/refresh.
- Ensure `removeSession` works correctly, by not passing it incorrect `frameId` when iframes were involved (we always ended up passing `frameId = 0` from top frame.
- Prevent pause-all from being called after pagehide.
- Add some more logging.