### PR TITLE
fix(bg/paymentSession): unmark session as invalid if force reset

### DIFF
--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -91,6 +91,7 @@ export class PaymentSession {
   findMinSendAmount(force?: boolean): Promise<void> {
     this.#minSendAmountPromise ??= this._findMinSendAmount();
     if (force) {
+      this.isInvalid = false;
       this.#minSendAmountPromise = this._findMinSendAmount(undefined, true);
     }
     return this.#minSendAmountPromise;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1356
Part of https://github.com/interledger/web-monetization-extension/issues/1355

## Changes proposed in this pull request

When we resumed after a forced `findMinSendAmount` (when key re-added), the session was still marked as `invalid`, so `PaymentManager` iterator said: "No sessions!" error and site stayed "invalid".
Took me a while to debug!