### PR TITLE
chore(tsconfig): use incremental builds for better local perf

### DIFF
--- a/src/shared/__tests__/helpers.test.ts
+++ b/src/shared/__tests__/helpers.test.ts
@@ -1,4 +1,6 @@
-import { addDays, addMonths, addSeconds } from 'date-fns';
+import { addDays } from 'date-fns/addDays';
+import { addMonths } from 'date-fns/addMonths';
+import { addSeconds } from 'date-fns/addSeconds';
 import {
   afterEach,
   beforeEach,

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -12,7 +12,7 @@ import {
   type WorkerInfo,
   type Worker,
 } from '@playwright/test';
-import { format } from 'date-fns';
+import { format } from 'date-fns/format';
 import { APP_URL } from '@/background/constants';
 import { DIST_DIR, ROOT_DIR } from '../../../scripts/esbuild/config';
 import type { TranslationKeys } from '../../../src/shared/helpers';

--- a/tests/e2e/walletBudget.spec.ts
+++ b/tests/e2e/walletBudget.spec.ts
@@ -15,7 +15,7 @@ import {
 } from './helpers/common';
 import { completeGrant, DEFAULT_CONTINUE_WAIT_MS } from './helpers/testWallet';
 import { transformBalance } from '@/shared/helpers';
-import { addMonths } from 'date-fns';
+import { addMonths } from 'date-fns/addMonths';
 import type { WalletAddress } from '@interledger/open-payments';
 import type { AmountValue } from '@/shared/types';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.tsbuildinfo",
     "paths": {
       "@/shared/*": ["./src/shared/*"],
       "@/popup/*": ["./src/pages/popup/*"],


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Running `pnpm typecheck` locally was taking too long (around 9s). 

## Changes proposed in this pull request

Use `incremental: true` to speed up local typechecking. Now takes 2s.

Also updated `date-fns` imports in tests, which leads to around 200 less files being read by `tsc` (small win).