### PR TITLE
feat(popup/RateOfPay): add UI to manage exceptions list

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -534,6 +534,40 @@
     "message": "Remove exception"
   },
 
+  "settings_sitePaymentRates_title": {
+    "message": "Hourly payments exceptions"
+  },
+  "settings_sitePaymentRates_desc": {
+    "message": "The website will be automatically detected and the exception rate will be applied. You can also choose the global rate any time."
+  },
+  "settings_sitePaymentRates_action_addException": {
+    "message": "Add new exception"
+  },
+  "settings_sitePaymentRates_text_formTitle": {
+    "message": "New exception"
+  },
+  "settings_sitePaymentRates_action_cancel": {
+    "message": "Cancel"
+  },
+  "settings_sitePaymentRates_inputSite_label": {
+    "message": "Add website domain"
+  },
+  "settings_sitePaymentRates_inputRate_label": {
+    "message": "Custom Rate"
+  },
+  "settings_sitePaymentRates_action_save": {
+    "message": "Save"
+  },
+  "settings_sitePaymentRates_inputSite_error_required": {
+    "message": "Domain is required"
+  },
+  "settings_sitePaymentRates_inputSite_error_invalid": {
+    "message": "Enter a valid domain (e.g. example.com)"
+  },
+  "settings_sitePaymentRates_noExceptions": {
+    "message": "There are no exceptions added"
+  },
+
   "settings_dataCollection_title": {
     "message": "Data Collection"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -553,7 +553,7 @@
     "message": "Add website domain"
   },
   "settings_sitePaymentRates_inputRate_label": {
-    "message": "Custom Rate"
+    "message": "Custom rate"
   },
   "settings_sitePaymentRates_action_save": {
     "message": "Save"

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -323,6 +323,7 @@ export class Background {
             await this.rateList.setRate(hostname, rate);
           }
           this.events.emit('rateList.site_rate_update', { hostname, rate });
+          void this.updateVisualIndicatorsForCurrentTab();
           return success(undefined);
         }
 

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -275,7 +275,7 @@ export const RateOfPayInput = ({
         onValidityChange?.(false);
       }}
       errorMessage={errorMessage}
-      min={Number(formatAmount(1))}
+      min={0}
       max={Number(formatAmount(maxRateOfPay))}
       amount={formatAmount(rateOfPay)}
       controls={true}

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -62,8 +62,8 @@ export const RateOfPayScreen = () => {
 };
 
 interface Props {
-  onRateChange: (rate: AmountValue) => Promise<void>;
-  onSiteRateChange: (data: SiteRateChangeData) => Promise<void>;
+  onRateChange: (rate: AmountValue) => Promise<void> | void;
+  onSiteRateChange: (data: SiteRateChangeData) => Promise<void> | void;
   toggle: (nowEnabled: boolean) => void | Promise<void>;
 }
 
