### PR TITLE
refactor(popup,app): use BrowserInfo context

### DIFF
--- a/src/pages/app/App.tsx
+++ b/src/pages/app/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   BrowserContextProvider,
+  BrowserInfoContextProvider,
   TranslationContextProvider,
 } from '@/pages/shared/lib/context';
 import browser from '@/shared/browser';
@@ -28,11 +29,13 @@ export const App = () => {
     <BrowserContextProvider browser={browser}>
       <TranslationContextProvider>
         <MessageContextProvider>
-          <WaitForStateLoad>
-            <Router hook={useHashLocation} base="/post-install">
-              <Routes />
-            </Router>
-          </WaitForStateLoad>
+          <BrowserInfoContextProvider>
+            <WaitForStateLoad>
+              <Router hook={useHashLocation} base="/post-install">
+                <Routes />
+              </Router>
+            </WaitForStateLoad>
+          </BrowserInfoContextProvider>
         </MessageContextProvider>
       </TranslationContextProvider>
     </BrowserContextProvider>

--- a/src/pages/app/lib/context.tsx
+++ b/src/pages/app/lib/context.tsx
@@ -11,7 +11,11 @@ import {
 } from '@/pages/shared/lib/context';
 import { dispatch } from './store';
 
-export { useBrowser, useTranslation } from '@/pages/shared/lib/context';
+export {
+  useBrowser,
+  useTranslation,
+  useBrowserInfo,
+} from '@/pages/shared/lib/context';
 
 export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   const message = useMessage();

--- a/src/pages/app/pages/PostInstall.tsx
+++ b/src/pages/app/pages/PostInstall.tsx
@@ -5,13 +5,9 @@ import {
   CaretDownIcon,
   ExternalIcon,
 } from '@/pages/shared/components/Icons';
-import {
-  getBrowserName,
-  isConsentRequired,
-  type BrowserName,
-} from '@/shared/helpers';
+import { isConsentRequired, type BrowserName } from '@/shared/helpers';
 import { getResponseOrThrow } from '@/shared/messages';
-import { useBrowser, useTranslation } from '@/app/lib/context';
+import { useBrowser, useBrowserInfo, useTranslation } from '@/app/lib/context';
 import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
 import { cn } from '@/pages/shared/lib/utils';
 import { useMessage } from '@/app/lib/context';
@@ -146,9 +142,9 @@ type StepId = (typeof STEP_ID)[number];
 
 const Steps = () => {
   const browser = useBrowser();
+  const browserInfo = useBrowserInfo();
   const t = useTranslation();
   const isPinnedToToolbar = usePinnedStatus();
-  const browserName = getBrowserName(browser, navigator.userAgent);
   const hasAllHostsPermission = useHasAllHostsPermission();
 
   const [selectedWallet, setSelectedWallet] = React.useState<WalletOption>(
@@ -164,6 +160,8 @@ const Steps = () => {
       return STEP_ID[idx + 1];
     });
   }, []);
+
+  const isSafari = browserInfo.name === 'safari';
 
   return (
     <ol className="flex flex-col gap-4">
@@ -252,7 +250,7 @@ const Steps = () => {
           )}
         </p>
         <img
