### PR TITLE
chore(tests/e2e): save cookies outside of `test-results` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,6 @@ src/safari/Web Monetization/Shared \(Extension\)/Resources/*
 
 # playwright
 /tests/e2e/test-results/
-/tests/e2e/test-results/.auth
+/tests/e2e/.auth
 /tests/e2e/playwright-report/
 /playwright/.cache/

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -12,6 +12,7 @@ import {
   type WorkerInfo,
   type Worker,
 } from '@playwright/test';
+import { format } from 'date-fns';
 import { APP_URL } from '@/background/constants';
 import { DIST_DIR, ROOT_DIR } from '../../../esbuild/config';
 import type { TranslationKeys } from '../../../src/shared/helpers';
@@ -26,9 +27,8 @@ export const BUILD_DIR = DIST_DIR;
 // https://playwright.dev/docs/auth#basic-shared-account-in-all-tests
 export const authFile = path.join(
   testDir,
-  'test-results',
   '.auth',
-  'rafiki-money.json',
+  `testnet-${format(new Date(), 'yyyyII')}.json`,
 );
 
 const FIREFOX_ADDON_UUID = crypto.randomUUID();


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

When re-running tests locally, we've to go through the auth.setup step each time, as the `test-results` folder gets cleared on each test run, making repetitive testing slower locally.

## Changes proposed in this pull request

Store auth cookies in `.auth` folder, and store that data weekly (`yyyy` followed by week number of the year (`II`)).