### PR TITLE
feat(popup/RateOfPay): configure current site's rate

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -515,6 +515,19 @@
     "message": "We couldn’t verify your wallet. Please try again, or manually copy the public key and add it to your digital wallet account."
   },
 
+  "settings_rate_continuousPayments_label": {
+    "message": "Continuous payments"
+  },
+  "settings_rate_continuousPayments_disabled_text": {
+    "message": "Ongoing payments are now disabled. You can still make one time payments."
+  },
+  "settings_rate_label_manageExceptions": {
+    "message": "Manage exceptions"
+  },
+  "settings_rate_label_addException": {
+    "message": "Add exception"
+  },
+
   "settings_dataCollection_title": {
     "message": "Data Collection"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -527,6 +527,12 @@
   "settings_rate_label_addException": {
     "message": "Add exception"
   },
+  "settings_rate_label_inputDefaultRate": {
+    "message": "Default rate"
+  },
+  "settings_rate_action_removeException": {
+    "message": "Remove exception"
+  },
 
   "settings_dataCollection_title": {
     "message": "Data Collection"

--- a/src/background/services/rateList.ts
+++ b/src/background/services/rateList.ts
@@ -1,5 +1,6 @@
 // cSpell:ignore IDBPDatabase
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import { normalizeHostname } from '@/shared/helpers';
 import type { Cradle as Cradle_ } from '@/background/container';
 import type { AmountValue } from '@/shared/types';
 
@@ -113,8 +114,7 @@ export function matchesPattern(hostname: string, pattern: string): boolean {
  * (*.sub.example.com) so they take priority over the apex wildcard.
  */
 export function hostnameToSiteKey(hostname: string): string {
-  const base = hostname.startsWith('www.') ? hostname.slice(4) : hostname;
-  return `*.${base}`;
+  return `*.${normalizeHostname(hostname)}`;
 }
 
 interface RatesSchema extends DBSchema {

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -52,6 +52,7 @@ type CallbackTab<T extends Extract<keyof Browser['tabs'], `on${string}`>> =
 
 export class TabEvents {
   private storage: Cradle['storage'];
+  private rateList: Cradle['rateList'];
   private tabState: Cradle['tabState'];
   private windowState: Cradle['windowState'];
   private sendToPopup: Cradle['sendToPopup'];
@@ -62,6 +63,7 @@ export class TabEvents {
 
   constructor({
     storage,
+    rateList,
     tabState,
     windowState,
     sendToPopup,
@@ -71,6 +73,7 @@ export class TabEvents {
     browserName,
   }: Cradle) {
     this.storage = storage;
+    this.rateList = rateList;
     this.tabState = tabState;
     this.windowState = windowState;
     this.sendToPopup = sendToPopup;
@@ -139,6 +142,12 @@ export class TabEvents {
 
   updateVisualIndicators = async (tab: Tabs.Tab) => {
     const tabInfo = this.tabState.getPopupTabData(tab);
+    if (tabInfo.url) {
+      const siteRate = await this.rateList
+        .getRateForHostname(new URL(tabInfo.url).hostname)
+        .catch(() => undefined);
+      if (siteRate) tabInfo.rateOfPay = siteRate;
+    }
     this.sendToPopup.send('SET_TAB_DATA', tabInfo);
     const { continuousPaymentsEnabled, enabled, connected, state } =
       await this.storage.get([

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -123,7 +123,7 @@ export const RateOfPayComponent = ({
       >
         <RateOfPayInput
           id="rateOfPay"
-          label="Default rate"
+          label={t('settings_rate_label_inputDefaultRate')}
           onRateChange={onRateChange}
           rateOfPay={rateOfPay}
           maxRateOfPay={maxRateOfPay}
@@ -187,6 +187,7 @@ const SiteRateOfPayInput = ({
 }: {
   onRateChange: Props['onSiteRateChange'];
 }) => {
+  const t = useTranslation();
   const { rateOfPay, maxRateOfPay, walletAddress, tab } = usePopupState();
 
   const hostname = new URL(tab.url).hostname;
@@ -206,7 +207,9 @@ const SiteRateOfPayInput = ({
           type="button"
           className="p-1 text-alt"
         >
-          <span className="sr-only">Remove exception</span>
+          <span className="sr-only">
+            {t('settings_rate_action_removeException')}
+          </span>
           <IconTrash className="size-4" />
         </button>
       </div>

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -4,7 +4,7 @@ import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmountMemoized as InputAmount } from '@/pages/shared/components/InputAmount';
 import { IconTrash } from '@/pages/shared/components/Icons';
-import { debounceAsync } from '@/shared/helpers';
+import { debounceAsync, normalizeHostname } from '@/shared/helpers';
 import { cn, formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { useMessage, useTelemetry, useTranslation } from '@/popup/lib/context';
 import { dispatch, usePopupState, type PopupState } from '@/popup/lib/store';
@@ -191,7 +191,7 @@ const SiteRateOfPayInput = ({
   const { rateOfPay, maxRateOfPay, walletAddress, tab } = usePopupState();
 
   const hostname = new URL(tab.url).hostname;
-  const site = hostname.replace(/^www\./, '');
+  const site = normalizeHostname(hostname);
 
   return (
     <>

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useLocation } from 'wouter';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
+import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmountMemoized as InputAmount } from '@/pages/shared/components/InputAmount';
+import { IconTrash } from '@/pages/shared/components/Icons';
 import { debounceAsync } from '@/shared/helpers';
-import { formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
+import { cn, formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { useMessage, useTelemetry, useTranslation } from '@/popup/lib/context';
 import { dispatch, usePopupState, type PopupState } from '@/popup/lib/store';
-import type { AmountValue } from '@/shared/types';
+import type { AmountValue, Host } from '@/shared/types';
 
 export const RateOfPayScreen = () => {
   const message = useMessage();
@@ -22,9 +25,22 @@ export const RateOfPayScreen = () => {
     }, 1000),
   );
 
+  const updateSiteRateOfPay = React.useRef(
+    debounceAsync(async (data: SiteRateChangeData) => {
+      const response = await message.send('SET_SITE_RATE_OF_PAY', data);
+      if (!response.success) return;
+      telemetry.capture('site_rate_of_pay_change');
+    }, 500),
+  );
+
   const onRateChange = async (rateOfPay: AmountValue) => {
     dispatch({ type: 'UPDATE_RATE_OF_PAY', data: { rateOfPay } });
     void updateRateOfPay.current(rateOfPay);
+  };
+
+  const onSiteRateChange = async (data: SiteRateChangeData) => {
+    dispatch({ type: 'UPDATE_SITE_RATE_OF_PAY', data });
+    void updateSiteRateOfPay.current(data);
   };
 
   const toggleContinuousPayments = (continuousPaymentsEnabled: boolean) => {
@@ -39,6 +55,7 @@ export const RateOfPayScreen = () => {
   return (
     <RateOfPayComponent
       onRateChange={onRateChange}
+      onSiteRateChange={onSiteRateChange}
       toggle={toggleContinuousPayments}
     />
   );
@@ -46,29 +63,40 @@ export const RateOfPayScreen = () => {
 
 interface Props {
   onRateChange: (rate: AmountValue) => Promise<void>;
+  onSiteRateChange: (data: SiteRateChangeData) => Promise<void>;
   toggle: (nowEnabled: boolean) => void | Promise<void>;
 }
 
-export const RateOfPayComponent = ({ onRateChange, toggle }: Props) => {
-  const { continuousPaymentsEnabled, rateOfPay, maxRateOfPay, walletAddress } =
-    usePopupState();
-  return (
-    <div className="space-y-8">
-      <RateOfPayInput
-        onRateChange={onRateChange}
-        rateOfPay={rateOfPay}
-        maxRateOfPay={maxRateOfPay}
-        walletAddress={walletAddress}
-        disabled={!continuousPaymentsEnabled}
-      />
+export type SiteRateChangeData = {
+  hostname: Host;
+  rate: AmountValue | null;
+};
 
-      <div className="space-y-2">
+export const RateOfPayComponent = ({
+  onRateChange,
+  onSiteRateChange,
+  toggle,
+}: Props) => {
+  const t = useTranslation();
+  const {
+    continuousPaymentsEnabled,
+    rateOfPay,
+    maxRateOfPay,
+    walletAddress,
+    tab,
+  } = usePopupState();
+  const [editingSiteRate, setEditingSiteRate] = useState(false);
+  const [_location, navigate] = useLocation();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
         <label
           htmlFor="continuous-payments-toggle"
-          className="flex items-center gap-x-4 px-2 @sm:mt-7"
+          className="flex items-center gap-x-4"
         >
-          <span className="font-medium text-medium @sm:font-normal flex-grow @sm:flex-grow-0 @sm:order-last">
-            Continuous payment
+          <span className="font-medium text-medium grow">
+            {t('settings_rate_continuousPayments_label')}
           </span>
           <SwitchButton
             id="continuous-payments-toggle"
@@ -80,19 +108,73 @@ export const RateOfPayComponent = ({ onRateChange, toggle }: Props) => {
         </label>
 
         {!continuousPaymentsEnabled ? (
-          <p className="text-weak">
-            Ongoing payments are now disabled. You can still make one time
-            payments.
+          <p className="text-weak italic">
+            {t('settings_rate_continuousPayments_disabled_text')}
           </p>
-        ) : (
-          <p className="text-weak" />
-        )}
+        ) : null}
       </div>
+
+      <div
+        className={cn(
+          'border p-3 rounded-lg',
+          continuousPaymentsEnabled ? 'border-popup' : 'border-base',
+          continuousPaymentsEnabled && !tab.rateOfPay ? 'bg-popup-light' : '',
+        )}
+      >
+        <RateOfPayInput
+          id="rateOfPay"
+          label="Default rate"
+          onRateChange={onRateChange}
+          rateOfPay={rateOfPay}
+          maxRateOfPay={maxRateOfPay}
+          walletAddress={walletAddress}
+        />
+      </div>
+
+      {(tab.rateOfPay || editingSiteRate) && (
+        <div
+          className={cn(
+            'space-y-2',
+            'border p-3 rounded-lg',
+            continuousPaymentsEnabled ? 'border-popup' : 'border-base',
+            continuousPaymentsEnabled && tab.rateOfPay ? 'bg-popup-light' : '',
+          )}
+        >
+          <SiteRateOfPayInput onRateChange={onSiteRateChange} />
+        </div>
+      )}
+
+      {!tab.rateOfPay ? (
+        <Button
+          type="button"
+          variant="default"
+          className="w-full font-semibold"
+          onClick={() => setEditingSiteRate(true)}
+        >
+          {t('settings_rate_label_addException')}
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="default"
+          className="w-full font-semibold"
+          onClick={() =>
+            navigate('~/settings/other', {
+              replace: true,
+              state: { open: 'sites-rate-of-pay' },
+            })
+          }
+        >
+          {t('settings_rate_label_manageExceptions')}
+        </Button>
+      )}
     </div>
   );
 };
 
 type RateOfPayInputProps = {
+  id: string;
+  label: React.ReactNode;
   onRateChange: Props['onRateChange'];
   walletAddress: PopupState['walletAddress'];
   rateOfPay: PopupState['rateOfPay'];
@@ -100,7 +182,50 @@ type RateOfPayInputProps = {
   disabled?: boolean;
 };
 
+const SiteRateOfPayInput = ({
+  onRateChange,
+}: {
+  onRateChange: Props['onSiteRateChange'];
+}) => {
+  const { rateOfPay, maxRateOfPay, walletAddress, tab } = usePopupState();
+
+  const hostname = new URL(tab.url).hostname;
+  const site = hostname.replace(/^www\./, '');
+
+  return (
+    <>
+      <div className="flex justify-between">
+        <label
+          htmlFor="rateOfPaySite"
+          className="flex items-center px-2 font-medium leading-6 text-medium"
+        >
+          {site} (exception)
+        </label>
+        <button
+          onClick={() => onRateChange({ rate: null, hostname })}
+          type="button"
+          className="p-1 text-alt"
+        >
+          <span className="sr-only">Remove exception</span>
+          <IconTrash className="size-4" />
+        </button>
+      </div>
+
+      <RateOfPayInput
+        id="rateOfPaySite"
+        label={null}
+        onRateChange={(rate) => onRateChange({ rate, hostname })}
+        rateOfPay={tab.rateOfPay || rateOfPay}
+        maxRateOfPay={maxRateOfPay}
+        walletAddress={walletAddress}
+      />
+    </>
+  );
+};
+
 const RateOfPayInput = ({
+  id,
+  label,
   onRateChange,
   walletAddress,
   rateOfPay,
@@ -122,9 +247,12 @@ const RateOfPayInput = ({
 
   return (
     <InputAmount
-      id="rateOfPay"
-      className="@sm:max-w-48"
-      label="Rate of pay per hour"
+      id={id}
+      label={label}
+      className={cn(
+        'bg-white border-base',
+        disabled && 'focus-within:border-base',
+      )}
       walletAddress={walletAddress}
       onChange={(value) => {
         setErrorMessage('');

--- a/src/pages/popup/lib/store.ts
+++ b/src/pages/popup/lib/store.ts
@@ -1,5 +1,11 @@
 import { proxy, useSnapshot } from 'valtio';
-import type { AmountValue, DeepNonNullable, PopupStore } from '@/shared/types';
+import { normalizeHostname } from '@/shared/helpers';
+import type {
+  AmountValue,
+  DeepNonNullable,
+  Host,
+  PopupStore,
+} from '@/shared/types';
 import type { BackgroundToPopupMessage } from '@/shared/messages';
 
 export type PopupState = Required<
@@ -39,6 +45,16 @@ export const dispatch = ({ type, data }: Actions) => {
     case 'UPDATE_RATE_OF_PAY':
       store.rateOfPay = data.rateOfPay;
       break;
+    case 'UPDATE_SITE_RATE_OF_PAY': {
+      const hostname = normalizeHostname(data.hostname);
+      const tabHostname = URL.parse(store.tab.url || '')?.hostname;
+      if (tabHostname && normalizeHostname(tabHostname) === hostname) {
+        store.tab.rateOfPay = data.rate ?? undefined;
+      } else {
+        // TODO: update in rates list
+      }
+      break;
+    }
     case 'SET_STATE':
       store.state = data.state;
       break;
@@ -63,4 +79,8 @@ type Actions =
   | { type: 'OPT_IN_OUT_TELEMETRY'; data: { isOptedIn: boolean } }
   | { type: 'SET_CONNECTED'; data: { connected: boolean } }
   | { type: 'UPDATE_RATE_OF_PAY'; data: { rateOfPay: AmountValue } }
+  | {
+      type: 'UPDATE_SITE_RATE_OF_PAY';
+      data: { hostname: Host; rate: AmountValue | null };
+    }
   | BackgroundToPopupMessage;

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -68,10 +68,11 @@ export default () => {
 };
 
 const InfoBanner = () => {
-  const { rateOfPay, balance, walletAddress } = usePopupState();
+  const { rateOfPay, tab, balance, walletAddress } = usePopupState();
 
   const rate = React.useMemo(() => {
-    const r = Number(rateOfPay) / 10 ** walletAddress.assetScale;
+    const currentRateOfPay = tab.rateOfPay ?? rateOfPay;
+    const r = Number(currentRateOfPay) / 10 ** walletAddress.assetScale;
     const roundedR = roundWithPrecision(r, walletAddress.assetScale);
 
     return formatCurrency(
@@ -79,7 +80,12 @@ const InfoBanner = () => {
       walletAddress.assetCode,
       walletAddress.assetScale,
     );
-  }, [rateOfPay, walletAddress.assetCode, walletAddress.assetScale]);
+  }, [
+    rateOfPay,
+    tab.rateOfPay,
+    walletAddress.assetCode,
+    walletAddress.assetScale,
+  ]);
 
   const remainingBalance = React.useMemo(() => {
     const val = Number(balance) / 10 ** walletAddress.assetScale;
@@ -96,7 +102,11 @@ const InfoBanner = () => {
       <dl className="flex items-center justify-between px-10">
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Hourly rate</dt>
-          <dd className="font-medium tabular-nums">{rate}</dd>
+          <dd className="font-medium tabular-nums">
+            {rate}
+            {/* For now: added * as indicator when custom rate is active, will be redesigned */}
+            {tab.rateOfPay ? '*' : ''}
+          </dd>
         </div>
         <div className="flex flex-col-reverse items-center">
           <dt className="text-sm">Balance</dt>

--- a/src/pages/shared/components/Icons.tsx
+++ b/src/pages/shared/components/Icons.tsx
@@ -197,6 +197,17 @@ export const XIcon = (props: React.SVGProps<SVGSVGElement>) => {
   );
 };
 
+export const IconTrash = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg fill="none" viewBox="0 0 14 16" aria-hidden="true" {...props}>
+      <path
+        d="M2.616 15.77C2.168 15.77 1.78667 15.6127 1.472 15.298C1.15733 14.9833 1 14.6023 1 14.155L1 1.77L0 1.77L0 0.77L4 0.77V0L10 0V0.77L14 0.77V1.77L13 1.77L13 14.155C13 14.615 12.846 14.9993 12.538 15.308C12.23 15.6167 11.8453 15.7707 11.384 15.77L2.616 15.77ZM12 1.77L2 1.77L2 14.155C2 14.3343 2.05767 14.4817 2.173 14.597C2.28833 14.7123 2.436 14.77 2.616 14.77L11.385 14.77C11.5383 14.77 11.6793 14.706 11.808 14.578C11.9367 14.45 12.0007 14.3087 12 14.154L12 1.77ZM4.808 12.77H5.808L5.808 3.77L4.808 3.77L4.808 12.77ZM8.192 12.77H9.192L9.192 3.77L8.192 3.77L8.192 12.77Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
 export const InfoCircle = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/pages/shared/tokens.css
+++ b/src/pages/shared/tokens.css
@@ -20,9 +20,11 @@
   --bg-switch-base: 152 225 208;
   --bg-disabled: 248 250 252;
   --bg-disabled-strong: 203 213 225;
+  --bg-popup-light: 243 255 252;
 
   /* Border colors */
   --border-base: 203 213 225;
+  --border-popup: 86 183 181;
   --border-focus: 59 130 246;
   --border-error: 220 38 38;
 

--- a/src/pages/tailwind.config.ts
+++ b/src/pages/tailwind.config.ts
@@ -38,6 +38,7 @@ module.exports = {
         error: 'rgb(var(--bg-error) / <alpha-value>)',
         'nav-active': 'rgb(var(--bg-nav-active) / <alpha-value>)',
         'error-hover': 'rgb(var(--bg-error-hover) / <alpha-value>)',
+        'popup-light': 'rgb(var(--bg-popup-light) / <alpha-value>)',
         'button-base': 'rgb(var(--bg-button-base) / <alpha-value>)',
         'button-base-hover': 'rgb(var(--bg-button-base-hover) / <alpha-value>)',
         'switch-base': 'rgb(var(--bg-switch-base) / <alpha-value>)',

--- a/src/shared/__tests__/helpers.test.ts
+++ b/src/shared/__tests__/helpers.test.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore wwwexample
 import { addDays } from 'date-fns/addDays';
 import { addMonths } from 'date-fns/addMonths';
 import { addSeconds } from 'date-fns/addSeconds';
@@ -14,6 +15,7 @@ import {
 import {
   isOkState,
   objectEquals,
+  normalizeHostname,
   removeQueryParams,
   withResolvers,
   getNextOccurrence,
@@ -76,6 +78,19 @@ describe('moveToFront', () => {
     const array = [obj1, obj2, obj3];
     moveToFront(array, obj3);
     expect(array).toEqual([obj3, obj1, obj2]);
+  });
+});
+
+describe('normalizeHostname', () => {
+  it('strips www. prefix', () => {
+    expect(normalizeHostname('www.example.com')).toBe('example.com');
+    expect(normalizeHostname('www.example.co.uk')).toBe('example.co.uk');
+  });
+
+  it('leaves non-www hostnames unchanged', () => {
+    expect(normalizeHostname('example.com')).toBe('example.com');
+    expect(normalizeHostname('sub.example.com')).toBe('sub.example.com');
+    expect(normalizeHostname('wwwexample.com')).toBe('wwwexample.com');
   });
 });
 

--- a/src/shared/helpers/misc.ts
+++ b/src/shared/helpers/misc.ts
@@ -37,6 +37,9 @@ export function isNotNull<T>(value: T | null): value is T {
   return value !== null;
 }
 
+export const normalizeHostname = (hostname: string): string =>
+  hostname.startsWith('www.') ? hostname.slice(4) : hostname;
+
 export const removeQueryParams = (urlString: string) => {
   const url = new URL(urlString);
   return url.origin + url.pathname;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -262,3 +262,5 @@ export type WindowId = NonNullable<Tabs.Tab['windowId']>;
 /** `0` represents the top-level frame, everything else is an _iframe_ */
 export type FrameId = number;
 export type SessionId = string;
+
+export type Host = URL['hostname'];


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1382
Part of https://github.com/interledger/web-monetization-extension/issues/1345
Part of https://github.com/interledger/web-monetization-extension/issues/1297 (story)

## Changes proposed in this pull request

- In SettingsRateOfPay, add form/inputs to set site-specific rate (for current tab).
- Add "Add exception" (when current tab/site doesn't have an exception rate set) and "manage exceptions" (when a rate for current tab/site is set)
   - Manage exceptions button takes user to "Settings -> other", to be developed separately.
- Fix one place in background that didn't add tab's rate of pay but override rest of the data (this has some performance optimization opportunity; for later)
- On the home page, added a "*" symbol to denote a custom rate is active; will be re-designed in upcoming PRs.


https://github.com/user-attachments/assets/778a5593-a8b9-44f5-99d0-924eef06d350

