### PR TITLE
feat(background): add per-site rate of pay support

### DIFF
--- a/src/background/services/__tests__/rateList.test.ts
+++ b/src/background/services/__tests__/rateList.test.ts
@@ -1,5 +1,10 @@
 import { openDB } from 'idb';
-import { RateListService, type RateListRecord } from '../rateList';
+import {
+  RateListService,
+  matchesPattern,
+  hostnameToSiteKey,
+  type RateListRecord,
+} from '../rateList';
 import type { StorageService } from '../storage';
 import type { WalletInfo } from '@/shared/types';
 import { describe, it, afterEach, vi, expect } from 'vitest';
@@ -69,10 +74,10 @@ describe('RateListService CRUD', () => {
   it('setRate and getAll', async () => {
     const rateList = makeRateListService();
     await rateList.setRate('example.com', '3');
-    await rateList.setRate('*.other.com', '5');
+    await rateList.setRate('other.com', '5');
     await expect(rateList.getAll()).resolves.toEqual(
       expect.arrayContaining([
-        { site: 'example.com', rate: '3' },
+        { site: '*.example.com', rate: '3' },
         { site: '*.other.com', rate: '5' },
       ]),
     );
@@ -110,7 +115,7 @@ describe('RateListService CRUD', () => {
     const rateList = makeRateListService();
     await rateList.setRate('example.com', '3');
     const [entry] = await rateList.getAll();
-    expect(entry).toEqual({ site: 'example.com', rate: '3' });
+    expect(entry).toEqual({ site: '*.example.com', rate: '3' });
     expect(entry).not.toHaveProperty('assetCode');
     expect(entry).not.toHaveProperty('assetScale');
   });
@@ -131,24 +136,15 @@ describe('RateListService.getRateForHostname', () => {
     ).rejects.toThrow('connected wallet');
   });
 
-  it('exact match takes priority over wildcard', async () => {
-    const rateList = makeRateListService();
-    await rateList.setRate('*.example.com', '3');
-    await rateList.setRate('www.example.com', '10');
-    await expect(rateList.getRateForHostname('www.example.com')).resolves.toBe(
-      '10',
-    );
-  });
-
   it('wildcard matches the apex domain', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*.example.com', '3');
+    await rateList.setRate('example.com', '3');
     await expect(rateList.getRateForHostname('example.com')).resolves.toBe('3');
   });
 
   it('wildcard matches a direct subdomain', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*.example.com', '3');
+    await rateList.setRate('example.com', '3');
     await expect(rateList.getRateForHostname('www.example.com')).resolves.toBe(
       '3',
     );
@@ -159,7 +155,7 @@ describe('RateListService.getRateForHostname', () => {
 
   it('wildcard matches a deep subdomain', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*.example.com', '3');
+    await rateList.setRate('example.com', '3');
     await expect(rateList.getRateForHostname('a.b.example.com')).resolves.toBe(
       '3',
     );
@@ -167,8 +163,8 @@ describe('RateListService.getRateForHostname', () => {
 
   it('more-specific wildcard takes priority over less-specific', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*.example.com', '3');
-    await rateList.setRate('*.sub.example.com', '7');
+    await rateList.setRate('example.com', '3');
+    await rateList.setRate('sub.example.com', '7');
     await expect(
       rateList.getRateForHostname('deep.sub.example.com'),
     ).resolves.toBe('7');
@@ -179,22 +175,60 @@ describe('RateListService.getRateForHostname', () => {
       rateList.getRateForHostname('other.example.com'),
     ).resolves.toBe('3');
   });
+});
 
-  it('falls back to * when no site-specific entry matches', async () => {
+describe('RateListService per-site priority and deletion', () => {
+  it('more-specific subdomain rate takes priority over apex rate', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*', '2');
-    await rateList.setRate('other.com', '5');
-    await expect(rateList.getRateForHostname('example.com')).resolves.toBe('2');
+    await rateList.setRate('hostname.com', '3');
+    await rateList.setRate('test.hostname.com', '7');
+    await expect(
+      rateList.getRateForHostname('test.hostname.com'),
+    ).resolves.toBe('7');
+    await expect(
+      rateList.getRateForHostname('deep.test.hostname.com'),
+    ).resolves.toBe('7');
+    await expect(
+      rateList.getRateForHostname('other.hostname.com'),
+    ).resolves.toBe('3');
   });
 
-  it('* is overridden by a matching site entry', async () => {
+  it('insertion order does not affect priority', async () => {
     const rateList = makeRateListService();
-    await rateList.setRate('*', '2');
-    await rateList.setRate('*.example.com', '3');
-    await expect(rateList.getRateForHostname('example.com')).resolves.toBe('3');
-    await expect(rateList.getRateForHostname('unrelated.com')).resolves.toBe(
-      '2',
-    );
+    await rateList.setRate('test.hostname.com', '7');
+    await rateList.setRate('hostname.com', '3');
+    await expect(
+      rateList.getRateForHostname('test.hostname.com'),
+    ).resolves.toBe('7');
+    await expect(
+      rateList.getRateForHostname('other.hostname.com'),
+    ).resolves.toBe('3');
+  });
+
+  it('deleting the specific rate falls back to the apex rate', async () => {
+    const rateList = makeRateListService();
+    await rateList.setRate('hostname.com', '3');
+    await rateList.setRate('test.hostname.com', '7');
+    await rateList.deleteRate('test.hostname.com');
+    await expect(
+      rateList.getRateForHostname('test.hostname.com'),
+    ).resolves.toBe('3');
+    await expect(
+      rateList.getRateForHostname('other.hostname.com'),
+    ).resolves.toBe('3');
+  });
+
+  it('deleting the apex rate leaves only the specific rate active', async () => {
+    const rateList = makeRateListService();
+    await rateList.setRate('hostname.com', '3');
+    await rateList.setRate('test.hostname.com', '7');
+    await rateList.deleteRate('hostname.com');
+    await expect(
+      rateList.getRateForHostname('test.hostname.com'),
+    ).resolves.toBe('7');
+    await expect(
+      rateList.getRateForHostname('other.hostname.com'),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -219,7 +253,7 @@ describe('RateListService currency isolation', () => {
 
     const usdAll = await usd.getAll();
     expect(usdAll).toHaveLength(1);
-    expect(usdAll[0].site).toBe('example.com');
+    expect(usdAll[0].site).toBe('*.example.com');
   });
 
   it('reconnecting with the same currency reuses existing data', async () => {
@@ -233,9 +267,25 @@ describe('RateListService currency isolation', () => {
   });
 });
 
-describe('RateListService.matchesPattern', () => {
-  const { matchesPattern } = RateListService;
+describe('hostnameToSiteKey', () => {
+  it('maps www to the apex wildcard', () => {
+    expect(hostnameToSiteKey('www.example.com')).toBe('*.example.com');
+  });
 
+  it('maps an apex domain to its own wildcard', () => {
+    expect(hostnameToSiteKey('example.com')).toBe('*.example.com');
+  });
+
+  it('maps other subdomains to their own wildcard', () => {
+    expect(hostnameToSiteKey('blog.example.com')).toBe('*.blog.example.com');
+    expect(hostnameToSiteKey('sub.example.com')).toBe('*.sub.example.com');
+    expect(hostnameToSiteKey('deep.sub.example.com')).toBe(
+      '*.deep.sub.example.com',
+    );
+  });
+});
+
+describe('matchesPattern', () => {
   it('* matches any hostname', () => {
     expect(matchesPattern('example.com', '*')).toBe(true);
     expect(matchesPattern('www.example.com', '*')).toBe(true);

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -35,6 +35,7 @@ export class Background {
   private events: Cradle['events'];
   private heartbeat: Cradle['heartbeat'];
   private telemetry: Cradle['telemetry'];
+  private rateList: Cradle['rateList'];
 
   constructor({
     browser,
@@ -51,6 +52,7 @@ export class Background {
     events,
     heartbeat,
     telemetry,
+    rateList,
   }: Cradle) {
     this.browser = browser;
     this.browserName = browserName;
@@ -66,6 +68,7 @@ export class Background {
     this.events = events;
     this.heartbeat = heartbeat;
     this.telemetry = telemetry;
+    this.rateList = rateList;
   }
 
   async start() {
@@ -304,6 +307,22 @@ export class Background {
 
         case 'UPDATE_RATE_OF_PAY': {
           await this.storage.updateRate(message.payload.rateOfPay);
+          return success(undefined);
+        }
+
+        case 'GET_PER_SITE_RATE_OF_PAY': {
+          const rates = await this.rateList.getAll();
+          return success(rates);
+        }
+
+        case 'SET_SITE_RATE_OF_PAY': {
+          const { hostname, rate } = message.payload;
+          if (rate === null) {
+            await this.rateList.deleteRate(hostname);
+          } else {
+            await this.rateList.setRate(hostname, rate);
+          }
+          this.events.emit('rateList.site_rate_update', { hostname, rate });
           return success(undefined);
         }
 

--- a/src/background/services/events.ts
+++ b/src/background/services/events.ts
@@ -12,6 +12,7 @@ interface BackgroundEvents {
   'open_payments.invalid_receiver': { tabId: number };
   request_popup_close: undefined;
   'storage.rate_of_pay_update': { rate: string };
+  'rateList.site_rate_update': { hostname: string; rate: AmountValue | null };
   'storage.state_update': {
     state: Storage['state'];
     prevState: Storage['state'];

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -482,7 +482,7 @@ export class MonetizationService {
     const { oneTimeGrant, recurringGrant, ...dataFromStorage } = storedData;
 
     const tabData = this.tabState.getPopupTabData(tab);
-    if (tabData.url) {
+    if (tabData.url && storedData.walletAddress) {
       const siteRate = await this.rateList.getRateForHostname(
         new URL(tabData.url).hostname,
       );

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -6,10 +6,15 @@ import type {
   StartMonetizationPayload,
   StopMonetizationPayload,
 } from '@/shared/messages';
+import {
+  matchesPattern,
+  hostnameToSiteKey,
+} from '@/background/services/rateList';
 import { getSender, getTabId } from '@/background/utils';
 import {
   ErrorWithKey,
   isOkState,
+  isTabWithUrl,
   removeQueryParams,
   transformBalance,
 } from '@/shared/helpers';
@@ -19,6 +24,7 @@ import type { Cradle } from '@/background/container';
 export class MonetizationService {
   private logger: Cradle['logger'];
   private rootLogger: Cradle['rootLogger'];
+  private browser: Cradle['browser'];
   private openPaymentsService: Cradle['openPaymentsService'];
   private outgoingPaymentGrantService: Cradle['outgoingPaymentGrantService'];
   private storage: Cradle['storage'];
@@ -29,10 +35,12 @@ export class MonetizationService {
   private telemetry: Cradle['telemetry'];
   private PaymentSession: Cradle['PaymentSession'];
   private PaymentManager: Cradle['PaymentManager'];
+  private rateList: Cradle['rateList'];
 
   constructor({
     logger,
     rootLogger,
+    browser,
     openPaymentsService,
     outgoingPaymentGrantService,
     storage,
@@ -43,9 +51,11 @@ export class MonetizationService {
     telemetry,
     PaymentSession,
     PaymentManager,
+    rateList,
   }: Cradle) {
     this.logger = logger;
     this.rootLogger = rootLogger;
+    this.browser = browser;
     this.openPaymentsService = openPaymentsService;
     this.outgoingPaymentGrantService = outgoingPaymentGrantService;
     this.storage = storage;
@@ -56,6 +66,7 @@ export class MonetizationService {
     this.telemetry = telemetry;
     this.PaymentSession = PaymentSession;
     this.PaymentManager = PaymentManager;
+    this.rateList = rateList;
 
     this.registerEventListeners();
   }
@@ -85,11 +96,14 @@ export class MonetizationService {
     let paymentManager = this.tabState.paymentManagers.get(tabId);
     if (!paymentManager) {
       const url = removeQueryParams(this.tabState.url.get(tabId) || fullUrl!);
+      const siteRate = await this.rateList.getRateForHostname(
+        new URL(url).hostname,
+      );
       paymentManager = new this.PaymentManager(
         tabId,
         url,
         connectedWallet,
-        rateOfPay,
+        siteRate ?? rateOfPay,
         {
           storage: this.storage,
           openPaymentsService: this.openPaymentsService,
@@ -348,10 +362,37 @@ export class MonetizationService {
   }
 
   private registerEventListeners() {
+    this.onSiteRateUpdate();
     this.onRateOfPayUpdate();
     this.onKeyRevoked();
     this.onOutOfFunds();
     this.onInvalidReceiver();
+  }
+
+  private onSiteRateUpdate() {
+    this.events.on('rateList.site_rate_update', async ({ hostname, rate }) => {
+      this.logger.debug("Received event='rateList.site_rate_update'", {
+        hostname,
+      });
+      const { rateOfPay } = await this.storage.get(['rateOfPay']);
+      if (!rateOfPay) return;
+
+      const site = hostnameToSiteKey(hostname);
+      const effectiveRate = rate ?? rateOfPay;
+
+      const matchingTabs = await this.browser.tabs
+        .query({ url: `*://${site}/*` })
+        .then((tabs) => tabs.filter(isTabWithUrl));
+
+      for (const tab of matchingTabs) {
+        const tabHostname = new URL(tab.url).hostname;
+        if (!matchesPattern(tabHostname, site)) continue;
+
+        const paymentManager = this.tabState.paymentManagers.get(tab.id);
+        if (!paymentManager) continue;
+        paymentManager.setRate(effectiveRate);
+      }
+    });
   }
 
   private onRateOfPayUpdate() {
@@ -370,11 +411,20 @@ export class MonetizationService {
         }
       }
 
-      for (const tabId of tabIds) {
-        const paymentManager = this.tabState.paymentManagers.get(tabId);
-        paymentManager?.setRate(rate);
+      const hasSiteRate = await Promise.all(tabIds.map(hasSiteSpecificRate));
+      for (let i = 0; i < tabIds.length; i++) {
+        if (hasSiteRate[i]) continue;
+        this.tabState.paymentManagers.get(tabIds[i])?.setRate(rate);
       }
     });
+
+    const hasSiteSpecificRate = async (tabId: number): Promise<boolean> => {
+      const tabUrl = this.tabState.url.get(tabId);
+      if (!tabUrl) return false;
+      const { hostname } = new URL(tabUrl);
+      const siteRate = await this.rateList.getRateForHostname(hostname);
+      return !!siteRate;
+    };
   }
 
   private onKeyRevoked() {
@@ -431,10 +481,18 @@ export class MonetizationService {
 
     const { oneTimeGrant, recurringGrant, ...dataFromStorage } = storedData;
 
+    const tabData = this.tabState.getPopupTabData(tab);
+    if (tabData.url) {
+      const siteRate = await this.rateList.getRateForHostname(
+        new URL(tabData.url).hostname,
+      );
+      if (siteRate) tabData.rateOfPay = siteRate;
+    }
+
     return {
       ...dataFromStorage,
       balance: balance.total.toString(),
-      tab: this.tabState.getPopupTabData(tab),
+      tab: tabData,
       transientState: this.storage.getTransientState(),
       grants: {
         oneTime: oneTimeGrant?.amount,

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -385,12 +385,9 @@ export class MonetizationService {
         .then((tabs) => tabs.filter(isTabWithUrl));
 
       for (const tab of matchingTabs) {
-        const tabHostname = new URL(tab.url).hostname;
-        if (!matchesPattern(tabHostname, site)) continue;
-
+        if (!matchesPattern(new URL(tab.url).hostname, site)) continue;
         const paymentManager = this.tabState.paymentManagers.get(tab.id);
-        if (!paymentManager) continue;
-        paymentManager.setRate(effectiveRate);
+        paymentManager?.setRate(effectiveRate);
       }
     });
   }
@@ -412,9 +409,9 @@ export class MonetizationService {
       }
 
       const hasSiteRate = await Promise.all(tabIds.map(hasSiteSpecificRate));
-      for (let i = 0; i < tabIds.length; i++) {
+      for (const [i, tabId] of tabIds.entries()) {
         if (hasSiteRate[i]) continue;
-        this.tabState.paymentManagers.get(tabIds[i])?.setRate(rate);
+        this.tabState.paymentManagers.get(tabId)?.setRate(rate);
       }
     });
 

--- a/src/background/services/rateList.ts
+++ b/src/background/services/rateList.ts
@@ -44,7 +44,7 @@ export class RateListService {
     return entries.map(({ site, rate }) => ({ site, rate }));
   }
 
-  async setRate(site: string, rate: AmountValue): Promise<void> {
+  async setRate(hostname: string, rate: AmountValue): Promise<void> {
     const wallet = await this.#getWallet();
     if (!wallet) {
       throw new Error('Cannot set rate without a connected wallet');
@@ -52,13 +52,15 @@ export class RateListService {
 
     const db = await this.#getDb();
     const { assetCode, assetScale } = wallet;
+    const site = hostnameToSiteKey(hostname);
     await db.put('rates', { assetCode, assetScale, site, rate });
   }
 
-  async deleteRate(site: string): Promise<void> {
+  async deleteRate(hostname: string): Promise<void> {
     const wallet = await this.#getWallet();
     if (!wallet) return;
     const db = await this.#getDb();
+    const site = hostnameToSiteKey(hostname);
     await db.delete('rates', [wallet.assetCode, wallet.assetScale, site]);
   }
 
@@ -89,19 +91,30 @@ export class RateListService {
     const defaultEntry = await db.get('rates', [assetCode, assetScale, '*']);
     return defaultEntry?.rate;
   }
+}
 
-  /**
-   * Returns true if the given hostname is covered by the pattern. Used by
-   * MonetizationService to decide which open tabs are affected when a per-site
-   * rate changes.
-   */
-  static matchesPattern(hostname: string, pattern: string): boolean {
-    if (pattern === '*') return true;
-    if (pattern === hostname) return true;
-    if (!pattern.startsWith('*.')) return false;
-    const domain = pattern.slice(2);
-    return hostname === domain || hostname.endsWith(`.${domain}`);
-  }
+/**
+ * Returns true if the given hostname is covered by the pattern. Used by
+ * MonetizationService to decide which open tabs are affected when a per-site
+ * rate changes.
+ */
+export function matchesPattern(hostname: string, pattern: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern === hostname) return true;
+  if (!pattern.startsWith('*.')) return false;
+  const domain = pattern.slice(2);
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+/**
+ * Converts a raw hostname to the site key used in the rate list. "www" is
+ * treated as an alias for the apex domain and gets the same low-priority
+ * wildcard (*.example.com). All other subdomains get their own wildcard
+ * (*.sub.example.com) so they take priority over the apex wildcard.
+ */
+export function hostnameToSiteKey(hostname: string): string {
+  const base = hostname.startsWith('www.') ? hostname.slice(4) : hostname;
+  return `*.${base}`;
 }
 
 interface RatesSchema extends DBSchema {

--- a/src/shared/helpers/misc.ts
+++ b/src/shared/helpers/misc.ts
@@ -1,5 +1,5 @@
-import type { Browser } from 'webextension-polyfill';
-import type { Storage } from '../types';
+import type { Browser, Tabs } from 'webextension-polyfill';
+import type { Storage, Tab } from '../types';
 
 export const notNullOrUndef = <T>(
   t: T | null | undefined,
@@ -128,6 +128,10 @@ export const getBrowserName = (
   }
 
   return 'unknown';
+};
+
+export const isTabWithUrl = (tab: Tabs.Tab): tab is Tab => {
+  return !!tab.id && !!tab.url;
 };
 
 /** @see {@linkcode Storage['consent']} */

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -142,6 +142,11 @@ export interface UpdateRateOfPayPayload {
   rateOfPay: AmountValue;
 }
 
+export interface SiteRateEntry {
+  site: string;
+  rate: AmountValue;
+}
+
 export interface UpdateBudgetPayload {
   walletAddressUrl: string;
   amount: ConnectWalletPayload['amount'];
@@ -196,6 +201,14 @@ export type PopupToBackgroundMessage = {
   UPDATE_RATE_OF_PAY: {
     input: UpdateRateOfPayPayload;
     output: never;
+  };
+  SET_SITE_RATE_OF_PAY: {
+    input: { hostname: string; rate: AmountValue | null };
+    output: never;
+  };
+  GET_PER_SITE_RATE_OF_PAY: {
+    input: never;
+    output: SiteRateEntry[];
   };
   OPEN_APP: {
     input: { path: string; action?: string };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -126,6 +126,7 @@ export type PopupTabInfo = {
   tabId: TabId;
   url: string;
   minSendAmount: AmountValue;
+  rateOfPay?: AmountValue;
   status:
     | never // just added for code formatting
     /** Happy state */

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -9,6 +9,7 @@ import {
   chromium,
   firefox,
   type BrowserContext,
+  type Page,
   type WorkerInfo,
   type Worker,
 } from '@playwright/test';
@@ -376,11 +377,11 @@ export class BrowserIntl {
 
 type Msg = PopupToBackgroundMessage;
 export async function sendBackgroundMessage<K extends keyof Msg>(
-  background: Background,
+  page: Page,
   action: K,
   payload: Msg[K]['input'] extends never ? undefined : Msg[K]['input'],
 ): Promise<Response<Msg[K]['output']>> {
-  return background.evaluate(
+  return page.evaluate(
     ([action, payload]) => chrome.runtime.sendMessage({ action, payload }),
     [action, payload],
   );

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -376,7 +376,7 @@ export class BrowserIntl {
 }
 
 type Msg = PopupToBackgroundMessage;
-export async function sendBackgroundMessage<K extends keyof Msg>(
+export async function sendMessageToBackground<K extends keyof Msg>(
   page: Page,
   action: K,
   payload: Msg[K]['input'] extends never ? undefined : Msg[K]['input'],

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -17,6 +17,10 @@ import { APP_URL } from '@/background/constants';
 import { DIST_DIR, ROOT_DIR } from '../../../scripts/esbuild/config';
 import type { TranslationKeys } from '../../../src/shared/helpers';
 import type { Storage, StorageKey } from '../../../src/shared/types';
+import type {
+  PopupToBackgroundMessage,
+  Response,
+} from '../../../src/shared/messages';
 
 export type BrowserInfo = { browserName: string; channel: string | undefined };
 export type Background = Worker;
@@ -368,6 +372,18 @@ export class BrowserIntl {
     }
     return result;
   }
+}
+
+type Msg = PopupToBackgroundMessage;
+export async function sendBackgroundMessage<K extends keyof Msg>(
+  background: Background,
+  action: K,
+  payload: Msg[K]['input'] extends never ? undefined : Msg[K]['input'],
+): Promise<Response<Msg[K]['output']>> {
+  return background.evaluate(
+    ([action, payload]) => chrome.runtime.sendMessage({ action, payload }),
+    [action, payload],
+  );
 }
 
 export async function getStorage<TKey extends StorageKey>(

--- a/tests/e2e/siteRate.spec.ts
+++ b/tests/e2e/siteRate.spec.ts
@@ -2,13 +2,14 @@ import { MIN_PAYMENT_WAIT } from '@/background/config';
 import { hostnameToSiteKey } from '@/background/services/rateList';
 import { getResponseOrThrow, type SiteRateEntry } from '@/shared/messages';
 import { test, expect } from './fixtures/connected';
-import { type Background, sendBackgroundMessage } from './fixtures/helpers';
+import { sendBackgroundMessage } from './fixtures/helpers';
 import {
   interceptPaymentCreateRequests,
   playgroundUrl,
   setupPlayground,
 } from './helpers/common';
 import type { AmountValue } from '@/shared/types';
+import type { Popup } from './pages/popup';
 
 const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
 const PLAYGROUND_HOSTNAME = 'webmonetization.org';
@@ -18,32 +19,25 @@ const SITE_RATE = '7200';
 
 test.describe('per-site rate – storage', () => {
   test('GET_PER_SITE_RATE_OF_PAY returns empty list initially', async ({
-    background,
     popup,
   }) => {
-    void popup;
-    const rates = await getSiteRates(background);
+    const rates = await getSiteRates(popup);
     expect(rates).toEqual([]);
   });
 
-  test('SET_SITE_RATE_OF_PAY stores a rate', async ({ background, popup }) => {
-    void popup;
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
-    const rates = await getSiteRates(background);
+  test('SET_SITE_RATE_OF_PAY stores a rate', async ({ popup }) => {
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '500');
+    const rates = await getSiteRates(popup);
     expect(rates).toContainEqual({
       site: hostnameToSiteKey(PLAYGROUND_HOSTNAME),
       rate: '500',
     });
   });
 
-  test('SET_SITE_RATE_OF_PAY overwrites existing entry', async ({
-    background,
-    popup,
-  }) => {
-    void popup;
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, '800');
-    const rates = await getSiteRates(background);
+  test('SET_SITE_RATE_OF_PAY overwrites existing entry', async ({ popup }) => {
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '500');
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '800');
+    const rates = await getSiteRates(popup);
     const entry = rates.filter(
       (r) => r.site === hostnameToSiteKey(PLAYGROUND_HOSTNAME),
     );
@@ -52,13 +46,11 @@ test.describe('per-site rate – storage', () => {
   });
 
   test('SET_SITE_RATE_OF_PAY with rate=null deletes the entry', async ({
-    background,
     popup,
   }) => {
-    void popup;
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
-    const rates = await getSiteRates(background);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '500');
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, null);
+    const rates = await getSiteRates(popup);
     expect(
       rates.find((r) => r.site === hostnameToSiteKey(PLAYGROUND_HOSTNAME)),
     ).toBeUndefined();
@@ -67,21 +59,15 @@ test.describe('per-site rate – storage', () => {
 
 test.describe('per-site rate – GET_DATA_POPUP', () => {
   test('tab.rateOfPay is present when a site rate is active', async ({
-    background,
     page,
     popup,
   }) => {
-    void popup;
     const SITE_RATE_VAL = '500';
     await setupPlayground(page, walletAddressUrl);
     await page.bringToFront();
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE_VAL);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE_VAL);
 
-    const res = await sendBackgroundMessage(
-      background,
-      'GET_DATA_POPUP',
-      undefined,
-    );
+    const res = await sendBackgroundMessage(popup, 'GET_DATA_POPUP', undefined);
     const data = getResponseOrThrow(res);
     expect(data.tab.rateOfPay).toBe(SITE_RATE_VAL);
   });
@@ -96,16 +82,14 @@ test.describe('per-site rate – payment session', () => {
   });
 
   test('site rate is used when a payment session starts', async ({
-    background,
     page,
     context,
     popup,
   }) => {
-    void popup;
     const { outgoingPaymentCreatedCallback } =
       interceptPaymentCreateRequests(context);
 
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE);
     await setupPlayground(page, walletAddressUrl);
 
     await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(1, {
@@ -115,7 +99,7 @@ test.describe('per-site rate – payment session', () => {
       outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
     );
 
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, null);
     await page.goto(playgroundUrl(walletAddressUrl));
 
     await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(2, {
@@ -129,12 +113,10 @@ test.describe('per-site rate – payment session', () => {
   });
 
   test('site rate change propagates to active payment session', async ({
-    background,
     page,
     context,
     popup,
   }) => {
-    void popup;
     const { outgoingPaymentCreatedCallback } =
       interceptPaymentCreateRequests(context);
     const monetizationCallback = await setupPlayground(page, walletAddressUrl);
@@ -144,7 +126,7 @@ test.describe('per-site rate – payment session', () => {
       outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
     );
 
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE);
     await context.clock.runFor(MIN_PAYMENT_WAIT);
 
     await expect(monetizationCallback).toHaveBeenCalledTimes(2);
@@ -156,12 +138,10 @@ test.describe('per-site rate – payment session', () => {
   });
 
   test('deleting site rate reverts active session to global rate', async ({
-    background,
     page,
     context,
     popup,
   }) => {
-    void popup;
     const { outgoingPaymentCreatedCallback } =
       interceptPaymentCreateRequests(context);
     const monetizationCallback = await setupPlayground(page, walletAddressUrl);
@@ -171,7 +151,7 @@ test.describe('per-site rate – payment session', () => {
       outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
     );
 
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE);
     await context.clock.runFor(MIN_PAYMENT_WAIT);
     await expect(monetizationCallback).toHaveBeenCalledTimes(2);
     const siteDebit = Number(
@@ -179,7 +159,7 @@ test.describe('per-site rate – payment session', () => {
     );
     expect(siteDebit).toBeGreaterThan(globalDebit);
 
-    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, null);
     await context.clock.runFor(MIN_PAYMENT_WAIT);
     await expect(monetizationCallback).toHaveBeenCalledTimes(3);
     const revertedDebit = Number(
@@ -191,20 +171,20 @@ test.describe('per-site rate – payment session', () => {
 
 // TODO: we'll use UI interactions in the future.
 async function setSiteRate(
-  background: Background,
+  popup: Popup,
   hostname: string,
   rate: AmountValue | null,
 ): Promise<void> {
-  const res = await sendBackgroundMessage(background, 'SET_SITE_RATE_OF_PAY', {
+  const res = await sendBackgroundMessage(popup, 'SET_SITE_RATE_OF_PAY', {
     hostname,
     rate,
   });
   getResponseOrThrow(res);
 }
 
-async function getSiteRates(background: Background): Promise<SiteRateEntry[]> {
+async function getSiteRates(popup: Popup): Promise<SiteRateEntry[]> {
   const res = await sendBackgroundMessage(
-    background,
+    popup,
     'GET_PER_SITE_RATE_OF_PAY',
     undefined,
   );

--- a/tests/e2e/siteRate.spec.ts
+++ b/tests/e2e/siteRate.spec.ts
@@ -100,6 +100,10 @@ test.describe('per-site rate – payment session', () => {
     );
 
     await setSiteRate(popup, PLAYGROUND_HOSTNAME, null);
+    // Navigate away to destroy the PaymentManager (clears its timer),
+    // then advance fake time so preventOverpaying won't block the next session.
+    await page.goto('about:blank');
+    await context.clock.runFor(MIN_PAYMENT_WAIT);
     await page.goto(playgroundUrl(walletAddressUrl));
 
     await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(2, {
@@ -160,7 +164,11 @@ test.describe('per-site rate – payment session', () => {
     expect(siteDebit).toBeGreaterThan(globalDebit);
 
     await setSiteRate(popup, PLAYGROUND_HOSTNAME, null);
+    // Navigate away to destroy the PaymentManager (clears its timer),
+    // then advance fake time so preventOverpaying won't block the next session.
+    await page.goto('about:blank');
     await context.clock.runFor(MIN_PAYMENT_WAIT);
+    await page.goto(playgroundUrl(walletAddressUrl));
     await expect(monetizationCallback).toHaveBeenCalledTimes(3);
     const revertedDebit = Number(
       outgoingPaymentCreatedCallback.calls[2][0].debitAmount.value,

--- a/tests/e2e/siteRate.spec.ts
+++ b/tests/e2e/siteRate.spec.ts
@@ -2,7 +2,7 @@ import { MIN_PAYMENT_WAIT } from '@/background/config';
 import { hostnameToSiteKey } from '@/background/services/rateList';
 import { getResponseOrThrow, type SiteRateEntry } from '@/shared/messages';
 import { test, expect } from './fixtures/connected';
-import { sendBackgroundMessage } from './fixtures/helpers';
+import { sendMessageToBackground } from './fixtures/helpers';
 import {
   interceptPaymentCreateRequests,
   playgroundUrl,
@@ -67,7 +67,11 @@ test.describe('per-site rate – GET_DATA_POPUP', () => {
     await page.bringToFront();
     await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE_VAL);
 
-    const res = await sendBackgroundMessage(popup, 'GET_DATA_POPUP', undefined);
+    const res = await sendMessageToBackground(
+      popup,
+      'GET_DATA_POPUP',
+      undefined,
+    );
     const data = getResponseOrThrow(res);
     expect(data.tab.rateOfPay).toBe(SITE_RATE_VAL);
   });
@@ -183,7 +187,7 @@ async function setSiteRate(
   hostname: string,
   rate: AmountValue | null,
 ): Promise<void> {
-  const res = await sendBackgroundMessage(popup, 'SET_SITE_RATE_OF_PAY', {
+  const res = await sendMessageToBackground(popup, 'SET_SITE_RATE_OF_PAY', {
     hostname,
     rate,
   });
@@ -191,7 +195,7 @@ async function setSiteRate(
 }
 
 async function getSiteRates(popup: Popup): Promise<SiteRateEntry[]> {
-  const res = await sendBackgroundMessage(
+  const res = await sendMessageToBackground(
     popup,
     'GET_PER_SITE_RATE_OF_PAY',
     undefined,

--- a/tests/e2e/siteRate.spec.ts
+++ b/tests/e2e/siteRate.spec.ts
@@ -1,0 +1,212 @@
+import { MIN_PAYMENT_WAIT } from '@/background/config';
+import { hostnameToSiteKey } from '@/background/services/rateList';
+import { getResponseOrThrow, type SiteRateEntry } from '@/shared/messages';
+import { test, expect } from './fixtures/connected';
+import { type Background, sendBackgroundMessage } from './fixtures/helpers';
+import {
+  interceptPaymentCreateRequests,
+  playgroundUrl,
+  setupPlayground,
+} from './helpers/common';
+import type { AmountValue } from '@/shared/types';
+
+const walletAddressUrl = process.env.TEST_WALLET_ADDRESS_URL;
+const PLAYGROUND_HOSTNAME = 'webmonetization.org';
+
+const GLOBAL_RATE = '3600';
+const SITE_RATE = '7200';
+
+test.describe('per-site rate – storage', () => {
+  test('GET_PER_SITE_RATE_OF_PAY returns empty list initially', async ({
+    background,
+    popup,
+  }) => {
+    void popup;
+    const rates = await getSiteRates(background);
+    expect(rates).toEqual([]);
+  });
+
+  test('SET_SITE_RATE_OF_PAY stores a rate', async ({ background, popup }) => {
+    void popup;
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
+    const rates = await getSiteRates(background);
+    expect(rates).toContainEqual({
+      site: hostnameToSiteKey(PLAYGROUND_HOSTNAME),
+      rate: '500',
+    });
+  });
+
+  test('SET_SITE_RATE_OF_PAY overwrites existing entry', async ({
+    background,
+    popup,
+  }) => {
+    void popup;
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, '800');
+    const rates = await getSiteRates(background);
+    const entry = rates.filter(
+      (r) => r.site === hostnameToSiteKey(PLAYGROUND_HOSTNAME),
+    );
+    expect(entry).toHaveLength(1);
+    expect(entry[0].rate).toBe('800');
+  });
+
+  test('SET_SITE_RATE_OF_PAY with rate=null deletes the entry', async ({
+    background,
+    popup,
+  }) => {
+    void popup;
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, '500');
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
+    const rates = await getSiteRates(background);
+    expect(
+      rates.find((r) => r.site === hostnameToSiteKey(PLAYGROUND_HOSTNAME)),
+    ).toBeUndefined();
+  });
+});
+
+test.describe('per-site rate – GET_DATA_POPUP', () => {
+  test('tab.rateOfPay is present when a site rate is active', async ({
+    background,
+    page,
+    popup,
+  }) => {
+    void popup;
+    const SITE_RATE_VAL = '500';
+    await setupPlayground(page, walletAddressUrl);
+    await page.bringToFront();
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE_VAL);
+
+    const res = await sendBackgroundMessage(
+      background,
+      'GET_DATA_POPUP',
+      undefined,
+    );
+    const data = getResponseOrThrow(res);
+    expect(data.tab.rateOfPay).toBe(SITE_RATE_VAL);
+  });
+});
+
+test.describe('per-site rate – payment session', () => {
+  test.beforeEach(async ({ background }) => {
+    await background.evaluate(
+      (rate) => chrome.storage.local.set({ rateOfPay: rate }),
+      GLOBAL_RATE,
+    );
+  });
+
+  test('site rate is used when a payment session starts', async ({
+    background,
+    page,
+    context,
+    popup,
+  }) => {
+    void popup;
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await setupPlayground(page, walletAddressUrl);
+
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(1, {
+      timeout: 10_000,
+    });
+    const siteRateDebit = Number(
+      outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
+    );
+
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
+    await page.goto(playgroundUrl(walletAddressUrl));
+
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(2, {
+      timeout: 10_000,
+    });
+    const globalRateDebit = Number(
+      outgoingPaymentCreatedCallback.calls[1][0].debitAmount.value,
+    );
+
+    expect(siteRateDebit).toBeGreaterThan(globalRateDebit);
+  });
+
+  test('site rate change propagates to active payment session', async ({
+    background,
+    page,
+    context,
+    popup,
+  }) => {
+    void popup;
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+    const monetizationCallback = await setupPlayground(page, walletAddressUrl);
+
+    await expect(monetizationCallback).toHaveBeenCalledTimes(1);
+    const firstDebit = Number(
+      outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
+    );
+
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await context.clock.runFor(MIN_PAYMENT_WAIT);
+
+    await expect(monetizationCallback).toHaveBeenCalledTimes(2);
+    const secondDebit = Number(
+      outgoingPaymentCreatedCallback.calls[1][0].debitAmount.value,
+    );
+
+    expect(secondDebit).toBeGreaterThan(firstDebit);
+  });
+
+  test('deleting site rate reverts active session to global rate', async ({
+    background,
+    page,
+    context,
+    popup,
+  }) => {
+    void popup;
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+    const monetizationCallback = await setupPlayground(page, walletAddressUrl);
+
+    await expect(monetizationCallback).toHaveBeenCalledTimes(1);
+    const globalDebit = Number(
+      outgoingPaymentCreatedCallback.calls[0][0].debitAmount.value,
+    );
+
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await context.clock.runFor(MIN_PAYMENT_WAIT);
+    await expect(monetizationCallback).toHaveBeenCalledTimes(2);
+    const siteDebit = Number(
+      outgoingPaymentCreatedCallback.calls[1][0].debitAmount.value,
+    );
+    expect(siteDebit).toBeGreaterThan(globalDebit);
+
+    await setSiteRate(background, PLAYGROUND_HOSTNAME, null);
+    await context.clock.runFor(MIN_PAYMENT_WAIT);
+    await expect(monetizationCallback).toHaveBeenCalledTimes(3);
+    const revertedDebit = Number(
+      outgoingPaymentCreatedCallback.calls[2][0].debitAmount.value,
+    );
+    expect(revertedDebit).toBe(globalDebit);
+  });
+});
+
+// TODO: we'll use UI interactions in the future.
+async function setSiteRate(
+  background: Background,
+  hostname: string,
+  rate: AmountValue | null,
+): Promise<void> {
+  const res = await sendBackgroundMessage(background, 'SET_SITE_RATE_OF_PAY', {
+    hostname,
+    rate,
+  });
+  getResponseOrThrow(res);
+}
+
+async function getSiteRates(background: Background): Promise<SiteRateEntry[]> {
+  const res = await sendBackgroundMessage(
+    background,
+    'GET_PER_SITE_RATE_OF_PAY',
+    undefined,
+  );
+  return getResponseOrThrow(res);
+}


### PR DESCRIPTION
## Context

Closes #1404
Part of #1345
Part of #1297 (story)

## Changes proposed in this pull request

- Add background messages for setting site's rate, getting all site rates
- Integrate `RateListService` into `MonetizationService`
- `setRate`/`deleteRate` now accept raw hostname instead of pattern key
- Return tab's `rateOfPay` in `GET_DATA_POPUP` response (defined only when user has set a custom rate)
- Add E2E tests
- Frontend work to follow