### PR TITLE
fix: support force disconnect wallet in case of error

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -54,6 +54,12 @@
   "keyRevoked_action_reconnectBtn": {
     "message": "Reconnect"
   },
+  "disconnectWallet_error_generic": {
+    "message": "We were unable to disconnect your wallet ($ERROR$).",
+    "placeholders": {
+      "ERROR": { "content": "$1", "example": "Internal server error" }
+    }
+  },
   "pay_action_pay": {
     "message": "Send now"
   },

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -266,12 +266,12 @@ export class Background {
               return;
 
             case 'DISCONNECT_WALLET':
-              await this.walletService.disconnectWallet();
+              await this.walletService.disconnectWallet(message.payload.force);
               this.tabState.clearAllState('disconnect');
               await this.browser.alarms.clear(ALARM_RESET_OUT_OF_FUNDS);
               await this.updateVisualIndicatorsForCurrentTab();
               this.sendToPopup.send('SET_STATE', { state: {}, prevState: {} });
-              return;
+              return success(undefined);
 
             case 'TOGGLE_CONTINUOUS_PAYMENTS': {
               await this.monetizationService.toggleContinuousPayments();

--- a/src/background/services/openPayments.ts
+++ b/src/background/services/openPayments.ts
@@ -212,7 +212,7 @@ export class OpenPaymentsService {
   }
 }
 
-const isOpenPaymentsClientError = (error: unknown) =>
+export const isOpenPaymentsClientError = (error: unknown) =>
   error instanceof OpenPaymentsClientError;
 
 export const isKeyRevokedError = (error: unknown) => {

--- a/src/pages/popup/components/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/components/ErrorKeyRevoked.tsx
@@ -11,7 +11,7 @@ import type { ReconnectWalletPayload, Response } from '@/shared/messages';
 
 interface Props {
   info: Pick<PopupStore, 'publicKey' | 'walletAddress'>;
-  disconnectWallet: () => Promise<Response>;
+  disconnectWallet: (force: boolean) => Promise<Response>;
   reconnectWallet: (data: ReconnectWalletPayload) => Promise<Response>;
   onReconnect?: () => void;
   onDisconnect?: () => void;
@@ -90,7 +90,7 @@ const MainScreen = ({
     setErrorMsg('');
     try {
       setIsLoading(true);
-      await disconnectWallet();
+      await disconnectWallet(true);
       onDisconnect?.();
     } catch (error) {
       setErrorMsg(error.message);

--- a/src/pages/popup/pages/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/pages/ErrorKeyRevoked.tsx
@@ -32,7 +32,7 @@ export default () => {
       info={{ publicKey, walletAddress }}
       reconnectWallet={(data) => message.send('RECONNECT_WALLET', data)}
       onReconnect={onReconnect}
-      disconnectWallet={() => message.send('DISCONNECT_WALLET')}
+      disconnectWallet={(force) => message.send('DISCONNECT_WALLET', { force })}
       onDisconnect={onDisconnect}
     />
   );

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -177,7 +177,7 @@ export type PopupToBackgroundMessage = {
     output: never;
   };
   DISCONNECT_WALLET: {
-    input: never;
+    input: { force: boolean };
     output: never;
   };
   TOGGLE_CONTINUOUS_PAYMENTS: {


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1162

## Changes proposed in this pull request

When there are issues with disconnecting wallet, show user an error and allow force disconnecting.

<img width="959" height="1097" alt="image" src="https://github.com/user-attachments/assets/2be94d7d-4a70-48a6-bd6b-877b54fd5528" />

The error is only shown when disconnecting from WalletInfo page. On keyRevoked error page, I decided to enable `force` by default to not add new UI.


Note: When we do a force disconnect, the access token isn't revoked from wallet end. We just delete it from our local storage (forget about it), so the user can move forward with their life. Hence, there can be dangling grants shown in wallet UI.

---

I considered adding a job queue for when things fail and doing them later on, but it had issues with authentication (in case client changed after a reconnect etc.). So, decided to keep it simple.