### PR TITLE
chore(ci/test-e2e): run on each PR from maintainers as well

### DIFF
--- a/.github/actions/tests-e2e-filter.cjs
+++ b/.github/actions/tests-e2e-filter.cjs
@@ -1,0 +1,56 @@
+// @ts-check
+
+/**
+ * @typedef {import('@octokit/openapi-webhooks-types').components['schemas']} Schemas
+ * @typedef {Schemas['webhook-pull-request-review-submitted']} PullRequestReviewSubmitted
+ * @typedef {Schemas['webhook-pull-request-opened']} PullRequest
+ */
+
+/**
+ * Retrieves the manifest version from the built extension.
+ * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
+ */
+module.exports = async ({ core, context }) => {
+  if (context.eventName === 'pull_request') {
+    const event = /** @type {PullRequest} */ (context.payload);
+    if (isAllowedAuthor(event.pull_request.author_association)) {
+      core.setOutput('chromium', true);
+      return;
+    }
+  } else if (context.eventName === 'pull_request_review') {
+    const event = /** @type {PullRequestReviewSubmitted} */ (context.payload);
+    if (
+      event.review.body === 'test-e2e' &&
+      isAllowedAuthor(event.review.author_association)
+    ) {
+      core.setOutput('chromium', true);
+      core.setOutput('chrome', true);
+      core.setOutput('msedge', true);
+      return;
+    }
+  }
+
+  skip(core);
+};
+
+/**
+ * @param {Schemas['author-association']} authorAssociation
+ */
+function isAllowedAuthor(authorAssociation) {
+  return (
+    authorAssociation === 'OWNER' ||
+    authorAssociation === 'MEMBER' ||
+    authorAssociation === 'COLLABORATOR'
+  );
+}
+
+/**
+ * @param {import('github-script').AsyncFunctionArguments['core']} core
+ * @returns {never}
+ */
+function skip(core) {
+  core.setOutput('chromium', false);
+  core.setOutput('chrome', false);
+  core.setOutput('msedge', false);
+  process.exit(0);
+}

