### PR TITLE
test(e2e): remove Chrome and Edge variants as no longer supported

### DIFF
--- a/.github/actions/tests-e2e-filter.ts
+++ b/.github/actions/tests-e2e-filter.ts
@@ -63,17 +63,5 @@ function getMatrix(projects: Project[]) {
       target: 'chrome',
       'runs-on': 'ubuntu-24.04',
     },
-    {
-      name: 'Chrome',
-      project: 'chrome' as Project,
-      target: 'chrome',
-      'runs-on': 'ubuntu-24.04',
-    },
-    {
-      name: 'Edge',
-      project: 'msedge' as Project,
-      target: 'chrome',
-      'runs-on': 'ubuntu-24.04',
-    },
   ].filter((p) => projects.includes(p.project));
 }

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -23,14 +23,6 @@ jobs:
             project: chromium
             target: chrome
             runs-on: ubuntu-24.04
-          - name: Chrome
-            project: chrome
-            target: chrome
-            runs-on: ubuntu-24.04
-          - name: Edge
-            project: msedge
-            target: chrome
-            runs-on: ubuntu-24.04
     timeout-minutes: 15
     name: E2E Tests - ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
@@ -52,7 +44,6 @@ jobs:
         run: pnpm test:e2e:${{ matrix.project }}
         env:
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
-          PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS: '1'
           TEST_WALLET_USERNAME: ${{ vars.E2E_WALLET_USERNAME }}
           TEST_WALLET_PASSWORD: ${{ secrets.E2E_WALLET_PASSWORD }}
           TEST_WALLET_ADDRESS_URL: ${{ vars.E2E_CONNECT_WALLET_ADDRESS_URL }}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,7 +6,7 @@ Run `pnpm test` to run unit tests locally. These tests are run automatically on 
 
 ## End-to-end Tests
 
-To run end-to-end tests, run `pnpm test:e2e` in terminal. To run tests with Chrome only, run `pnpm test:e2e:chrome`.
+To run end-to-end tests, run `pnpm test:e2e` in terminal. To run tests with Chrome only, run `pnpm test:e2e:chromium`.
 
 Make sure you run `pnpm build chrome` before running tests.
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "test:watch": "jest --watch",
     "test:e2e": "playwright test",
     "test:e2e:chromium": "playwright test --project=chromium",
-    "test:e2e:chrome": "playwright test --project=chrome",
-    "test:e2e:msedge": "playwright test --project=msedge",
     "test:e2e:report": "playwright show-report tests/e2e/playwright-report",
     "test:ci": "jest --reporters=default --reporters=github-actions"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { loadEnvFile } from 'node:process';
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 import { testDir, authFile } from './tests/e2e/fixtures/helpers';
 
 if (!process.env.CI) {
@@ -43,16 +43,6 @@ export default defineConfig({
       dependencies: ['setup'],
     },
 
-    {
-      name: 'chrome',
-      use: {
-        ...devices['Desktop Chrome'],
-        storageState: authFile,
-        channel: 'chrome',
-      },
-      dependencies: ['setup'],
-    },
-
     // Firefox+Playwright doesn't work well enough at the moment.
     // {
     //   name: 'firefox',
@@ -66,16 +56,6 @@ export default defineConfig({
     //   use: { ...devices['Desktop Safari'], storageState: authFile },
     //   dependencies: ['setup'],
     // },
-
-    {
-      name: 'msedge',
-      use: {
-        ...devices['Desktop Edge'],
-        channel: 'msedge',
-        storageState: authFile,
-      },
-      dependencies: ['setup'],
-    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -1,7 +1,6 @@
 # Used when running tests locally.
 # In CI, we pass these in via the environment variables directly.
 # See TestEnvVars in tests/e2e/env.d.ts for details of each variable
-PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1
 
 TEST_WALLET_USERNAME=user@email.com
 TEST_WALLET_PASSWORD=some-password

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -152,7 +152,6 @@ export async function loadContext(
     context = await chromium.launchPersistentContext('', {
       channel,
       args: [
-        '--headless=new',
         '--disable-gpu',
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

E2E tests for Chrome are broken, and will soon be for Edge as well. Chrome, Edge [removed the CLI flags required to load extensions](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/FxMU1TvxWWg/m/daZVTYNlBQAJ) for testing, and [Playwright recommends we test with Chromium only](https://playwright.dev/docs/chrome-extensions#introduction:~:text=Google%20Chrome%20and%20Microsoft%20Edge%20removed%20the%20command%2Dline%20flags%20needed%20to%20side%2Dload%20extensions%2C%20so%20use%20Chromium%20that%20comes%20bundled%20with%20Playwright).

## Changes proposed in this pull request

- Remove Chrome, Edge specific test setups, use Chromium only.
- There's no difference in tests we've - we only use Chromium behaviors in test, as other browsers don't provide API to test browser specific behaviors either (like Edge split tabs)