### PR TITLE
chore: release version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web-monetization-extension",
   "description": "Web Monetization is a browser API that allows the creation of a payment stream from the user agent to the website.",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/chrome-manifest",
   "name": "Web Monetization",
-  "version": "0.11.3",
+  "version": "1.0.0",
   "manifest_version": 3,
   "minimum_chrome_version": "110.0",
   "description": "__MSG_appDescription__",

--- a/src/safari/Web Monetization/Config.xcconfig
+++ b/src/safari/Web Monetization/Config.xcconfig
@@ -5,4 +5,4 @@
 //  Created by https://github.com/sidvishnoi on 04/07/25.
 //
 
-CURRENT_PROJECT_VERSION = 0.11.3
+CURRENT_PROJECT_VERSION = 1.0.0


### PR DESCRIPTION
Bump extension version to 1.0.0

This PR was sent manually instead of via the "bump version" GitHub action, as that action is meant for patch/minor changes only.