### PR TITLE
test(e2e): update expected payment flow for multiple links

### DIFF
--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -29,6 +29,7 @@ export const test = base.extend<Fixtures>({
   context: [
     async ({ browserName, channel }, use, testInfo) => {
       const context = await loadContext({ browserName, channel }, testInfo);
+      await context.clock.install();
       await use(context);
       await context.close();
     },

--- a/tests/e2e/multiple.spec.ts
+++ b/tests/e2e/multiple.spec.ts
@@ -202,7 +202,7 @@ test.describe('should monetized site with multiple wallet address', () => {
 
       expect(
         monetizationCallback.calls.map(([ev]) => ev.paymentPointer).sort(),
-        'monetization callback is called once for each wallet address',
+        'monetization callback is called twice for each wallet address',
       ).toEqual([...walletAddresses, ...walletAddresses].sort());
     });
 

--- a/tests/e2e/multiple.spec.ts
+++ b/tests/e2e/multiple.spec.ts
@@ -1,3 +1,4 @@
+import { MIN_PAYMENT_WAIT } from '@/background/config';
 import { test, expect, DEFAULT_BUDGET } from './fixtures/connected';
 import {
   getWalletInfoCached,
@@ -53,7 +54,15 @@ const orderById = <T extends { id: string }>(a: T, b: T) =>
   a.id.localeCompare(b.id);
 
 test.describe('should monetized site with multiple wallet address', () => {
-  test('same currency', async ({ page, popup }) => {
+  test('same currency', async ({ page, popup, background, context }) => {
+    // At rateOfPay=3600, we pay $0.01 every second. But given minimum interval
+    // is 2s, we'll need to wait for 2s.
+    const rateOfPay = '3600';
+    const interval = MIN_PAYMENT_WAIT;
+    await background.evaluate((rateOfPay) => {
+      return chrome.storage.local.set({ rateOfPay });
+    }, rateOfPay);
+
     const walletAddresses = [
       walletAddressUrl,
       walletAddressUrlSameCurrency,
@@ -65,11 +74,38 @@ test.describe('should monetized site with multiple wallet address', () => {
     );
 
     await test.step('continuous payments', async () => {
-      await expect(monetizationCallback).toHaveBeenCalledTimes(count);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(1);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[0],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(2);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[1],
+      });
+
       expect(
         monetizationCallback.calls.map(([ev]) => ev.paymentPointer).sort(),
         'monetization callback is called once for each wallet address',
-      ).toEqual(walletAddresses);
+      ).toEqual([...walletAddresses].sort());
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(3);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[0],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(4);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[1],
+      });
+
+      expect(
+        monetizationCallback.calls.map(([ev]) => ev.paymentPointer).sort(),
+        'monetization callback is called twice for each wallet address',
+      ).toEqual([...walletAddresses, ...walletAddresses].sort());
     });
 
     await setContinuousPayments(popup, false);
@@ -101,7 +137,15 @@ test.describe('should monetized site with multiple wallet address', () => {
     });
   });
 
-  test('different currencies', async ({ page, popup, context }) => {
+  test('different currencies', async ({ page, popup, background, context }) => {
+    // At rateOfPay=3600, we pay $0.01 every second. But given minimum interval
+    // is 2s, we'll need to wait for 2s.
+    const rateOfPay = '3600';
+    const interval = MIN_PAYMENT_WAIT;
+    await background.evaluate((rateOfPay) => {
+      return chrome.storage.local.set({ rateOfPay });
+    }, rateOfPay);
+
     const walletAddressesInfo = [
       walletInfoSameCurrency,
       walletInfoWeakerCurrency,
@@ -116,11 +160,50 @@ test.describe('should monetized site with multiple wallet address', () => {
     );
 
     await test.step('continuous payments', async () => {
-      await expect(monetizationCallback).toHaveBeenCalledTimes(count);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(1);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[0],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(2);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[1],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(3);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[2],
+      });
+
       expect(
         monetizationCallback.calls.map(([ev]) => ev.paymentPointer).sort(),
         'monetization callback is called once for each wallet address',
-      ).toEqual(walletAddresses);
+      ).toEqual([...walletAddresses].sort());
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(4);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[0],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(5);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[1],
+      });
+
+      await context.clock.runFor(interval);
+      await expect(monetizationCallback).toHaveBeenCalledTimes(6);
+      await expect(monetizationCallback).toHaveBeenLastCalledWithMatching({
+        paymentPointer: walletAddresses[2],
+      });
+
+      expect(
+        monetizationCallback.calls.map(([ev]) => ev.paymentPointer).sort(),
+        'monetization callback is called once for each wallet address',
+      ).toEqual([...walletAddresses, ...walletAddresses].sort());
     });
 
     await setContinuousPayments(popup, false);

--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -24,6 +24,8 @@ test('Reconnect to test wallet with automatic key addition', async ({
   background,
   i18n,
 }) => {
+  test.slow();
+
   const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
   const revokeInfo = await test.step('connect wallet', async () => {
     const connectButton = await test.step('fill popup', async () => {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

https://github.com/interledger/web-monetization-extension/pull/1066 updated continuous payment logic, but our E2E tests lagged behind.
Also had to update playground a bit to make tests more reliable: https://github.com/WICG/webmonetization/pull/545.

## Changes proposed in this pull request

- Update E2E tests for multiple wallet addresses' continuous payments
- Also mark a test (`reconnectAutoKeyTestWallet.spec.ts`) as slow, as it can take upto ~40s now, instead of default 30s.
