### PR TITLE
fix: install polyfill via manifest.json

### DIFF
--- a/src/content/services/contentScript.ts
+++ b/src/content/services/contentScript.ts
@@ -4,7 +4,6 @@ import { failure, success } from '@/shared/messages';
 
 export class ContentScript {
   private browser: Cradle['browser'];
-  private window: Cradle['window'];
   private logger: Cradle['logger'];
   private monetizationLinkManager: Cradle['monetizationLinkManager'];
   private frameManager: Cradle['frameManager'];
@@ -21,7 +20,6 @@ export class ContentScript {
   }: Cradle) {
     Object.assign(this, {
       browser,
-      window,
       logger,
       monetizationLinkManager,
       frameManager,
@@ -34,7 +32,6 @@ export class ContentScript {
   }
 
   async start() {
-    await this.injectPolyfill();
     if (this.isFirstLevelFrame) {
       this.logger.info('Content script started');
 
@@ -68,20 +65,5 @@ export class ContentScript {
         }
       },
     );
-  }
-
-  // TODO: When Firefox has good support for `world: MAIN`, inject this directly
-  // via manifest.json https://bugzilla.mozilla.org/show_bug.cgi?id=1736575 and
-  // remove this, along with injectPolyfill from background
-  // See: https://github.com/interledger/web-monetization-extension/issues/607
-  async injectPolyfill() {
-    const document = this.window.document;
-    const script = document.createElement('script');
-    script.src = this.browser.runtime.getURL('polyfill/polyfill.js');
-    await new Promise<void>((resolve) => {
-      script.addEventListener('load', () => resolve(), { once: true });
-      document.documentElement.appendChild(script);
-    });
-    script.remove();
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,13 @@
       "js": ["content/content.js"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["https://*/*", "http://localhost/*", "http://127.0.0.1/*"],
+      "js": ["polyfill/polyfill.js"],
+      "run_at": "document_start",
+      "world": "MAIN",
+      "all_frames": true
     }
   ],
   "background": {
@@ -29,11 +36,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "polyfill/*",
-        "pages/progress-connect/*",
-        "assets/fonts/**/*"
-      ],
+      "resources": ["pages/progress-connect/*", "assets/fonts/**/*"],
       "matches": ["<all_urls>"]
     }
   ],
@@ -47,7 +50,7 @@
   ],
   "browser_specific_settings": {
     "gecko": {
-      "strict_min_version": "110.0",
+      "strict_min_version": "142.0",
       "data_collection_permissions": {
         "required": ["financialAndPaymentInfo"],
         "optional": ["technicalAndInteraction"]


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/607

## Changes proposed in this pull request

- Remove custom script injection for polyfill, instead install it via `manifest.json` with "MAIN" execution context.
- Raise minimum supported Firefox version to 142 (not 140, as there's permissions warning on 140)