### PR TITLE
fix(keyAutoAdd/gatehub): support custom wallet addresses

### DIFF
--- a/src/content/keyAutoAdd/gatehub.ts
+++ b/src/content/keyAutoAdd/gatehub.ts
@@ -6,10 +6,10 @@ import {
 } from './lib/keyAutoAdd';
 import { isTimedOut, waitForURL } from './lib/helpers';
 import {
+  getActiveWallet,
   gql,
   GraphQlError,
   graphQlRequest,
-  walletAddressUrlToId,
 } from './lib/helpers/gatehub';
 import type { JWK } from '@interledger/open-payments';
 
@@ -64,12 +64,18 @@ const findWallet: Run<void> = async (
   { setNotificationSize },
 ) => {
   setNotificationSize('fullscreen');
+  const activeWallet = getActiveWallet();
+  if (!activeWallet) {
+    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+      'No active wallet found',
+    ]);
+  }
 
   const data = await graphQlRequest<GetUserPaymentPointersResponse>({
     operationName: 'GetUserPaymentPointers',
     variables: {
-      address: walletAddressUrlToId(walletAddressUrl),
-      walletType: 'Hosted',
+      address: activeWallet.address,
+      walletType: activeWallet.walletType,
     },
     query: gql`
       query GetUserPaymentPointers($address: String!, $walletType: WalletType) {

--- a/src/content/keyAutoAdd/lib/helpers/gatehub.ts
+++ b/src/content/keyAutoAdd/lib/helpers/gatehub.ts
@@ -30,6 +30,30 @@ export const walletAddressUrlToId = (url: string) => {
   return pathname.match(/\/(\d+)/)![1];
 };
 
+export function getActiveWallet() {
+  let activeWallet: Record<string, unknown> | null = null;
+  try {
+    activeWallet = JSON.parse(
+      window.localStorage.getItem('activeWallet') || 'null',
+    );
+  } catch {}
+
+  if (
+    typeof activeWallet === 'object' &&
+    activeWallet &&
+    typeof activeWallet.address === 'string' &&
+    activeWallet.address &&
+    activeWallet.walletType === 'Hosted'
+  ) {
+    return {
+      address: activeWallet.address,
+      walletType: activeWallet.walletType,
+    };
+  }
+
+  return null;
+}
+
 // For syntax highlighting
 export const gql = String.raw;
 


### PR DESCRIPTION
## Context

Fixes #1360

## Changes proposed in this pull request

When using custom wallet addresses, we cannot use `walletAddressUrlToId`. Grab the wallet address ID from `localStorage` instead.