### PR TITLE
fix(keyAutoAdd/gatehub): grab all addresses for ownership check

### DIFF
--- a/src/content/keyAutoAdd/gatehub.ts
+++ b/src/content/keyAutoAdd/gatehub.ts
@@ -6,7 +6,8 @@ import {
 } from './lib/keyAutoAdd';
 import { isTimedOut, waitForURL } from './lib/helpers';
 import {
-  getActiveWallet,
+  getUserWallets,
+  getUserPaymentPointers,
   gql,
   GraphQlError,
   graphQlRequest,
@@ -14,16 +15,6 @@ import {
 import type { JWK } from '@interledger/open-payments';
 
 // #region: Steps
-
-type GetUserPaymentPointersResponse = {
-  me: {
-    wallets: {
-      ilpPaymentPointers: {
-        paymentPointerUrl: string;
-      }[];
-    }[];
-  };
-};
 
 type AddILPWalletAddressKeyResponse = {
   addILPWalletAddressKey: {
@@ -64,48 +55,25 @@ const findWallet: Run<void> = async (
   { setNotificationSize },
 ) => {
   setNotificationSize('fullscreen');
-  const activeWallet = getActiveWallet();
-  if (!activeWallet) {
+  const wallets = await getUserWallets();
+  if (!wallets.length) {
     throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
       'No active wallet found',
     ]);
   }
 
-  const data = await graphQlRequest<GetUserPaymentPointersResponse>({
-    operationName: 'GetUserPaymentPointers',
-    variables: {
-      address: activeWallet.address,
-      walletType: activeWallet.walletType,
-    },
-    query: gql`
-      query GetUserPaymentPointers($address: String!, $walletType: WalletType) {
-        me {
-          wallets(address: $address, walletType: $walletType) {
-            ilpPaymentPointers {
-              paymentPointerUrl
-            }
-          }
-        }
-      }
-    `,
-  }).catch((error) => {
-    if (error instanceof GraphQlError) {
-      throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
-        error.message,
-      ]);
-    }
-    throw error;
-  });
-
-  const walletBelongsToUser = data.me.wallets.some((wallet) => {
-    return wallet.ilpPaymentPointers.some(
-      ({ paymentPointerUrl }) =>
-        paymentPointerUrl.toLowerCase() === walletAddressUrl.toLowerCase(),
-    );
-  });
-  if (!walletBelongsToUser) {
-    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
+  for (const wallet of wallets) {
+    const data = await getUserPaymentPointers(wallet);
+    const walletBelongsToUser = data.wallets.some((wallet) => {
+      return wallet.ilpPaymentPointers.some(
+        ({ paymentPointerUrl }) =>
+          paymentPointerUrl.toLowerCase() === walletAddressUrl.toLowerCase(),
+      );
+    });
+    if (walletBelongsToUser) return; // ok
   }
+
+  throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
 };
 
 const addKey: Run<void> = async ({ nickName, walletAddressUrl, publicKey }) => {

--- a/src/content/keyAutoAdd/lib/helpers/gatehub.ts
+++ b/src/content/keyAutoAdd/lib/helpers/gatehub.ts
@@ -1,4 +1,4 @@
-import { sleep } from '@/shared/helpers';
+import { ErrorWithKey, sleep } from '@/shared/helpers';
 
 export const getAuthToken = async (): Promise<string> => {
   let attempt = 0;
@@ -30,28 +30,70 @@ export const walletAddressUrlToId = (url: string) => {
   return pathname.match(/\/(\d+)/)![1];
 };
 
-export function getActiveWallet() {
-  let activeWallet: Record<string, unknown> | null = null;
-  try {
-    activeWallet = JSON.parse(
-      window.localStorage.getItem('activeWallet') || 'null',
-    );
-  } catch {}
+export async function getUserWallets() {
+  type GetWalletsResponse = Me<{
+    wallets: { address: string; walletType: string; enabled: boolean }[];
+  }>;
 
-  if (
-    typeof activeWallet === 'object' &&
-    activeWallet &&
-    typeof activeWallet.address === 'string' &&
-    activeWallet.address &&
-    activeWallet.walletType === 'Hosted'
-  ) {
-    return {
-      address: activeWallet.address,
-      walletType: activeWallet.walletType,
-    };
-  }
+  const data = await graphQlRequest<GetWalletsResponse>({
+    operationName: 'GetWallets',
+    variables: { filter: { includeDeleted: false } },
+    query: gql`
+      query GetWallets($filter: FilterWalletsInput, $walletType: WalletType) {
+        me {
+          wallets(filter: $filter, walletType: $walletType) {
+            address
+            walletType
+            enabled
+          }
+        }
+      }
+    `,
+  }).catch((error) => {
+    if (error instanceof GraphQlError) {
+      throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+        error.message,
+      ]);
+    }
+    throw error;
+  });
+  return data.me.wallets;
+}
 
-  return null;
+export async function getUserPaymentPointers(wallet: {
+  address: string;
+  walletType: string;
+}) {
+  type GetUserPaymentPointersResponse = Me<{
+    wallets: { ilpPaymentPointers: { paymentPointerUrl: string }[] }[];
+  }>;
+
+  const data = await graphQlRequest<GetUserPaymentPointersResponse>({
+    operationName: 'GetUserPaymentPointers',
+    variables: {
+      address: wallet.address,
+      walletType: wallet.walletType,
+    },
+    query: gql`
+      query GetUserPaymentPointers($address: String!, $walletType: WalletType) {
+        me {
+          wallets(address: $address, walletType: $walletType) {
+            ilpPaymentPointers {
+              paymentPointerUrl
+            }
+          }
+        }
+      }
+    `,
+  }).catch((error) => {
+    if (error instanceof GraphQlError) {
+      throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+        error.message,
+      ]);
+    }
+    throw error;
+  });
+  return data.me;
 }
 
 // For syntax highlighting
@@ -87,6 +129,8 @@ export async function graphQlRequest<R>(body: {
   }
   return json.data as R;
 }
+
+type Me<Data> = { me: Data };
 
 export class GraphQlError extends Error {
   public readonly errors: {

--- a/src/content/keyAutoAdd/lib/helpers/gatehub.ts
+++ b/src/content/keyAutoAdd/lib/helpers/gatehub.ts
@@ -49,14 +49,7 @@ export async function getUserWallets() {
         }
       }
     `,
-  }).catch((error) => {
-    if (error instanceof GraphQlError) {
-      throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
-        error.message,
-      ]);
-    }
-    throw error;
-  });
+  }).catch(handleError);
   return data.me.wallets;
 }
 
@@ -85,15 +78,17 @@ export async function getUserPaymentPointers(wallet: {
         }
       }
     `,
-  }).catch((error) => {
-    if (error instanceof GraphQlError) {
-      throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
-        error.message,
-      ]);
-    }
-    throw error;
-  });
+  }).catch(handleError);
   return data.me;
+}
+
+function handleError(error: unknown): never {
+  if (error instanceof GraphQlError) {
+    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+      error.message,
+    ]);
+  }
+  throw error;
 }
 
 // For syntax highlighting


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1383

## Changes proposed in this pull request

Instead of trying to find wallet addresses from the active wallet (grabbing from localStorage, a capability GateHub removed in some update), we use the graphql endpoint to first find all the wallets of user, and then for each wallet, find all wallet addresses, to check if the one provided by the user is one of them.
