### PR TITLE
fix(ci): use dynamic imports for actions/github-script scripts

### DIFF
--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -21,7 +21,7 @@ jobs:
         id: get-workflow-artifacts
         with:
           script: |
-            const { default: script } = await import('./.github/actions/get-workflow-artifacts.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/get-workflow-artifacts.ts')
             await script({ github, context, core })
 
       - name: Find comment

--- a/.github/workflows/bump-manifest-version.yml
+++ b/.github/workflows/bump-manifest-version.yml
@@ -35,7 +35,7 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         with:
           script: |
-            const { default: script } = await import('./.github/actions/bump-manifest-version.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/bump-manifest-version.ts')
             await script({ github, context, core })
 
       - name: Format with Biome

--- a/.github/workflows/delete-pr-artifacts.yml
+++ b/.github/workflows/delete-pr-artifacts.yml
@@ -18,5 +18,5 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { default: script } = await import('./.github/actions/delete-artifacts.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/delete-artifacts.ts')
             await script({ github, context, core })

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -116,7 +116,7 @@ jobs:
         id: version
         with:
           script: |
-            const { default: script } = await import('./.github/actions/get-built-version.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/get-built-version.ts')
             await script({ github, context, core })
 
       - name: Delete existing release

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -38,7 +38,7 @@ jobs:
         id: version
         with:
           script: |
-            const { default: script } = await import('./.github/actions/get-built-version.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/get-built-version.ts')
             await script({ github, context, core })
 
       - name: Delete existing release # To keep the workflow idempotent.

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -43,7 +43,7 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         with:
           script: |
-            const { default: script } = await import('./.github/actions/validate-stable-release.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/validate-stable-release.ts')
             await script({ github, context, core })
 
       - name: Build
@@ -54,7 +54,7 @@ jobs:
         id: version
         with:
           script: |
-            const { default: script } = await import('./.github/actions/get-built-version.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/get-built-version.ts')
             await script({ github, context, core })
 
       - name: Delete existing release # To keep the workflow idempotent.

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { default: script } = await import('./.github/actions/tests-e2e-filter.ts')
+            const { default: script } = await import('${{ github.workspace }}/.github/actions/tests-e2e-filter.ts')
             await script({ github, context, core })
 
   test-e2e:


### PR DESCRIPTION
## Context

Prevent `SyntaxError: Cannot use import statement outside a module`,
Regressed in https://github.com/interledger/web-monetization-extension/pull/1215. We could not test there easily as the PR was from a fork.

## Changes proposed in this pull request

- Use dynamic imports with absolute paths.