### PR TITLE
refactor: remove `dotenv` dependency; supported in Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/webextension-polyfill": "^0.12.4",
     "archiver": "^7.0.1",
     "autoprefixer": "^10.4.21",
-    "dotenv": "^17.2.3",
     "esbuild": "^0.25.11",
     "esbuild-node-builtin": "^0.1.1",
     "esbuild-plugin-copy": "^2.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
-import { createRequire } from 'node:module';
+import { loadEnvFile } from 'node:process';
 import { defineConfig, devices } from '@playwright/test';
 import { testDir, authFile } from './tests/e2e/fixtures/helpers';
 
 if (!process.env.CI) {
-  const require = createRequire(import.meta.url);
-  require('dotenv').config({ path: path.join(testDir, '.env'), quiet: true });
+  loadEnvFile(path.join(testDir, '.env'));
 }
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
       esbuild:
         specifier: ^0.25.11
         version: 0.25.11
@@ -1924,10 +1921,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
-    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5404,8 +5397,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dotenv@17.2.3: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Node.js has native support for .env files now.

## Changes proposed in this pull request

- Remove `dotenv` dependency
- Use `loadEnvFile` from `node:process`
