### PR TITLE
fix: prevent popup scrollbar when browser zoom exceeds 100%

### DIFF
--- a/src/pages/popup/components/layout/MainLayout.tsx
+++ b/src/pages/popup/components/layout/MainLayout.tsx
@@ -8,12 +8,12 @@ const Divider = () => {
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div
-      className="flex h-popup w-popup touch:w-full touch:h-screen flex-col gap-4 px-6 touch:px-4 py-4 @container"
+      className="flex h-popup max-h-screen w-popup touch:w-full touch:h-screen flex-col gap-4 px-6 touch:px-4 py-4 overflow-hidden @container"
       id="main"
     >
       <Header />
       <Divider />
-      <main className="flex flex-1 flex-col">{children}</main>
+      <main className="flex flex-1 flex-col overflow-y-auto">{children}</main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes the popup showing an unwanted scrollbar when browser zoom level is above 100%.

**Root cause:** The popup container has a fixed height of 600px (`h-popup`), but when browser zoom exceeds 100%, the available viewport in CSS pixels shrinks below 600px, causing overflow.

**Fix:**
- Add `max-h-screen` to the popup container — caps height at the actual viewport height regardless of zoom level
- Add `overflow-hidden` to the container — prevents the outer scrollbar
- Add `overflow-y-auto` to the `<main>` content area — keeps content accessible via scoped scrolling when it overflows (e.g., error states with long content)

This ensures the header and divider remain fixed at top while content scrolls naturally within the available space.

## Changes

| File | Change |
|------|--------|
| `src/pages/popup/components/layout/MainLayout.tsx` | Add `max-h-screen overflow-hidden` to container, `overflow-y-auto` to main |

## Test plan

- [ ] Open extension popup at 100% zoom — no change in behavior
- [ ] Open extension popup at 110% zoom — no scrollbar appears
- [ ] Open extension popup at 125%+ zoom — content area scrolls if needed, header stays fixed
- [ ] Test on Chrome, Edge, Firefox

Closes #1014