--- a/.github/actions/tests-e2e-filter.cjs
+++ b/.github/actions/tests-e2e-filter.cjs
@@ -14,7 +14,7 @@ module.exports = async ({ core, context }) => {
   if (context.eventName === 'pull_request') {
     const event = /** @type {PullRequest} */ (context.payload);
     if (isAllowedAuthor(event.pull_request.author_association)) {
-      core.setOutput('chromium', true);
+      core.setOutput('matrix', getMatrix(['chromium']));
       return;
     }
   } else if (context.eventName === 'pull_request_review') {
@@ -23,9 +23,7 @@ module.exports = async ({ core, context }) => {
       event.review.body === 'test-e2e' &&
       isAllowedAuthor(event.review.author_association)
     ) {
-      core.setOutput('chromium', true);
-      core.setOutput('chrome', true);
-      core.setOutput('msedge', true);
+      core.setOutput('matrix', getMatrix(['chromium', 'chrome', 'msedge']));
       return;
     }
   }
@@ -49,8 +47,33 @@ function isAllowedAuthor(authorAssociation) {
  * @returns {never}
  */
 function skip(core) {
-  core.setOutput('chromium', false);
-  core.setOutput('chrome', false);
-  core.setOutput('msedge', false);
+  core.setOutput('matrix', getMatrix([]));
   process.exit(0);
+}
+
+/**
+ * @typedef {'chromium' | 'chrome' | 'msedge'} Project
+ * @param {Project[]} projects
+ */
+function getMatrix(projects) {
+  return [
+    {
+      name: 'Chromium',
+      project: /** @type {Project} */ ('chromium'),
+      target: 'chrome',
+      'runs-on': 'ubuntu-22.04',
+    },
+    {
+      name: 'Chrome',
+      project: /** @type {Project} */ ('chrome'),
+      target: 'chrome',
+      'runs-on': 'ubuntu-22.04',
+    },
+    {
+      name: 'Edge',
+      project: /** @type {Project} */ ('msedge'),
+      target: 'chrome',
+      'runs-on': 'ubuntu-22.04',
+    },
+  ].filter((p) => projects.includes(p.project));
 }

--- a/.github/actions/tests-e2e-filter.cjs
+++ b/.github/actions/tests-e2e-filter.cjs
@@ -14,26 +14,26 @@ module.exports = async ({ core, context }) => {
   if (context.eventName === 'pull_request') {
     const event = /** @type {PullRequest} */ (context.payload);
     if (!isAllowedAuthor(event.pull_request.author_association)) {
-      skip(core, 'The PR author is not allowed to run them.');
+      await skip(core, 'The PR author is not allowed to run them.');
     }
 
     const matrix = getMatrix(['chromium']);
     core.setOutput('matrix', matrix);
-    core.info(`Running tests for ${matrix.map((m) => m.name).join(', ')}`);
+    core.info(`Running E2E tests for ${matrix.map((m) => m.name).join(', ')}`);
   }
 
   if (context.eventName === 'pull_request_review') {
     const event = /** @type {PullRequestReviewSubmitted} */ (context.payload);
     if (event.review.body !== 'test-e2e') {
-      skip(core, 'The review comment body is not `test-e2e`');
+      await skip(core, 'The review comment body is not `test-e2e`');
     }
     if (!isAllowedAuthor(event.review.author_association)) {
-      skip(core, 'The review author is not allowed to run them.');
+      await skip(core, 'The review author is not allowed to run them.');
     }
 
     const matrix = getMatrix(['chromium', 'chrome', 'msedge']);
     core.setOutput('matrix', matrix);
-    core.info(`Running tests for ${matrix.map((m) => m.name).join(', ')}`);
+    core.info(`Running E2E tests for ${matrix.map((m) => m.name).join(', ')}`);
   }
 };
 
@@ -51,11 +51,12 @@ function isAllowedAuthor(authorAssociation) {
 /**
  * @param {import('github-script').AsyncFunctionArguments['core']} core
  * @param {string} reason
- * @returns {never}
+ * @returns {Promise<never>}
  */
-function skip(core, reason) {
-  void core.summary.addQuote(`Skipping tests: ${reason}`).write();
+async function skip(core, reason) {
+  core.info('Skipping running E2E tests.');
   core.setOutput('matrix', getMatrix([]));
+  await core.summary.addQuote(`Skipping tests: ${reason}`).write();
   process.exit(0);
 }
 

--- a/.github/actions/tests-e2e-filter.cjs
+++ b/.github/actions/tests-e2e-filter.cjs
@@ -7,7 +7,6 @@
  */
 
 /**
- * Retrieves the manifest version from the built extension.
  * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
  */
 module.exports = async ({ core, context }) => {

--- a/.github/actions/tests-e2e-filter.cjs
+++ b/.github/actions/tests-e2e-filter.cjs
@@ -54,6 +54,7 @@ function isAllowedAuthor(authorAssociation) {
  */
 async function skip(core, reason) {
   core.info('Skipping running E2E tests.');
+  core.setOutput('skip', true);
   core.setOutput('matrix', getMatrix([]));
   await core.summary.addQuote(`Skipping tests: ${reason}`).write();
   process.exit(0);

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -2,13 +2,35 @@ name: End-to-End Tests
 on:
   pull_request_review:
     types: [submitted]
+  pull_request:
+    branches: [main, 'v[0-9]+.x']
 
 jobs:
+  filter:
+    name: Prepare
+    runs-on: ubuntu-22.04
+    outputs:
+      chromium: ${{ steps.filter.outputs.chromium }}
+      chrome: ${{ steps.filter.outputs.chrome }}
+      msedge: ${{ steps.filter.outputs.msedge }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # TODO: remove me
+      - name: Environment setup
+        uses: ./.github/actions/setup
+
+      - name: Find tests to run
+        id: filter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/actions/tests-e2e-filter.cjs')
+            await script({ github, context, core })
+
   test-e2e:
-    if: ${{
-      github.event.review.body == 'test-e2e' &&
-      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
-      }}
+    needs: prepare
+    if: needs.filter.outputs[matrix.project] == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -2,7 +2,8 @@ name: End-to-End Tests
 on:
   pull_request_review:
     types: [submitted]
-  pull_request: {}
+  pull_request:
+    branches: [main, 'v[0-9]+.x']
 
 jobs:
   filter:
@@ -29,7 +30,6 @@ jobs:
 
   test-e2e:
     needs: prepare
-    if: needs.filter.outputs[matrix.project] == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,8 @@ jobs:
             runs-on: ubuntu-22.04
 
     timeout-minutes: 15
-    name: E2E Tests - ${{ matrix.name }}
+    if: ${{ needs.filter.outputs[matrix.project] == 'true' }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     environment: test
     steps:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -10,9 +10,7 @@ jobs:
     name: Prepare
     runs-on: ubuntu-22.04
     outputs:
-      chromium: ${{ steps.filter.outputs.chromium }}
-      chrome: ${{ steps.filter.outputs.chrome }}
-      msedge: ${{ steps.filter.outputs.msedge }}
+      matrix: ${{ steps.filter.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,26 +31,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Chromium
-            project: chromium
-            target: chrome
-            runs-on: ubuntu-22.04
-          - name: Chrome
-            project: chrome
-            target: chrome
-            runs-on: ubuntu-22.04
-          # - name: Firefox
-          #   project: firefox
-          #   target: firefox
-          #   runs-on: ubuntu-22.04
-          - name: Edge
-            project: msedge
-            target: chrome
-            runs-on: ubuntu-22.04
+        include: ${{ fromJson(needs.filter.outputs.matrix) }}
 
     timeout-minutes: 15
-    if: ${{ needs.filter.outputs[matrix.project] == 'true' }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     environment: test

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -2,8 +2,7 @@ name: End-to-End Tests
 on:
   pull_request_review:
     types: [submitted]
-  pull_request:
-    branches: [main, 'v[0-9]+.x']
+  pull_request: {}
 
 jobs:
   filter:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -27,7 +27,7 @@ jobs:
             await script({ github, context, core })
 
   test-e2e:
-    needs: prepare
+    needs: filter
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
+      skip: ${{ steps.filter.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
       - name: Environment setup
@@ -26,6 +27,7 @@ jobs:
 
   test-e2e:
     needs: filter
+    if: needs.filter.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -13,8 +13,6 @@ jobs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # TODO: remove me
       - name: Environment setup
         uses: ./.github/actions/setup
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@biomejs/biome": "2.0.6",
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
     "@jgoz/jest-esbuild": "^1.0.9",
+    "@octokit/openapi-webhooks-types": "^12.0.3",
     "@playwright/test": "^1.53.2",
     "@tailwindcss/forms": "^0.5.10",
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@jgoz/jest-esbuild':
         specifier: ^1.0.9
         version: 1.0.9(@babel/core@7.27.4)(esbuild@0.25.6)(jest@30.0.4(@types/node@22.15.32)(ts-node@10.9.2(@types/node@22.15.32)(typescript@5.8.3)))
+      '@octokit/openapi-webhooks-types':
+        specifier: ^12.0.3
+        version: 12.0.3
       '@playwright/test':
         specifier: ^1.53.2
         version: 1.53.2
@@ -858,6 +861,9 @@ packages:
 
   '@octokit/openapi-types@22.2.0':
     resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
+
+  '@octokit/openapi-webhooks-types@12.0.3':
+    resolution: {integrity: sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==}
 
   '@octokit/plugin-paginate-rest@9.2.1':
     resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
@@ -4291,6 +4297,8 @@ snapshots:
   '@octokit/openapi-types@20.0.0': {}
 
   '@octokit/openapi-types@22.2.0': {}
+
+  '@octokit/openapi-webhooks-types@12.0.3': {}
 
   '@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.2.0)':
     dependencies:


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

To make sure E2E test failures aren't easily ignored.

## Changes proposed in this pull request

- Run E2E tests automatically on each PR from repo maintainers (or those with write access)
- Run only for Chromium to keep things lighter
   - Can still run all tests with `test-e2e` review comment from maintainers for other cases
- Add `.github/actions/tests-e2e-filter.cjs` helper as a "Prepare" step to detect which tests to run, and if should run tests.
   - Can improve this in future further to only run specific tests based on changed files, review comment body details etc.
   - Had to dynamically generate `matrix` as we cannot use matrix with `if` on job-level.