### PR TITLE
fix(bg/wallet): generate keys if not present before connecting

### DIFF
--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -80,6 +80,7 @@ export class WalletService {
       autoKeyAddConsent,
     } = params;
 
+    await this.generateKeys();
     await this.openPaymentsService.initClient(walletAddress.id);
 
     const browser = this.browser;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

When I accidentally delete keys (during dev), the extension is forever stuck in missing keys state. The key storage gets corrupted beyond repair on updates.

## Changes proposed in this pull request

Generate fresh pair of keys during connect process if not already present in storage.