### PR TITLE
fix(AutoKeyAddConsent): update message to reflect data "sharing"

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -216,9 +216,15 @@
     "description": "Learn more about how this works"
   },
   "connectWalletKeyService_text_consentP2": {
-    "message": "By agreeing, you provide us consent to automatically access your wallet to securely add a key."
+    "message": "By agreeing, you consent to us:"
   },
   "connectWalletKeyService_text_consentP3": {
+    "message": "Automatically & securely adding a key to your wallet, and"
+  },
+  "connectWalletKeyService_text_consentP4": {
+    "message": "Sharing your browser and extension names with your wallet."
+  },
+  "connectWalletKeyService_text_consent_no_access_funds": {
     "message": "Please note, this process does not involve accessing or handling your funds."
   },
   "connectWalletKeyService_label_consentAccept": {

--- a/src/pages/shared/components/AutoKeyAddConsent.tsx
+++ b/src/pages/shared/components/AutoKeyAddConsent.tsx
@@ -36,9 +36,15 @@ export const AutoKeyAddConsent = ({ onAccept, onDecline, intent }: Props) => {
         </a>
       </p>
 
-      <div className="space-y-2 pt-12 text-medium">
+      <div className="space-y-2 pt-12 text-medium text-left">
         <p>{t('connectWalletKeyService_text_consentP2')}</p>
-        <p>{t('connectWalletKeyService_text_consentP3')}</p>
+        <ul className="list-disc px-2 pb-4">
+          <li>{t('connectWalletKeyService_text_consentP3')}</li>
+          <li>{t('connectWalletKeyService_text_consentP4')}</li>
+        </ul>
+        <p className="text-center">
+          {t('connectWalletKeyService_text_consent_no_access_funds')}
+        </p>
       </div>
 
       <div className="mx-auto flex w-3/4 justify-around gap-4">


### PR DESCRIPTION
## Context

Firefox add-ons reviewer concerns on data collection consent.

## Changes proposed in this pull request

Update auto-key addition consent message to reflect user's browser name and extension name is shared with the wallet.

| Before | After |
| --- | --- | 
| <img width="967" height="1260" alt="image" src="https://github.com/user-attachments/assets/6e18f0ad-0075-48bd-bf3b-6c570ba7e064" /> | <img width="967" height="1260" alt="image" src="https://github.com/user-attachments/assets/d98e074b-81de-474f-bc89-9857820a5517" /> | 