@@ -176,10 +176,13 @@ type RateOfPayInputProps = {
   id: string;
   label: React.ReactNode;
   onRateChange: Props['onRateChange'];
+  onValidityChange?: (isValid: boolean) => void;
   walletAddress: PopupState['walletAddress'];
   rateOfPay: PopupState['rateOfPay'];
   maxRateOfPay: PopupState['maxRateOfPay'];
   disabled?: boolean;
+  className?: string;
+  smallSize?: boolean;
 };
 
 const SiteRateOfPayInput = ({
@@ -226,14 +229,17 @@ const SiteRateOfPayInput = ({
   );
 };
 
-const RateOfPayInput = ({
+export const RateOfPayInput = ({
   id,
   label,
   onRateChange,
+  onValidityChange,
   walletAddress,
   rateOfPay,
   maxRateOfPay,
   disabled,
+  className,
+  smallSize,
 }: RateOfPayInputProps) => {
   const t = useTranslation();
   const [errorMessage, setErrorMessage] = React.useState('');
@@ -255,20 +261,26 @@ const RateOfPayInput = ({
       className={cn(
         'bg-white border-base',
         disabled && 'focus-within:border-base',
+        className,
       )}
       walletAddress={walletAddress}
       onChange={(value) => {
         setErrorMessage('');
+        onValidityChange?.(true);
         const rate = Number(value) * 10 ** walletAddress.assetScale;
         onRateChange(Math.round(rate).toString());
       }}
-      onError={(error) => setErrorMessage(t(error))}
+      onError={(error) => {
+        setErrorMessage(t(error));
+        onValidityChange?.(false);
+      }}
       errorMessage={errorMessage}
       min={Number(formatAmount(1))}
       max={Number(formatAmount(maxRateOfPay))}
       amount={formatAmount(rateOfPay)}
       controls={true}
       readOnly={disabled}
+      size={smallSize ? 'small' : 'default'}
     />
   );
 };

--- a/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
+++ b/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { IconPlus } from '@/pages/shared/components/Icons';
+import { Button } from '@/pages/shared/components/ui/Button';
+import { useTranslation } from '@/popup/lib/context';
+import { usePopupState } from '@/popup/lib/store';
+import { normalizeHostname } from '@/shared/helpers';
+import type { Host } from '@/shared/types';
+import { AddExceptionForm } from './RateOfPaySiteAddException';
+import { SitesList } from './RateOfPaySitesList';
+
+export function RateOfPayManageSites() {
+  const t = useTranslation();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [highlightedHostname, setHighlightedHostname] = useState<Host | null>(
+    null,
+  );
+  const { tab } = usePopupState();
+
+  const defaultHostname = normalizeHostname(URL.parse(tab.url)?.hostname || '');
+
+  useEffect(() => {
+    if (!highlightedHostname) return;
+    const timer = setTimeout(() => setHighlightedHostname(null), 2000);
+    return () => clearTimeout(timer);
+  }, [highlightedHostname]);
+
+  const handleFormDone = useCallback(
+    (res: 'ok' | 'cancel', hostname?: Host) => {
+      setIsFormOpen(false);
+      if (res === 'ok' && hostname) {
+        setHighlightedHostname(hostname);
+      }
+    },
+    [],
+  );
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 my-6">
+        <p>{t('settings_sitePaymentRates_desc')}</p>
+
+        {!isFormOpen ? (
+          <Button
+            type="button"
+            variant="default"
+            className="gap-2"
+            onClick={() => setIsFormOpen(true)}
+          >
+            <IconPlus className="size-4 p-0.5" />
+            {t('settings_sitePaymentRates_action_addException')}
+          </Button>
+        ) : (
+          <AddExceptionForm
+            defaultHostname={defaultHostname}
+            onDone={handleFormDone}
+          />
+        )}
+      </div>
+
+      <div className="space-y-6">
+        <h3 className="font-bold text-medium text-lg">Your exceptions</h3>
+        <SitesList highlightedHostname={highlightedHostname} />
+      </div>
+    </>
+  );
+}

--- a/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
+++ b/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
@@ -24,15 +24,11 @@ export function RateOfPayManageSites() {
     return () => clearTimeout(timer);
   }, [highlightedHostname]);
 
-  const handleFormDone = useCallback(
-    (res: 'ok' | 'cancel', hostname?: Host) => {
-      setIsFormOpen(false);
-      if (res === 'ok' && hostname) {
-        setHighlightedHostname(hostname);
-      }
-    },
-    [],
-  );
+  type OnDone = React.ComponentProps<typeof AddExceptionForm>['onDone'];
+  const onFormDone: OnDone = useCallback((entry) => {
+    setIsFormOpen(false);
+    if (entry) setHighlightedHostname(entry.hostname);
+  }, []);
 
   return (
     <>
@@ -52,7 +48,7 @@ export function RateOfPayManageSites() {
         ) : (
           <AddExceptionForm
             defaultHostname={defaultHostname}
-            onDone={handleFormDone}
+            onDone={onFormDone}
           />
         )}
       </div>

--- a/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/pages/shared/components/ui/Input';
 import { useMessage, useTranslation } from '@/popup/lib/context';
 import { usePopupState, dispatch } from '@/popup/lib/store';
 import { normalizeHostname } from '@/shared/helpers';
-import type { Host } from '@/shared/types';
+import type { AmountValue, Host } from '@/shared/types';
 import { RateOfPayInput } from './RateOfPay';
 
 export function AddExceptionForm({
@@ -12,7 +12,7 @@ export function AddExceptionForm({
   onDone,
 }: {
   defaultHostname: Host;
-  onDone: (res: 'ok' | 'cancel', hostname?: Host) => void;
+  onDone: (entry?: { hostname: Host; rate: AmountValue }) => void;
 }) {
   const t = useTranslation();
   const message = useMessage();
@@ -32,14 +32,14 @@ export function AddExceptionForm({
   const [isRateValid, setIsRateValid] = useState(true);
   const isSiteValid = isValidHostname(hostname);
 
-  const save = useCallback(
-    (ev: React.SubmitEvent) => {
+  const save: React.SubmitEventHandler = useCallback(
+    (ev) => {
       ev.preventDefault();
 
       const data = { rate, hostname };
       dispatch({ type: 'UPDATE_SITE_RATE_OF_PAY', data });
       void message.send('SET_SITE_RATE_OF_PAY', data);
-      onDone('ok', hostname);
+      onDone(data);
     },
     [message, rate, hostname, onDone],
   );
@@ -53,7 +53,7 @@ export function AddExceptionForm({
         <button
           className="underline text-error"
           type="button"
-          onClick={() => onDone('cancel')}
+          onClick={() => onDone()}
         >
           {t('settings_sitePaymentRates_action_cancel')}
         </button>

--- a/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useCallback } from 'react';
+import { Button } from '@/pages/shared/components/ui/Button';
+import { Input } from '@/pages/shared/components/ui/Input';
+import { useMessage, useTranslation } from '@/popup/lib/context';
+import { usePopupState, dispatch } from '@/popup/lib/store';
+import { normalizeHostname } from '@/shared/helpers';
+import type { Host } from '@/shared/types';
+import { RateOfPayInput } from './RateOfPay';
+
+export function AddExceptionForm({
+  defaultHostname,
+  onDone,
+}: {
+  defaultHostname: Host;
+  onDone: (res: 'ok' | 'cancel', hostname?: Host) => void;
+}) {
+  const t = useTranslation();
+  const message = useMessage();
+  const {
+    walletAddress,
+    rateOfPay: defaultRateOfPay,
+    sitesRateOfPay,
+    maxRateOfPay,
+  } = usePopupState();
+
+  const [hostname, setHostname] = useState(() => defaultHostname);
+  const [rate, setRate] = useState(() => {
+    if (!defaultHostname) return defaultRateOfPay;
+    const existing = sitesRateOfPay.find((e) => e.hostname === defaultHostname);
+    return existing?.rate || defaultRateOfPay;
+  });
+  const [isRateValid, setIsRateValid] = useState(true);
+  const isSiteValid = isValidHostname(hostname);
+
+  const save = useCallback(
+    (ev: React.SubmitEvent) => {
+      ev.preventDefault();
+
+      const data = { rate, hostname };
+      dispatch({ type: 'UPDATE_SITE_RATE_OF_PAY', data });
+      void message.send('SET_SITE_RATE_OF_PAY', data);
+      onDone('ok', hostname);
+    },
+    [message, rate, hostname, onDone],
+  );
+
+  return (
+    <form className="flex flex-col gap-6" onSubmit={save}>
+      <div className="flex justify-between gap-2">
+        <h3 className="font-medium text-secondary">
+          {t('settings_sitePaymentRates_text_formTitle')}
+        </h3>
+        <button
+          className="underline text-error"
+          type="button"
+          onClick={() => onDone('cancel')}
+        >
+          {t('settings_sitePaymentRates_action_cancel')}
+        </button>
+      </div>
+
+      <div className="h-px bg-gray-200" />
+
+      <SiteInput value={hostname} onChange={setHostname} />
+
+      <RateOfPayInput
+        id="site-rate-of-pay-new"
+        label={t('settings_sitePaymentRates_inputRate_label')}
+        rateOfPay={rate}
+        onRateChange={setRate}
+        onValidityChange={setIsRateValid}
+        maxRateOfPay={maxRateOfPay}
+        walletAddress={walletAddress}
+      />
+
+      <Button
+        type="submit"
+        variant="default"
+        disabled={!isSiteValid || !isRateValid}
+      >
+        {t('settings_sitePaymentRates_action_save')}
+      </Button>
+    </form>
+  );
+}
+
+function SiteInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const t = useTranslation();
+  const [error, setError] = useState('');
+
+  const validate = (val: string): string => {
+    if (!val) {
+      return t('settings_sitePaymentRates_inputSite_error_required');
+    }
+    if (!isValidHostname(val)) {
+      return t('settings_sitePaymentRates_inputSite_error_invalid');
+    }
+    return '';
+  };
+
+  return (
+    <Input
+      label={t('settings_sitePaymentRates_inputSite_label')}
+      value={value}
+      onChange={(ev) => {
+        const val = toHostname(ev.currentTarget.value.trim());
+        onChange(val);
+        setError(validate(val));
+      }}
+      onBlur={() => setError(validate(value))}
+      errorMessage={error}
+      spellCheck="false"
+    />
+  );
+}
+
+const toHostname = (value: string): string => {
+  const url = URL.parse(value) ?? URL.parse(`http://${value}`);
+  return url?.hostname ? normalizeHostname(url.hostname) : value;
+};
+
+const isValidHostname = (val: string): boolean => {
+  if (!val) return false;
+  const parsed = URL.parse(`http://${val}`);
+  return !!parsed && parsed.hostname === val;
+};

--- a/src/pages/popup/components/Settings/RateOfPaySitesList.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySitesList.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { IconTrash } from '@/pages/shared/components/Icons';
+import { cn } from '@/pages/shared/lib/utils';
+import { useMessage, useTelemetry, useTranslation } from '@/popup/lib/context';
+import { dispatch, usePopupState } from '@/popup/lib/store';
+import { debounceAsync } from '@/shared/helpers';
+import type { AmountValue, Host, WalletInfo } from '@/shared/types';
+import { RateOfPayInput, type SiteRateChangeData } from './RateOfPay';
+
+export function SitesList({
+  highlightedHostname,
+}: {
+  highlightedHostname: Host | null;
+}) {
+  const t = useTranslation();
+  const message = useMessage();
+  const telemetry = useTelemetry();
+  const { walletAddress, maxRateOfPay, sitesRateOfPay = [] } = usePopupState();
+
+  useEffect(() => {
+    message.send('GET_PER_SITE_RATE_OF_PAY').then((res) => {
+      if (!res.success) return;
+      const entries = res.payload.map((e) => ({
+        hostname: e.site.replace(/^\*\./, ''),
+        rate: e.rate,
+      }));
+      dispatch({ type: 'SET_DATA_SITES_RATE_OF_PAY', data: entries });
+    });
+  }, [message]);
+
+  const listRef = useRef<HTMLUListElement>(null);
+  useEffect(() => {
+    if (!highlightedHostname) return;
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-hostname="${CSS.escape(highlightedHostname)}"]`,
+    );
+    el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [highlightedHostname]);
+
+  const updateSiteRateOfPay = React.useRef(
+    debounceAsync(async (data: SiteRateChangeData) => {
+      await message.send('SET_SITE_RATE_OF_PAY', data);
+      telemetry.capture('site_rate_of_pay_change');
+    }, 500),
+  );
+
+  const onSetRate = useCallback((data: SiteRateChangeData) => {
+    dispatch({ type: 'UPDATE_SITE_RATE_OF_PAY', data });
+    void updateSiteRateOfPay.current(data);
+  }, []);
+
+  if (!sitesRateOfPay.length) {
+    return (
+      <p className="text-xs italic text-slate-600">
+        {t('settings_sitePaymentRates_noExceptions')}
+      </p>
+    );
+  }
+
+  return (
+    <ul ref={listRef} className="space-y-6 list-none">
+      {sitesRateOfPay.map(({ hostname, rate }) => (
+        <li
+          key={hostname}
+          data-hostname={hostname}
+          className={cn(
+            'flex items-center gap-4 -mx-2 px-2 py-1',
+            'transition-colors duration-500',
+            hostname === highlightedHostname && 'bg-popup-light',
+          )}
+        >
+          <SiteEntry
+            hostname={hostname}
+            rate={rate}
+            onSetRate={onSetRate}
+            walletAddress={walletAddress}
+            maxRateOfPay={maxRateOfPay}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+type SiteEntryProps = {
+  hostname: Host;
+  rate: AmountValue;
+  onSetRate(data: SiteRateChangeData): void;
+  maxRateOfPay: AmountValue;
+  walletAddress: WalletInfo;
+};
+function SiteEntry({
+  hostname,
+  rate,
+  onSetRate,
+  maxRateOfPay,
+  walletAddress,
+}: SiteEntryProps) {
+  const t = useTranslation();
+  const id = `rate-of-pay-${hostname.replaceAll('.', '_')}`;
+  return (
+    <>
+      <span
+        className="font-medium text-medium overflow-hidden text-ellipsis grow"
+        title={hostname}
+      >
+        {hostname}
+      </span>
+
+      <RateOfPayInput
+        maxRateOfPay={maxRateOfPay}
+        rateOfPay={rate}
+        id={id}
+        label={null}
+        onRateChange={(rate) => onSetRate({ rate, hostname })}
+        walletAddress={walletAddress}
+        className="w-30"
+        smallSize={true}
+      />
+
+      <button
+        type="button"
+        className="p-1 text-alt"
+        onClick={() => onSetRate({ hostname, rate: null })}
+      >
+        <IconTrash className="size-4" />
+        <span className="sr-only">
+          {t('settings_rate_action_removeException')}
+        </span>
+      </button>
+    </>
+  );
+}

--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -2,17 +2,33 @@ import React from 'react';
 import { CaretDownIcon } from '@/pages/shared/components/Icons';
 import { useTranslation } from '@/popup/lib/context';
 import { DataCollectionSettings } from './SettingsDataCollection';
+import { RateOfPayManageSites } from './RateOfPayManageSites';
 
 export function SettingsScreen() {
   const t = useTranslation();
 
+  React.useEffect(() => {
+    const openSitePaymentRates = history.state?.open === 'sites-rate-of-pay';
+    const toOpen = openSitePaymentRates
+      ? document.getElementById('settings-site-payment-rates')!
+      : document.getElementById('settings-data-collection')!;
+    toOpen.setAttribute('open', '');
+    toOpen.scrollIntoView();
+  }, []);
+
   return (
-    <div>
+    <div className="space-y-3 pb-8">
       <SettingsAccordion
         id="settings-data-collection"
         title={t('settings_dataCollection_title')}
       >
         <DataCollectionSettings />
+      </SettingsAccordion>
+      <SettingsAccordion
+        id="settings-site-payment-rates"
+        title={t('settings_sitePaymentRates_title')}
+      >
+        <RateOfPayManageSites />
       </SettingsAccordion>
     </div>
   );
@@ -25,10 +41,9 @@ function SettingsAccordion({
 }: React.PropsWithChildren<{ title: string; id: string }>) {
   return (
     <details
-      className="border border-gray-200 p-4 not-open:pb-2 rounded-md space-y-2 group"
+      className="border border-gray-200 p-4 rounded-md space-y-2 group not-open:pb-2"
       id={id}
       name="other-settings"
-      open
     >
       <summary className="flex cursor-pointer items-center justify-between font-semibold text-xl text-alt">
         {title}

--- a/src/pages/popup/lib/store.ts
+++ b/src/pages/popup/lib/store.ts
@@ -1,5 +1,6 @@
 import { proxy, useSnapshot } from 'valtio';
 import { normalizeHostname } from '@/shared/helpers';
+import { compareSitesByDomain } from '@/pages/shared/lib/utils';
 import type {
   AmountValue,
   DeepNonNullable,
@@ -50,11 +51,31 @@ export const dispatch = ({ type, data }: Actions) => {
       const tabHostname = URL.parse(store.tab.url || '')?.hostname;
       if (tabHostname && normalizeHostname(tabHostname) === hostname) {
         store.tab.rateOfPay = data.rate ?? undefined;
+      }
+
+      store.sitesRateOfPay ??= [];
+      if (data.rate === null) {
+        store.sitesRateOfPay = store.sitesRateOfPay.filter(
+          (e) => e.hostname !== hostname,
+        );
       } else {
-        // TODO: update in rates list
+        const e = store.sitesRateOfPay.find((e) => e.hostname === hostname);
+        if (!e) {
+          store.sitesRateOfPay = [
+            ...store.sitesRateOfPay,
+            { hostname, rate: data.rate },
+          ].sort((a, b) => compareSitesByDomain(a.hostname, b.hostname));
+        } else {
+          e.rate = data.rate;
+        }
       }
       break;
     }
+    case 'SET_DATA_SITES_RATE_OF_PAY':
+      store.sitesRateOfPay = [...data].sort((a, b) =>
+        compareSitesByDomain(a.hostname, b.hostname),
+      );
+      break;
     case 'SET_STATE':
       store.state = data.state;
       break;
@@ -82,5 +103,9 @@ type Actions =
   | {
       type: 'UPDATE_SITE_RATE_OF_PAY';
       data: { hostname: Host; rate: AmountValue | null };
+    }
+  | {
+      type: 'SET_DATA_SITES_RATE_OF_PAY';
+      data: { hostname: Host; rate: AmountValue }[];
     }
   | BackgroundToPopupMessage;

--- a/src/pages/shared/components/Icons.tsx
+++ b/src/pages/shared/components/Icons.tsx
@@ -208,6 +208,17 @@ export const IconTrash = (props: React.SVGProps<SVGSVGElement>) => {
   );
 };
 
+export const IconPlus = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg viewBox="0 0 12 12" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M5.5 6.5H0V5.5H5.5V0H6.5V5.5H12V6.5H6.5V12H5.5V6.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
 export const InfoCircle = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/pages/shared/components/InputAmount.tsx
+++ b/src/pages/shared/components/InputAmount.tsx
@@ -27,6 +27,7 @@ interface Props {
   min?: number;
   max?: number;
   controls?: boolean;
+  size?: 'small' | 'default';
 }
 
 export const InputAmount = ({
@@ -45,6 +46,7 @@ export const InputAmount = ({
   min = 0,
   max,
   readOnly,
+  size = 'default',
   controls = false,
 }: Props) => {
   const { assetScale } = walletAddress;
@@ -134,6 +136,7 @@ export const InputAmount = ({
       description={description}
       placeholder={placeholder}
       wrapperClassName={wrapperClassName}
+      className={size === 'small' ? 'py-2.5' : ''}
       defaultValue={amount}
       readOnly={readOnly}
       leadingAddOn={

--- a/src/pages/shared/lib/utils.test.ts
+++ b/src/pages/shared/lib/utils.test.ts
@@ -3,7 +3,90 @@ import {
   formatNumber,
   formatCurrency,
   getCurrencySymbol,
+  compareSitesByDomain,
 } from '@/pages/shared/lib/utils';
+
+describe('compareSitesByDomain', () => {
+  const sort = (hostnames: string[]) =>
+    [...hostnames].sort(compareSitesByDomain);
+
+  it('sorts root domain before its subdomains', () => {
+    expect(sort(['test.sidvishnoi.com', 'sidvishnoi.com'])).toEqual([
+      'sidvishnoi.com',
+      'test.sidvishnoi.com',
+    ]);
+    expect(sort(['www.example.com', 'example.com'])).toEqual([
+      'example.com',
+      'www.example.com',
+    ]);
+  });
+
+  it('groups subdomains with their root domain', () => {
+    expect(
+      sort([
+        'test.sidvishnoi.com',
+        'example.com',
+        'www.example.com',
+        'sidvishnoi.com',
+      ]),
+    ).toEqual([
+      'example.com',
+      'www.example.com',
+      'sidvishnoi.com',
+      'test.sidvishnoi.com',
+    ]);
+  });
+
+  it('sorts groups alphabetically by domain', () => {
+    expect(sort(['zebra.com', 'apple.com'])).toEqual([
+      'apple.com',
+      'zebra.com',
+    ]);
+  });
+
+  it('handles multi-level TLDs (e.g. co.uk)', () => {
+    expect(sort(['www.example.co.uk', 'example.co.uk'])).toEqual([
+      'example.co.uk',
+      'www.example.co.uk',
+    ]);
+    expect(sort(['foo.co.uk', 'bar.co.uk'])).toEqual([
+      'bar.co.uk',
+      'foo.co.uk',
+    ]);
+  });
+
+  it('groups multi-level TLD subdomains together', () => {
+    expect(
+      sort(['www.foo.co.uk', 'bar.com', 'foo.co.uk', 'www.bar.com']),
+    ).toEqual(['bar.com', 'www.bar.com', 'foo.co.uk', 'www.foo.co.uk']);
+  });
+
+  it('returns 0 for identical hostnames', () => {
+    expect(compareSitesByDomain('example.com', 'example.com')).toBe(0);
+  });
+
+  it('sorts by domain name, not TLD', () => {
+    expect(sort(['zebra.com', 'apple.xyz'])).toEqual([
+      'apple.xyz',
+      'zebra.com',
+    ]);
+  });
+
+  it('uses TLD only as a tiebreaker when domain names are equal', () => {
+    expect(sort(['example.xyz', 'example.com'])).toEqual([
+      'example.com',
+      'example.xyz',
+    ]);
+  });
+
+  it('sorts subdomains alphabetically within the same root', () => {
+    expect(sort(['z.example.com', 'a.example.com', 'example.com'])).toEqual([
+      'example.com',
+      'a.example.com',
+      'z.example.com',
+    ]);
+  });
+});
 
 describe('formatNumber', () => {
   it('should display right format for integers', () => {

--- a/src/pages/shared/lib/utils.ts
+++ b/src/pages/shared/lib/utils.ts
@@ -87,6 +87,18 @@ export function formatNumber(
   }
 }
 
+export function compareSitesByDomain(a: string, b: string): number {
+  const partsA = a.split('.').reverse();
+  const partsB = b.split('.').reverse();
+  const len = Math.min(partsA.length, partsB.length);
+  for (let i = 1; i < len; i++) {
+    const cmp = partsA[i].localeCompare(partsB[i]);
+    if (cmp !== 0) return cmp;
+  }
+  if (partsA.length !== partsB.length) return partsA.length - partsB.length;
+  return partsA[0].localeCompare(partsB[0]);
+}
+
 export const cn = (...inputs: CxOptions) => {
   return twMerge(cx(inputs));
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -233,6 +233,8 @@ export type PopupStore = Omit<
     oneTime: OneTimeGrant['amount'];
     recurring: RecurringGrant['amount'];
   }>;
+  // set on request only, not on initial load (perf)
+  sitesRateOfPay?: { hostname: Host; rate: AmountValue }[];
 };
 
 export type AppStore = Pick<


### PR DESCRIPTION

## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1381
Part of https://github.com/interledger/web-monetization-extension/issues/1345
Part of https://github.com/interledger/web-monetization-extension/issues/1297 (story)

## Changes proposed in this pull request

- Add manage site exceptions to Settings -> Other
- In `RateOfPayManageSites`, two parts:
   - AddExceptionForm:
      - adds a site to exception; defaults to current tab.
      - Updates store data appropriately.
   - SitesList:
      - lists exceptions, ordered by domain.
      - Can edit rates here as well, and remove.
      - When an exception is added/modified in AddExceptionForm, the list scroll/focuses that entry (a UX affordance) and closes the form.
- Updated some shared components to support new designs (mostly bandaid 🙈) [^1]


Note to reviewer: Sorry for large PR. It's mostly markup, but let me know if I should try to split it further into smaller chunks.

[^1]: There's a bug in InputAmount that it doesn't update value in the SitesList when an exception is added from AddExceptionForm (component control bug).