### PR TITLE
fix(ConnectWalletForm): recheck `isKeyAdded` before asking

### DIFF
--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -265,9 +265,9 @@ export const ConnectWalletForm = ({
       }
     }
 
-    const walletInfo =
-      walletAddressInfo ??
-      (await getWalletInfo(toWalletAddressUrl(walletAddressUrl)));
+    const walletInfo = walletAddressInfo
+      ? await getWalletInfo(walletAddressInfo.walletAddress.id)
+      : await getWalletInfo(toWalletAddressUrl(walletAddressUrl));
 
     if (
       !walletInfo.isKeyAdded &&


### PR DESCRIPTION
## Context

Closes #1366

## Changes proposed in this pull request

Recheck wallet address info before asking for consent. Regressed in https://github.com/interledger/web-monetization-extension/pull/1309, where to improve performance, we avoided the lookup, as user adding key from popup meant popup will be closed and we'll be automatically fetching latest info, but in app page form, we need to manually get latest info.