### PR TITLE
fix(bg): success redirect only after reconnect post-process done

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -264,9 +264,16 @@ export class Background {
         }
 
         case 'RECONNECT_WALLET': {
+          const { payload } = message;
           const lastActiveTab = await this.windowState.getCurrentTab();
-          await this.walletService.reconnectWallet(message.payload);
+          const onDone = await this.walletService.reconnectWallet(payload);
           await this.refreshAllPaymentSessions(lastActiveTab);
+          await onDone?.();
+          if (lastActiveTab) {
+            await this.tabEvents.updateVisualIndicators(lastActiveTab);
+          } else {
+            await this.updateVisualIndicatorsForCurrentTab();
+          }
           return success(undefined);
         }
 
@@ -427,15 +434,6 @@ export class Background {
       await Promise.all(
         paymentManager.sessions.map((s) => s.findMinSendAmount(true)),
       );
-    }
-
-    if (priorityTab?.id) {
-      if (priorityTab.id === this.windowState.getCurrentTabId()) {
-        this.tabState.paymentManagers.get(priorityTab.id)?.resume();
-      }
-      await this.tabEvents.updateVisualIndicators(priorityTab);
-    } else {
-      await this.updateVisualIndicatorsForCurrentTab();
     }
   }
 

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -276,7 +276,7 @@ export class WalletService {
       type: 'success',
       intent: 'reconnect',
     }));
-    await this.redirectOnSuccess(tabId);
+    return () => this.redirectOnSuccess(tabId);
   }
 
   async disconnectWallet(force = false) {


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Follow-up for https://github.com/interledger/web-monetization-extension/pull/1357 (UX improvement)

## Changes proposed in this pull request

Redirect user to success only after reconnect post-processing is finished.