### PR TITLE
fix(bg): set install ID for telemetry at install/update time

### DIFF
--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -411,6 +411,7 @@ export class MonetizationService {
   async getPopupData(tab: Pick<Tabs.Tab, 'id' | 'url'>): Promise<PopupStore> {
     const storedData = await this.storage.get([
       'consent',
+      'uid',
       'enabled',
       'continuousPaymentsEnabled',
       'connected',

--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -23,7 +23,7 @@ const defaultStorage = {
    * structural changes would need migrations for keeping compatibility with
    * existing installations.
    */
-  version: 5,
+  version: 6,
   consent: 0,
   state: {},
   connected: false,
@@ -37,7 +37,7 @@ const defaultStorage = {
   oneTimeGrantSpentAmount: '0',
   rateOfPay: null,
   maxRateOfPay: null,
-} satisfies Omit<Storage, 'publicKey' | 'privateKey' | 'keyId'>;
+} satisfies Omit<Storage, 'uid' | 'publicKey' | 'privateKey' | 'keyId'>;
 
 export class StorageService {
   private browser: Cradle['browser'];
@@ -97,6 +97,7 @@ export class StorageService {
 
     if (Object.keys(data).length === 0) {
       await this.set(defaultStorage);
+      await this.set({ uid: crypto.randomUUID() });
     }
   }
 
@@ -300,5 +301,11 @@ const MIGRATIONS: Record<Storage['version'], Migration> = {
       data.walletAddress.url = data.walletAddress.id;
     }
     return [data, ['minRateOfPay']];
+  },
+  6: (data) => {
+    if (!data.uid) {
+      data.uid = crypto.randomUUID();
+    }
+    return [data];
   },
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -72,6 +72,11 @@ export interface Storage {
   version: number;
 
   /**
+   * Distinct ID, for analytics/telemetry. Set at install time.
+   */
+  uid: string;
+
+  /**
    * Data sharing consent.
    * @note When this value in storage is smaller than the "current" consent
    * version, the user needs to provide consent again (then update this value).


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/1094

## Changes proposed in this pull request

Add a user/install ID for data collection/tracing at install/update time.