### PR TITLE
refactor(popup/Settings/Other): extract into components

### DIFF
--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -1,103 +1,41 @@
 import React from 'react';
-import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import { CaretDownIcon } from '@/pages/shared/components/Icons';
-import {
-  useBrowser,
-  useBrowserInfo,
-  useTelemetry,
-  useTranslation,
-} from '@/pages/shared/lib/context';
-import { dispatch, usePopupState } from '@/popup/lib/store';
-import { useMessage } from '@/popup/lib/context';
-import type { Browser } from '@/shared/browser';
+import { useTranslation } from '@/app/lib/context';
+import { DataCollectionSettings } from './SettingsDataCollection';
 
 export function SettingsScreen() {
+  const t = useTranslation();
+
   return (
     <div>
-      <DataCollectionSettings />
+      <SettingsAccordion
+        id="settings-data-collection"
+        title={t('settings_dataCollection_title')}
+      >
+        <DataCollectionSettings />
+      </SettingsAccordion>
     </div>
   );
 }
 
-function DataCollectionSettings() {
-  const t = useTranslation();
-  const message = useMessage();
-  const { consentTelemetry = false } = usePopupState();
-  const telemetry = useTelemetry();
-  const browser = useBrowser();
-  const browserInfo = useBrowserInfo();
-
+function SettingsAccordion({
+  title,
+  id,
+  children,
+}: React.PropsWithChildren<{ title: string; id: string }>) {
   return (
     <details
-      className="border border-gray-200 p-4 rounded-md space-y-2 group"
+      className="border border-gray-200 p-4 not-open:pb-2 rounded-md space-y-2 group"
+      id={id}
+      name="other-settings"
       open
     >
       <summary className="flex cursor-pointer items-center justify-between font-semibold text-xl text-alt">
-        {t('settings_dataCollection_title')}
+        {title}
         <CaretDownIcon className="h-4 w-4 group-open:rotate-180" />
       </summary>
 
-      <label
-        htmlFor="data-collection-toggle"
-        className="flex justify-between gap-2"
-      >
-        <span className="font-medium">
-          {t('settings_dataCollection_label')}
-        </span>
-        <SwitchButton
-          id="data-collection-toggle"
-          size="small"
-          checked={consentTelemetry}
-          onChange={async (ev) => {
-            const isOptedIn = ev.currentTarget.checked;
-            if (browserInfo.name === 'firefox') {
-              const ok = await handleFirefoxDataCollectionPermission(
-                isOptedIn,
-                browser,
-              );
-              if (!ok) {
-                ev.preventDefault();
-                return;
-              }
-            }
-            await message.send('OPT_IN_OUT_TELEMETRY', { isOptedIn });
-            dispatch({ type: 'OPT_IN_OUT_TELEMETRY', data: { isOptedIn } });
-            telemetry.optInOut(isOptedIn);
-          }}
-        />
-      </label>
-
-      <p className="text-sm">
-        {t('settings_dataCollection_text')}{' '}
-        {t('settings_dataCollection_text_learnMore')}{' '}
-        <button
-          type="button"
-          onClick={() =>
-            message.send('OPEN_APP', { path: '/post-install/consent' })
-          }
-          className="underline text-alt"
-        >
-          data policy.
-        </button>
-      </p>
+      {children}
     </details>
   );
-}
-
-async function handleFirefoxDataCollectionPermission(
-  isOptedIn: boolean,
-  browser: Browser,
-): Promise<boolean> {
-  const permission = {
-    data_collection: ['technicalAndInteraction' as const],
-  };
-  if (isOptedIn) {
-    const granted = await browser.permissions.request(permission);
-    if (!granted) {
-      return false;
-    }
-  } else {
-    await browser.permissions.remove(permission);
-  }
-  return true;
 }

--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CaretDownIcon } from '@/pages/shared/components/Icons';
-import { useTranslation } from '@/app/lib/context';
+import { useTranslation } from '@/popup/lib/context';
 import { DataCollectionSettings } from './SettingsDataCollection';
 
 export function SettingsScreen() {

--- a/src/pages/popup/components/Settings/SettingsDataCollection.tsx
+++ b/src/pages/popup/components/Settings/SettingsDataCollection.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { SwitchButton } from '@/pages/shared/components/ui/Switch';
+import {
+  useBrowser,
+  useBrowserInfo,
+  useTelemetry,
+  useTranslation,
+} from '@/pages/shared/lib/context';
+import { dispatch, usePopupState } from '@/popup/lib/store';
+import { useMessage } from '@/popup/lib/context';
+import type { Browser } from '@/shared/browser';
+
+export function DataCollectionSettings() {
+  const t = useTranslation();
+  const message = useMessage();
+  const { consentTelemetry = false } = usePopupState();
+  const telemetry = useTelemetry();
+  const browser = useBrowser();
+  const browserInfo = useBrowserInfo();
+
+  return (
+    <>
+      <label
+        htmlFor="data-collection-toggle"
+        className="flex justify-between gap-2"
+      >
+        <span className="font-medium">
+          {t('settings_dataCollection_label')}
+        </span>
+        <SwitchButton
+          id="data-collection-toggle"
+          size="small"
+          checked={consentTelemetry}
+          onChange={async (ev) => {
+            const isOptedIn = ev.currentTarget.checked;
+            if (browserInfo.name === 'firefox') {
+              const ok = await handleFirefoxDataCollectionPermission(
+                isOptedIn,
+                browser,
+              );
+              if (!ok) {
+                ev.preventDefault();
+                return;
+              }
+            }
+            await message.send('OPT_IN_OUT_TELEMETRY', { isOptedIn });
+            dispatch({ type: 'OPT_IN_OUT_TELEMETRY', data: { isOptedIn } });
+            telemetry.optInOut(isOptedIn);
+          }}
+        />
+      </label>
+
+      <p className="text-sm">
+        {t('settings_dataCollection_text')}{' '}
+        {t('settings_dataCollection_text_learnMore')}{' '}
+        <button
+          type="button"
+          onClick={() =>
+            message.send('OPEN_APP', { path: '/post-install/consent' })
+          }
+          className="underline text-alt"
+        >
+          data policy.
+        </button>
+      </p>
+    </>
+  );
+}
+
+async function handleFirefoxDataCollectionPermission(
+  isOptedIn: boolean,
+  browser: Browser,
+): Promise<boolean> {
+  const permission = {
+    data_collection: ['technicalAndInteraction' as const],
+  };
+  if (isOptedIn) {
+    const granted = await browser.permissions.request(permission);
+    if (!granted) {
+      return false;
+    }
+  } else {
+    await browser.permissions.remove(permission);
+  }
+  return true;
+}


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/1381

## Changes proposed in this pull request

- Move `DataCollectionSettings` out of `Settings`
- Create a `SettingsAccordion` component for multiple settings (will be reused with a future RateOfPayManage component)


(E2E test failure is unrelated; something up with Interledger wallet)