### PR TITLE
fix(keyAutoAdd/gatehub): find wallet case-insensitive

### DIFF
--- a/src/content/keyAutoAdd/gatehub.ts
+++ b/src/content/keyAutoAdd/gatehub.ts
@@ -93,7 +93,8 @@ const findWallet: Run<void> = async (
 
   const walletBelongsToUser = data.me.wallets.some((wallet) => {
     return wallet.ilpPaymentPointers.some(
-      ({ paymentPointerUrl }) => paymentPointerUrl === walletAddressUrl,
+      ({ paymentPointerUrl }) =>
+        paymentPointerUrl.toLowerCase() === walletAddressUrl.toLowerCase(),
     );
   });
   if (!walletBelongsToUser) {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

GateHub key addition was found to be broken in sandbox.

## Changes proposed in this pull request

When checking if the wallet belongs to user during automatic key addition, compare API response for wallet addresses in all lowercase.
