### PR TITLE
fix(one-time-payment): start polling timeout after making payment

### DIFF
--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -7,7 +7,6 @@ import type {
   StopMonetizationPayload,
 } from '@/shared/messages';
 import { getSender, getTabId } from '@/background/utils';
-import { OUTGOING_PAYMENT_POLLING_MAX_DURATION } from '@/background/config';
 import {
   ErrorWithKey,
   isOkState,
@@ -313,11 +312,10 @@ export class MonetizationService {
       throw new ErrorWithKey('pay_error_notMonetized');
     }
 
-    const signal = AbortSignal.timeout(OUTGOING_PAYMENT_POLLING_MAX_DURATION); // can use other signals as well, such as popup closed etc.
     const amountToSend = BigInt(
       (Number(amount) * 10 ** walletAddress.assetScale).toFixed(0),
     );
-    const result = await paymentManager.pay(amountToSend, signal);
+    const result = await paymentManager.pay(amountToSend);
 
     const { sentAmount, debitAmount } = result.amounts;
     return {

--- a/src/background/services/paymentManager.ts
+++ b/src/background/services/paymentManager.ts
@@ -8,7 +8,8 @@ import type { PaymentSession } from './paymentSession';
 import {
   MIN_PAYMENT_WAIT,
   OUTGOING_PAYMENT_POLLING_MAX_ATTEMPTS,
-} from '../config';
+  OUTGOING_PAYMENT_POLLING_MAX_DURATION,
+} from '@/background/config';
 import { bigIntMax } from '../utils';
 import {
   ErrorWithKey,
@@ -183,7 +184,7 @@ export class PaymentManager {
   // #endregion
 
   // #region One time payment
-  async pay(amount: bigint, signal?: AbortSignal) {
+  async pay(amount: bigint) {
     const payableSessions = this.payableSessions;
     if (!payableSessions.length) {
       throw new Error('No sessions to pay');
@@ -219,6 +220,7 @@ export class PaymentManager {
     );
 
     this.logger.debug('polling outgoing payments for completion');
+    const signal = AbortSignal.timeout(OUTGOING_PAYMENT_POLLING_MAX_DURATION); // can combined with other signals as well, such as popup closed etc.
     const result = await this.getPayStatus(
       outgoingPaymentResults,
       Array.from(distribution.keys()),


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Reported by Chimoney that they were often getting "taking too long" message.

If making the payment took longer, we had less time for polling afterwards. Other wallets were making payments faster (maybe faster sandbox account), so it wasn’t caught.

Aside: maybe the timeout earlier meant user facing timeout after they click the pay button - it included the payment + polling. Or, it was regressed at some stage.

Might relate to https://github.com/interledger/web-monetization-extension/issues/877, but not enough data in that issue.

## Changes proposed in this pull request

Start polling timeout after making the payment, so the polling timeout does what its name says.