-          src={imgSrc(browserName, {
+          src={imgSrc(browserInfo.name, {
             chrome: '/assets/images/pin-extension-chrome.png',
             firefox: '/assets/images/pin-extension-firefox.png',
             safari: '/assets/images/pin-extension-safari.mp4',
@@ -265,7 +263,7 @@ const Steps = () => {
       </Step>
 
       {/* Add this special step for Safari as without this permission beforehand, Safari requires pages being reloaded for extension to work. This can help with other browsers as well (conditioning on whether we've the permissions, instead of just the browserName), but let's do only for Safari for now. */}
-      {browserName === 'safari' && (
+      {isSafari && (
         <Step
           id={STEP_ID[3]}
           index={3}
@@ -295,7 +293,7 @@ const Steps = () => {
       <Step
         isPrimaryButton={true}
         id={STEP_ID[4]}
-        index={browserName === 'safari' ? 4 : 3}
+        index={isSafari ? 4 : 3}
         open={isOpen === STEP_ID[4]}
         onClick={onClick}
         title={t('postInstall_action_submit')}

--- a/src/pages/app/pages/PostInstallConsent.tsx
+++ b/src/pages/app/pages/PostInstallConsent.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Redirect } from 'wouter';
-import { getBrowserName, isConsentRequired } from '@/shared/helpers';
+import { isConsentRequired } from '@/shared/helpers';
 import { getResponseOrThrow } from '@/shared/messages';
-import { useBrowser, useMessage, useTranslation } from '@/app/lib/context';
+import {
+  useBrowser,
+  useBrowserInfo,
+  useMessage,
+  useTranslation,
+} from '@/app/lib/context';
 import { dispatch, useAppState } from '@/app/lib/store';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
@@ -214,14 +219,14 @@ function AcceptForm({
   const { connected, consent } = useAppState();
   const message = useMessage();
   const browser = useBrowser();
+  const browserInfo = useBrowserInfo();
   const hasChanges = useAcceptFormHasChanges(telemetryConsentRef);
-  const browserName = getBrowserName(browser, navigator.userAgent);
 
   const onSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
     const formData = new FormData(ev.currentTarget);
     let consentTelemetry = formData.get('consent-field-telemetry') === 'on';
-    if (browserName === 'firefox') {
+    if (browserInfo.name === 'firefox') {
       const permission = {
         data_collection: ['technicalAndInteraction' as const],
       };

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MainLayout } from '@/popup/components/layout/MainLayout';
 import {
   BrowserContextProvider,
+  BrowserInfoContextProvider,
   TranslationContextProvider,
 } from '@/pages/shared/lib/context';
 import { MessageContextProvider, WaitForStateLoad } from '@/popup/lib/context';
@@ -46,13 +47,15 @@ export const Popup = () => {
     <BrowserContextProvider browser={browser}>
       <MessageContextProvider>
         <TranslationContextProvider>
-          <WaitForStateLoad>
-            <Router hook={useHashLocation}>
-              <MainLayout>
-                <Routes />
-              </MainLayout>
-            </Router>
-          </WaitForStateLoad>
+          <BrowserInfoContextProvider>
+            <WaitForStateLoad>
+              <Router hook={useHashLocation}>
+                <MainLayout>
+                  <Routes />
+                </MainLayout>
+              </Router>
+            </WaitForStateLoad>
+          </BrowserInfoContextProvider>
         </TranslationContextProvider>
       </MessageContextProvider>
     </BrowserContextProvider>

--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -3,12 +3,12 @@ import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import { CaretDownIcon } from '@/pages/shared/components/Icons';
 import {
   useBrowser,
+  useBrowserInfo,
   useTelemetry,
   useTranslation,
 } from '@/pages/shared/lib/context';
 import { dispatch, usePopupState } from '@/popup/lib/store';
 import { useMessage } from '@/popup/lib/context';
-import { getBrowserName } from '@/shared/helpers';
 import type { Browser } from '@/shared/browser';
 
 export function SettingsScreen() {
@@ -25,7 +25,7 @@ function DataCollectionSettings() {
   const { consentTelemetry = false } = usePopupState();
   const telemetry = useTelemetry();
   const browser = useBrowser();
-  const browserName = getBrowserName(browser, navigator.userAgent);
+  const browserInfo = useBrowserInfo();
 
   return (
     <details className="border p-4 rounded-md space-y-2 group" open>
@@ -47,7 +47,7 @@ function DataCollectionSettings() {
           checked={consentTelemetry}
           onChange={async (ev) => {
             const isOptedIn = ev.currentTarget.checked;
-            if (browserName === 'firefox') {
+            if (browserInfo.name === 'firefox') {
               const ok = await handleFirefoxDataCollectionPermission(
                 isOptedIn,
                 browser,

--- a/src/pages/popup/lib/context.tsx
+++ b/src/pages/popup/lib/context.tsx
@@ -11,7 +11,11 @@ import {
 } from '@/pages/shared/lib/context';
 import { dispatch } from './store';
 
-export { useBrowser, useTranslation } from '@/pages/shared/lib/context';
+export {
+  useBrowser,
+  useBrowserInfo,
+  useTranslation,
+} from '@/pages/shared/lib/context';
 
 export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   const message = useMessage();

--- a/src/pages/popup/pages/MissingHostPermission.tsx
+++ b/src/pages/popup/pages/MissingHostPermission.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { WarningSign } from '@/pages/shared/components/Icons';
-import { useBrowser, useTranslation } from '@/popup/lib/context';
-import { getBrowserName } from '@/shared/helpers';
+import {
+  useBrowser,
+  useBrowserInfo,
+  useTranslation,
+} from '@/popup/lib/context';
 
 export default () => {
   const browser = useBrowser();
+  const browserInfo = useBrowserInfo();
   const t = useTranslation();
-  const browserName = getBrowserName(browser, navigator.userAgent);
+
   return (
     <div
       className="rounded-md bg-orange-50 p-4 text-sm"
@@ -31,7 +35,7 @@ export default () => {
           return browser.permissions.request({ origins }).finally(() => {
             // So we open popup with refreshed state, avoiding additional message passing.
             // Firefox closes popup automatically.
-            if (browserName === 'safari') {
+            if (browserInfo.name === 'safari') {
               // Safari won't allow closing popup, so reload instead
               window.location.reload();
             } else {

--- a/src/pages/shared/lib/context.tsx
+++ b/src/pages/shared/lib/context.tsx
@@ -1,9 +1,11 @@
 import React, { type PropsWithChildren } from 'react';
 import { PostHog } from 'posthog-js/dist/module.no-external';
 import { POSTHOG_KEY, POSTHOG_HOST } from '@/shared/defines';
-import type { Browser } from 'webextension-polyfill';
+import type { Browser, Runtime } from 'webextension-polyfill';
 import {
+  getBrowserName,
   tFactory,
+  type BrowserName,
   type ErrorWithKeyLike,
   type Translation,
 } from '@/shared/helpers';
@@ -22,6 +24,36 @@ export const BrowserContextProvider = ({
     <BrowserContext.Provider value={browser}>
       {children}
     </BrowserContext.Provider>
+  );
+};
+// #endregion
+
+// #region BrowserInfo
+type BrowserInfo = {
+  name: BrowserName;
+  ua: string;
+  platform: Partial<Runtime.PlatformInfo>;
+};
+
+const BrowserInfoContext = React.createContext({} as BrowserInfo);
+
+export const useBrowserInfo = () => React.useContext(BrowserInfoContext);
+
+export const BrowserInfoContextProvider = ({ children }: PropsWithChildren) => {
+  const browser = useBrowser();
+  const [platform, setPlatform] = React.useState<BrowserInfo['platform']>({});
+
+  const ua = navigator.userAgent;
+  const name = getBrowserName(browser, ua);
+
+  React.useEffect(() => {
+    browser.runtime.getPlatformInfo().then(setPlatform);
+  }, [browser]);
+
+  return (
+    <BrowserInfoContext.Provider value={{ name, ua, platform }}>
+      {children}
+    </BrowserInfoContext.Provider>
   );
 };
 // #endregion


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Extracted from Firefox Android work, where we needed to find platform info.

## Changes proposed in this pull request

- Instead of calling `getBrowserName` is different screens, use `BrowserInfo` from a custom context/hook.