### PR TITLE
fix(PostInstallConsent): update content structure and improve copy

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -313,7 +313,7 @@
     "message": "By continuing, you consent to share the information below."
   },
   "postInstallConsent_text_dataShared_title": {
-    "message": "What’s shared"
+    "message": "What’s shared by the extension"
   },
   "postInstallConsent_text_dataShared_yourWallet_title": {
     "message": "With your wallet provider:"
@@ -324,29 +324,26 @@
   "postInstallConsent_text_dataShared_yourWallet_keyConsent": {
     "message": "Note: You will always be asked for consent before any connection."
   },
-  "postInstallConsent_text_dataShared_yourWallet_headers": {
-    "message": "Your IP address, language, and browser version while you use the extension, which is automatically sent by your browser."
-  },
   "postInstallConsent_text_dataShared_websiteWallets_title": {
-    "message": "With the wallets used on websites you visit that use Web Monetization:"
-  },
-  "postInstallConsent_text_dataShared_websiteWallets_headers": {
-    "message": "Your IP address, language, and browser version information, which is automatically sent by your browser."
+    "message": "With the website’s wallet provider:"
   },
   "postInstallConsent_text_dataShared_websiteWallets_wa": {
     "message": "Your wallet address."
   },
+  "postInstallConsent_text_dataShared_websites_title": {
+    "message": "With the websites you visit:"
+  },
+  "postInstallConsent_text_dataShared_websites_text": {
+    "message": "Nothing. The extension never shares your wallet address, balance, or currency with the websites you visit. Your browsing history remains private in your browser."
+  },
+  "postInstallConsent_text_dataShared_browser_title": {
+    "message": "What’s shared by your browser"
+  },
+  "postInstallConsent_text_dataShared_browser_text": {
+    "message": "Your IP address, language, and browser version are shared with your wallet provider and the website’s wallet provider while you use the extension."
+  },
   "postInstallConsent_text_dataShared_headers": {
-    "message": "Browsers send certain HTTP headers by default  each request that inform the servers about your language (`Accept-Language` header), browser version (`User-Agent` header) and more. Your IP address is also sent by default."
-  },
-  "postInstallConsent_text_dataNotShared_title": {
-    "message": "What’s never shared"
-  },
-  "postInstallConsent_text_dataNotShared_walletDetails": {
-    "message": "Your wallet address, balance, or currency are never shared with websites you visit."
-  },
-  "postInstallConsent_text_dataNotShared_browsingHistory": {
-    "message": "Your browsing history. It stays private in your browser."
+    "message": "Browsers send certain HTTP headers by default with each request that inform the servers about your language (`Accept-Language` header), browser version (`User-Agent` header) and more. Your IP address is also sent by default."
   },
   "postInstallConsent_text_permissions_title": {
     "message": "Extension Permissions"

--- a/src/pages/app/pages/PostInstallConsent.tsx
+++ b/src/pages/app/pages/PostInstallConsent.tsx
@@ -40,11 +40,13 @@ const Main = () => {
   return (
     <main className="mx-auto w-full max-w-3xl p-3 sm:p-8">
       <div className="space-y-4 mb-48">
-        <p>{t('postInstallConsent_text_header1')}</p>
-        <p>{t('postInstallConsent_text_header2')}</p>
+        <div className="space-y-1">
+          <p>{t('postInstallConsent_text_header1')}</p>
+          <p>{t('postInstallConsent_text_header2')}</p>
+        </div>
 
         <DataShared />
-        <DataNotShared />
+        <DataSharedBrowser />
         <Permissions />
       </div>
 
@@ -67,15 +69,7 @@ function DataShared() {
         <h4 className="font-medium text-lg">
           {t('postInstallConsent_text_dataShared_yourWallet_title')}
         </h4>
-        <ul className="list-disc ml-4">
-          <li>{t('postInstallConsent_text_dataShared_websiteWallets_wa')}</li>
-          <li>
-            {t('postInstallConsent_text_dataShared_yourWallet_headers')}
-            <InformationTooltip
-              text={t('postInstallConsent_text_dataShared_headers')}
-            />
-          </li>
-        </ul>
+        <p>{t('postInstallConsent_text_dataShared_yourWallet_wa')}</p>
         <p>{t('postInstallConsent_text_dataShared_yourWallet_keyConsent')}</p>
       </div>
 
@@ -83,31 +77,32 @@ function DataShared() {
         <h4 className="font-medium text-lg">
           {t('postInstallConsent_text_dataShared_websiteWallets_title')}
         </h4>
-        <ul className="list-disc ml-4">
-          <li>{t('postInstallConsent_text_dataShared_websiteWallets_wa')}</li>
-          <li>
-            {t('postInstallConsent_text_dataShared_websiteWallets_headers')}
-            <InformationTooltip
-              text={t('postInstallConsent_text_dataShared_headers')}
-            />
-          </li>
-        </ul>
+        <p>{t('postInstallConsent_text_dataShared_websiteWallets_wa')}</p>
+      </div>
+
+      <div className="space-y-1">
+        <h4 className="font-medium text-lg">
+          {t('postInstallConsent_text_dataShared_websites_title')}
+        </h4>
+        <p>{t('postInstallConsent_text_dataShared_websites_text')}</p>
       </div>
     </div>
   );
 }
 
-function DataNotShared() {
+function DataSharedBrowser() {
   const t = useTranslation();
   return (
     <div className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
-        {t('postInstallConsent_text_dataNotShared_title')}
+        {t('postInstallConsent_text_dataShared_browser_title')}
       </h3>
-      <ul className="list-disc ml-4">
-        <li>{t('postInstallConsent_text_dataNotShared_walletDetails')}</li>
-        <li>{t('postInstallConsent_text_dataNotShared_browsingHistory')}</li>
-      </ul>
+      <p>
+        {t('postInstallConsent_text_dataShared_browser_text')}{' '}
+        <InformationTooltip
+          text={t('postInstallConsent_text_dataShared_headers')}
+        />
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Context

General exercise we did during team call when reviewing copy for telemetry.
Prerequisite for https://github.com/interledger/web-monetization-extension/pull/1263

## Changes proposed in this pull request

- Change headings to split into shared by extension and shared by browser
- In shared by extension: split into shared with your wallet, website wallets and websites

Based on: [Google Doc](https://docs.google.com/document/d/1gGGTcQk2L3CB6XkgnMPnmCt4RV4YJElRoXKL0FTSrDQ/edit?tab=t.0) by Melisssa and [Slack discussion](https://interledgerfoundation.slack.com/archives/C06CVJRT5N3/p1764847053348419?thread_ts=1764775250.591439&cid=C06CVJRT5N3).