### PR TITLE
refactor(popup): extract and reuse `toErrorInfo`

### DIFF
--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -10,7 +10,12 @@ import {
   InputAmount,
   validateAmount,
 } from '@/pages/shared/components/InputAmount';
-import { cn, formatNumber } from '@/pages/shared/lib/utils';
+import {
+  cn,
+  formatNumber,
+  toErrorInfoFactory,
+  type ErrorInfo,
+} from '@/pages/shared/lib/utils';
 import { useTranslation } from '@/popup/lib/context';
 import { deepClone } from 'valtio/utils';
 import {
@@ -35,7 +40,6 @@ interface Inputs {
 }
 
 type ConnectTransientState = DeepReadonly<PopupTransientState['connect']>;
-type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'walletAddressUrl' | 'amount' | 'keyPair' | 'connect';
 type Errors = Record<ErrorsParams, ErrorInfo | null>;
 
@@ -69,6 +73,7 @@ export const ConnectWalletForm = ({
   onConnect = () => {},
 }: ConnectWalletFormProps) => {
   const t = useTranslation();
+  const toErrorInfo = React.useMemo(() => toErrorInfoFactory(t), [t]);
 
   const [walletAddressUrl, setWalletAddressUrl] = React.useState<
     Inputs['walletAddressUrl']
@@ -93,18 +98,6 @@ export const ConnectWalletForm = ({
     setErrors((prev) => ({ ...prev, keyPair: null, connect: null }));
     setAutoKeyShareFailed(false);
   }, [clearConnectState]);
-
-  const toErrorInfo = React.useCallback(
-    (
-      err?: string | DeepReadonly<ErrorWithKeyLike> | null,
-    ): ErrorInfo | null => {
-      if (!err) return null;
-      if (typeof err === 'string') return { message: err };
-      // @ts-expect-error readonly, it's ok
-      return { message: t(err), info: err };
-    },
-    [t],
-  );
 
   const [walletAddressInfo, setWalletAddressInfo] =
     React.useState<ConnectWalletAddressInfo | null>(null);

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -2,28 +2,24 @@ import React from 'react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
 import { FadeInOut } from '@/pages/shared/components/FadeInOut';
-import { roundWithPrecision, cn } from '@/pages/shared/lib/utils';
-import type { ErrorWithKeyLike } from '@/shared/helpers';
+import {
+  roundWithPrecision,
+  cn,
+  toErrorInfoFactory,
+  type ErrorInfo,
+} from '@/pages/shared/lib/utils';
 import { useMessage, useTranslation } from '@/popup/lib/context';
 import { usePopupState } from '@/popup/lib/store';
 
-type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'amount' | 'pay';
 type Errors = Record<ErrorsParams, ErrorInfo | null>;
 
 export const PayWebsiteForm = () => {
   const t = useTranslation();
+  const toErrorInfo = React.useMemo(() => toErrorInfoFactory(t), [t]);
+
   const message = useMessage();
   const { walletAddress, tab } = usePopupState();
-
-  const toErrorInfo = React.useCallback(
-    (err?: string | ErrorWithKeyLike | null): ErrorInfo | null => {
-      if (!err) return null;
-      if (typeof err === 'string') return { message: err };
-      return { message: t(err), info: err };
-    },
-    [t],
-  );
 
   const [amount, setAmount] = React.useState('');
   const [errors, setErrors] = React.useState<Errors>({

--- a/src/pages/popup/components/Settings/Budget.tsx
+++ b/src/pages/popup/components/Settings/Budget.tsx
@@ -3,11 +3,8 @@ import { Switch } from '@/pages/shared/components/ui/Switch';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
 import { ErrorMessage } from '@/pages/shared/components/ErrorMessage';
-import {
-  type ErrorWithKeyLike,
-  getNextOccurrence,
-  transformBalance,
-} from '@/shared/helpers';
+import { toErrorInfoFactory, type ErrorInfo } from '@/pages/shared/lib/utils';
+import { getNextOccurrence, transformBalance } from '@/shared/helpers';
 import { useMessage, useTranslation } from '@/popup/lib/context';
 import type { Response, UpdateBudgetPayload } from '@/shared/messages';
 import type { PopupState } from '@/popup/lib/store';
@@ -39,7 +36,6 @@ type BudgetAmountProps = {
   onBudgetChanged: () => void;
 };
 
-type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
 type ErrorsParams = 'amount' | 'root';
 type Errors = Record<ErrorsParams, ErrorInfo | null>;
 
@@ -50,15 +46,7 @@ const BudgetAmount = ({
   onBudgetChanged,
 }: BudgetAmountProps) => {
   const t = useTranslation();
-
-  const toErrorInfo = React.useCallback(
-    (err?: string | ErrorWithKeyLike | null): ErrorInfo | null => {
-      if (!err) return null;
-      if (typeof err === 'string') return { message: err };
-      return { message: t(err), info: err };
-    },
-    [t],
-  );
+  const toErrorInfo = React.useMemo(() => toErrorInfoFactory(t), [t]);
 
   const originalValues = {
     walletAddressUrl: walletAddress.id,

--- a/src/pages/shared/lib/utils.ts
+++ b/src/pages/shared/lib/utils.ts
@@ -1,5 +1,8 @@
 import { cx, type CxOptions } from 'class-variance-authority';
 import { twMerge } from 'tailwind-merge';
+import type { useTranslation } from './context';
+import type { DeepReadonly } from '@/shared/types';
+import type { ErrorWithKeyLike } from '@/shared/helpers';
 
 export const getCurrencySymbol = (assetCode: string): string => {
   if (!isISO4217Code(assetCode)) {
@@ -87,3 +90,16 @@ export function formatNumber(
 export const cn = (...inputs: CxOptions) => {
   return twMerge(cx(inputs));
 };
+
+export type ErrorInfo = { message: string; info?: ErrorWithKeyLike };
+
+export function toErrorInfoFactory(t: ReturnType<typeof useTranslation>) {
+  return (
+    err?: string | DeepReadonly<ErrorWithKeyLike> | null,
+  ): ErrorInfo | null => {
+    if (!err) return null;
+    if (typeof err === 'string') return { message: err };
+    // @ts-expect-error readonly, it's ok
+    return { message: t(err), info: err };
+  };
+}


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Extracted from https://github.com/interledger/web-monetization-extension/pull/1122

## Changes proposed in this pull request

Extract `ErrorInfo` type and `toErrorInfoFactory` as helpers.