### PR TITLE
test(e2e/connectAutoKeyChimoney): don't require login on consent

### DIFF
--- a/tests/e2e/connectAutoKeyChimoney.spec.ts
+++ b/tests/e2e/connectAutoKeyChimoney.spec.ts
@@ -171,21 +171,6 @@ for (const testCase of TEST_CASES) {
       });
 
       await test.step('shows connect consent page', async () => {
-        // Chimoney asks for login before consent page additionally?
-        await page.waitForURL((url) => url.href.startsWith(URLS.login));
-        await expect(page.locator('form')).toBeVisible();
-        const url = page.url();
-        if (
-          (url.includes('/app') && testCase.type !== 'app') ||
-          (url.includes('/business') && testCase.type !== 'business')
-        ) {
-          await page.locator('a', { hasText: LOGIN_PAGE_LINK_TEXT }).click();
-          await expect(page.locator('form')).toBeVisible();
-        }
-        await page.waitForURL((url) => url.href.startsWith(URLS.login));
-
-        await login(page, { username, password });
-
         await waitForGrantConsentPage(page);
         await expect(
           page.getByRole('button', { name: 'Accept', exact: true }),


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Either Chimoney improved it, or https://github.com/interledger/web-monetization-extension/pull/1125 helped.
Another E2E test to pass!

## Changes proposed in this pull request


