### PR TITLE
fix(shared/style.css): break styles out of `@layer base`

### DIFF
--- a/src/pages/shared/style.css
+++ b/src/pages/shared/style.css
@@ -2,6 +2,19 @@
 @import './tokens.css';
 @config '../tailwind.config.ts';
 
+body {
+  @apply bg-white font-titillium text-base text-medium;
+}
+
+button,
+[role='button'] {
+  cursor: pointer;
+}
+
+:disabled {
+  cursor: default;
+}
+
 @layer base {
   @font-face {
     font-family: 'Titillium Web';
@@ -37,18 +50,5 @@
     font-style: normal;
     /* font-bold */
     font-weight: 700;
-  }
-
-  body {
-    @apply bg-white font-titillium text-base text-medium;
-  }
-
-  button,
-  [role='button'] {
-    cursor: pointer;
-  }
-
-  :disabled {
-    cursor: default;
   }
 }


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1412

## Changes proposed in this pull request

The `body { font-family: system-ui, sans-serif; font-size: 75%; }` rule is an internal stylesheet that Chrome injects into extension pages. The C in CSS means unlayered styles always defeat layered styles, so our styles took lower priority. Seen after upgrade as tailwind now outputs native CSS `@layer`, instead of transpiling it.

This PR moves the styles out of base layer.