### PR TITLE
feat(popup): set up PostHog for events data collection

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -5,6 +5,7 @@ Rafiki
 Chimoney
 GateHub
 MMAON
+PostHog
 
 SPSP
 webextension
@@ -22,6 +23,8 @@ webmonetization
 jwks
 requestfinished
 TOTP
+autocapture
+pageleave
 
 # scripts and 3rd party terms
 nvmrc

--- a/esbuild/dev.ts
+++ b/esbuild/dev.ts
@@ -32,6 +32,10 @@ export const getDevOptions = ({
       CONFIG_LOG_SERVER_ENDPOINT: process.env.LOG_SERVER
         ? JSON.stringify(process.env.LOG_SERVER)
         : JSON.stringify(false),
+      CONFIG_POSTHOG_KEY: JSON.stringify(process.env.POSTHOG_KEY || ''),
+      CONFIG_POSTHOG_HOST: JSON.stringify(
+        process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
+      ),
     },
   };
 };

--- a/esbuild/prod.ts
+++ b/esbuild/prod.ts
@@ -41,6 +41,13 @@ export const getProdOptions = ({
         'https://webmonetization.org/welcome',
       ),
       CONFIG_LOG_SERVER_ENDPOINT: JSON.stringify(false),
+      CONFIG_POSTHOG_KEY: JSON.stringify(
+        process.env.POSTHOG_KEY ||
+          'phc_A42pTzb0ySkVYmNBSSfsr3K8BOyyuhR7g8l8hUdd6cv',
+      ),
+      CONFIG_POSTHOG_HOST: JSON.stringify(
+        process.env.POSTHOG_HOST || 'https://eu.i.posthog.com',
+      ),
     },
   };
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "httpbis-digest-headers": "^1.0.0",
     "iso8601-duration": "^2.1.3",
     "loglevel": "^1.9.2",
+    "posthog-js": "^1.298.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "safe-buffer": "5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       loglevel:
         specifier: ^1.9.2
         version: 1.9.2
+      posthog-js:
+        specifier: ^1.298.0
+        version: 1.298.0
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -934,6 +937,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@posthog/core@1.6.0':
+    resolution: {integrity: sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==}
+
   '@preact/signals-core@1.8.0':
     resolution: {integrity: sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA==}
 
@@ -1777,6 +1783,9 @@ packages:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
 
+  core-js@3.47.0:
+    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -1801,8 +1810,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crypto-browserify@3.12.1:
@@ -2032,6 +2041,9 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2512,6 +2524,7 @@ packages:
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
     engines: {node: '>= 0.6'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2932,6 +2945,9 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  posthog-js@1.298.0:
+    resolution: {integrity: sha512-Zwzsf7TO8qJ6DFLuUlQSsT/5OIOcxSBZlKOSk3satkEnwKdmnBXUuxgVXRHrvq1kj7OB2PVAPgZiQ8iHHj9DRA==}
 
   preact@10.25.4:
     resolution: {integrity: sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==}
@@ -3485,6 +3501,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webextension-polyfill@0.12.0:
     resolution: {integrity: sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==}
@@ -4440,6 +4459,10 @@ snapshots:
     dependencies:
       playwright: 1.56.1
 
+  '@posthog/core@1.6.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
   '@preact/signals-core@1.8.0': {}
 
   '@preact/signals@1.3.1(preact@10.25.4)':
@@ -5258,6 +5281,8 @@ snapshots:
       depd: 2.0.0
       keygrip: 1.1.0
 
+  core-js@3.47.0: {}
+
   core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
@@ -5292,7 +5317,7 @@ snapshots:
   create-require@1.1.1:
     optional: true
 
-  cross-spawn@7.0.3:
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -5507,7 +5532,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -5552,6 +5577,8 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fflate@0.4.8: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5563,7 +5590,7 @@ snapshots:
 
   foreground-child@3.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   fraction.js@4.3.7: {}
@@ -6662,6 +6689,14 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.298.0:
+    dependencies:
+      '@posthog/core': 1.6.0
+      core-js: 3.47.0
+      fflate: 0.4.8
+      preact: 10.25.4
+      web-vitals: 4.2.4
+
   preact@10.25.4: {}
 
   prettier@3.6.2: {}
@@ -7246,6 +7281,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-vitals@4.2.4: {}
 
   webextension-polyfill@0.12.0: {}
 

--- a/src/shared/defines.ts
+++ b/src/shared/defines.ts
@@ -3,7 +3,12 @@ import type { LogLevelDesc } from 'loglevel';
 declare const CONFIG_LOG_LEVEL: LogLevelDesc;
 declare const CONFIG_LOG_SERVER_ENDPOINT: string | false;
 declare const CONFIG_OPEN_PAYMENTS_REDIRECT_URL: string;
+declare const CONFIG_POSTHOG_KEY: string;
+declare const CONFIG_POSTHOG_HOST: string;
 
 export const LOG_LEVEL = CONFIG_LOG_LEVEL;
 export const LOG_SERVER_ENDPOINT = CONFIG_LOG_SERVER_ENDPOINT;
 export const OPEN_PAYMENTS_REDIRECT_URL = CONFIG_OPEN_PAYMENTS_REDIRECT_URL;
+
+export const POSTHOG_KEY = CONFIG_POSTHOG_KEY;
+export const POSTHOG_HOST = CONFIG_POSTHOG_HOST;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -84,6 +84,12 @@ export interface Storage {
    */
   consent?: number;
 
+  /**
+   * Whether the user has provided consent to analytics and telemetry.
+   * @default undefined implies user has never provided consent.
+   */
+  consentTelemetry?: boolean;
+
   /** If a wallet is connected or not */
   connected: boolean;
   /** Whether the extension (actually any sort of payment) is enabled  */
@@ -164,7 +170,10 @@ export type PopupStore = Omit<
   }>;
 };
 
-export type AppStore = Pick<Storage, 'publicKey' | 'connected' | 'consent'> & {
+export type AppStore = Pick<
+  Storage,
+  'publicKey' | 'connected' | 'consent' | 'consentTelemetry'
+> & {
   transientState: PopupTransientState;
 };
 


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/1094

## Changes proposed in this pull request

- Set up PostHog for popup
- Set up PostHog keys at build time
- Keep opted out by default (configurable by `consentTelemetry` storage key)

Will set up for `app` pages and background as follow up.
Followed by consent management.
