### PR TITLE
fix(PostInstallConsent): prevent crash in Safari on getting ext name

### DIFF
--- a/src/pages/app/pages/PostInstallConsent.tsx
+++ b/src/pages/app/pages/PostInstallConsent.tsx
@@ -62,9 +62,8 @@ function DataShared() {
   const browserName = getBrowserName(browser, navigator.userAgent);
   const [extensionName, setExtensionName] = React.useState('');
   React.useEffect(() => {
-    browser.management.getSelf().then((s) => {
-      setExtensionName(s.name);
-    });
+    const { name } = browser.runtime.getManifest();
+    setExtensionName(name);
   }, [browser]);
 
   return (


### PR DESCRIPTION
## Context

`browser.management.getSelf()` isn't supported in Safari.

## Changes proposed in this pull request

Use `browser.runtime.getManifest()` to know extension's name.
