### PR TITLE
fix: get connect wallet info via background only

### DIFF
--- a/src/pages/app/pages/PostInstall.tsx
+++ b/src/pages/app/pages/PostInstall.tsx
@@ -4,11 +4,8 @@ import {
   CaretDownIcon,
   ExternalIcon,
 } from '@/pages/shared/components/Icons';
-import {
-  getBrowserName,
-  getConnectWalletInfo,
-  type BrowserName,
-} from '@/shared/helpers';
+import { getBrowserName, type BrowserName } from '@/shared/helpers';
+import { getResponseOrThrow } from '@/shared/messages';
 import { useBrowser, useTranslation } from '@/app/lib/context';
 import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
 import { cn } from '@/pages/shared/lib/utils';
@@ -466,7 +463,11 @@ function StepConnectWallet({
         saveValue={(key, val) => {
           localStorage?.setItem(`connect.${key}`, val.toString());
         }}
-        getWalletInfo={getConnectWalletInfo}
+        getWalletInfo={(walletAddressUrl) =>
+          message
+            .send('GET_CONNECT_WALLET_ADDRESS_INFO', walletAddressUrl)
+            .then(getResponseOrThrow)
+        }
         walletAddressPlaceholder={selectedWallet.walletAddressPlaceholder}
         connectWallet={(data) => message.send('CONNECT_WALLET', data)}
         clearConnectState={() => message.send('RESET_CONNECT_STATE')}

--- a/src/pages/popup/pages/ConnectWallet.tsx
+++ b/src/pages/popup/pages/ConnectWallet.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useLocation } from 'wouter';
+import { getResponseOrThrow } from '@/shared/messages';
 import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
 import { useMessage } from '@/popup/lib/context';
-import { getConnectWalletInfo } from '@/shared/helpers';
 import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '@/popup/Popup';
 
@@ -30,7 +30,11 @@ export default () => {
       saveValue={(key, val) => {
         localStorage?.setItem(`connect.${key}`, val.toString());
       }}
-      getWalletInfo={getConnectWalletInfo}
+      getWalletInfo={(walletAddressUrl) =>
+        message
+          .send('GET_CONNECT_WALLET_ADDRESS_INFO', walletAddressUrl)
+          .then(getResponseOrThrow)
+      }
       connectWallet={(data) => message.send('CONNECT_WALLET', data)}
       onConnect={() => {
         // The popup closes due to redirects on connect, so we don't need to

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -29,6 +29,13 @@ export type Response<TPayload = void> =
   | SuccessResponse<TPayload>
   | ErrorResponse;
 
+export function getResponseOrThrow<T>(res: Response<T>) {
+  if (res.success) {
+    return res.payload;
+  }
+  throw res.error ?? new Error(res.message);
+}
+
 type MessageMap = Record<string, { input: unknown; output: unknown }>;
 type MessagesWithInput<T extends MessageMap> = {
   [K in keyof T as T[K]['input'] extends never ? never : K]: T[K];
@@ -248,6 +255,10 @@ export type AppToBackgroundMessage = {
   GET_DATA_APP: {
     input: never;
     output: AppState;
+  };
+  GET_CONNECT_WALLET_ADDRESS_INFO: {
+    input: GetWalletAddressInfoPayload['walletAddressUrl'];
+    output: ConnectWalletAddressInfo;
   };
   CONNECT_WALLET: PopupToBackgroundMessage['CONNECT_WALLET'];
   RESET_CONNECT_STATE: PopupToBackgroundMessage['RESET_CONNECT_STATE'];


### PR DESCRIPTION
## Context

https://github.com/interledger/web-monetization-extension/pull/1073 added this message, but we were doing fetches from frontend directly.

## Changes proposed in this pull request

- Use the `GET_CONNECT_WALLET_ADDRESS_INFO` message
- Add a util `getResponseOrThrow` to throw when `Response` isn't successful.
