### PR TITLE
fix(deps): don't override `structured-headers` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
       "safe-buffer": "5.2.1",
       "string_decoder": "1.3.0",
       "readable-stream": "2.3.8",
-      "parse5": "7.3.0",
-      "structured-headers": "1.0.1"
+      "parse5": "7.3.0"
     }
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   string_decoder: 1.3.0
   readable-stream: 2.3.8
   parse5: 7.3.0
-  structured-headers: 1.0.1
 
 importers:
 
@@ -3092,9 +3091,12 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  structured-headers@1.0.1:
-    resolution: {integrity: sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==}
-    engines: {node: '>= 14', npm: '>=6'}
+  structured-headers@0.5.0:
+    resolution: {integrity: sha512-oLnmXSsjhud+LxRJpvokwP8ImEB2wTg8sg30buwfVViKMuluTv3BlOJHUX9VW9pJ2nQOxmx87Z0kB86O4cphag==}
+
+  structured-headers@2.0.2:
+    resolution: {integrity: sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==}
+    engines: {node: '>=18', npm: '>=6'}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -5354,7 +5356,7 @@ snapshots:
 
   http-message-signatures@1.0.6:
     dependencies:
-      structured-headers: 1.0.1
+      structured-headers: 2.0.2
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -5365,7 +5367,7 @@ snapshots:
 
   httpbis-digest-headers@1.0.0:
     dependencies:
-      structured-headers: 1.0.1
+      structured-headers: 0.5.0
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -6522,7 +6524,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  structured-headers@1.0.1: {}
+  structured-headers@0.5.0: {}
+
+  structured-headers@2.0.2: {}
 
   sucrase@3.35.0:
     dependencies:


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

The E2E failures in https://github.com/interledger/web-monetization-extension/pull/1387 weren't transient (Nightly has been failing since the updates, some transient issues hid the real breakge). `http-message-signatures` bumped their `structured-headers` version to v2, while we were forcing v1, so OP integration broke.

## Changes proposed in this pull request

Don't restrict `structured-headers` dependency version, let the packages define their versions.
