### PR TITLE
feat(Home): new design with site-specific rate of pay

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -39,6 +39,29 @@
   "app_text_disabled": {
     "message": "The extension is disabled. Click the power icon above to enable the extension and continue making payments."
   },
+
+  "home_title_balance": {
+    "message": "Balance"
+  },
+  "home_action_manageBudget": {
+    "message": "Manage budget"
+  },
+  "home_title_hourlyRate": {
+    "message": "Hourly rate"
+  },
+  "home_action_addException": {
+    "message": "Add exception"
+  },
+  "home_action_manageExceptions": {
+    "message": "Manage exceptions"
+  },
+  "home_text_hourlyRateException": {
+    "message": "Exception"
+  },
+  "home_text_hourlyRateDefault": {
+    "message": "default"
+  },
+
   "keyRevoked_error_title": {
     "message": "Unauthorized access to the wallet."
   },

--- a/src/background/services/__tests__/rateList.test.ts
+++ b/src/background/services/__tests__/rateList.test.ts
@@ -50,6 +50,21 @@ mockedOpenDB.mockImplementation(async (_name, _v, { upgrade }) => {
       mockStore.delete(`${ac}:${as}:${site}`);
       return Promise.resolve();
     },
+    getKeyFromIndex: (
+      _s: string,
+      _i: string,
+      range: { only: [assetCode: string, assetScale: number] },
+    ) => {
+      const [ac, as] = range.only;
+      const entry = [...mockStore.values()].find(
+        (e) => e.assetCode === ac && e.assetScale === as,
+      );
+      return Promise.resolve(
+        entry
+          ? ([entry.assetCode, entry.assetScale, entry.site] as const)
+          : undefined,
+      );
+    },
   };
   upgrade(db);
   return db;
@@ -73,8 +88,10 @@ function makeRateListService(
 describe('RateListService CRUD', () => {
   it('setRate and getAll', async () => {
     const rateList = makeRateListService();
+    await expect(rateList.isEmpty()).resolves.toBe(true);
     await rateList.setRate('example.com', '3');
     await rateList.setRate('other.com', '5');
+    await expect(rateList.isEmpty()).resolves.toBe(false);
     await expect(rateList.getAll()).resolves.toEqual(
       expect.arrayContaining([
         { site: '*.example.com', rate: '3' },
@@ -97,6 +114,7 @@ describe('RateListService CRUD', () => {
     await rateList.setRate('example.com', '3');
     await rateList.deleteRate('example.com');
     await expect(rateList.getAll()).resolves.toHaveLength(0);
+    await expect(rateList.isEmpty()).resolves.toBe(true);
   });
 
   it('getAll throws with no wallet connected', async () => {

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -485,10 +485,12 @@ export class MonetizationService {
       );
       if (siteRate) tabData.rateOfPay = siteRate;
     }
+    const isRateListEmpty = await this.rateList.isEmpty();
 
     return {
       ...dataFromStorage,
       balance: balance.total.toString(),
+      hasSitesRateOfPay: !isRateListEmpty,
       tab: tabData,
       transientState: this.storage.getTransientState(),
       grants: {

--- a/src/background/services/rateList.ts
+++ b/src/background/services/rateList.ts
@@ -45,6 +45,18 @@ export class RateListService {
     return entries.map(({ site, rate }) => ({ site, rate }));
   }
 
+  async isEmpty(): Promise<boolean> {
+    const wallet = await this.#getWallet();
+    if (!wallet) return true;
+    const db = await this.#getDb();
+    const key = await db.getKeyFromIndex(
+      'rates',
+      'by-currency',
+      IDBKeyRange.only([wallet.assetCode, wallet.assetScale]),
+    );
+    return key === undefined;
+  }
+
   async setRate(hostname: string, rate: AmountValue): Promise<void> {
     const wallet = await this.#getWallet();
     if (!wallet) {
@@ -71,6 +83,7 @@ export class RateListService {
    * 2. Wildcard patterns, most-specific first (e.g. *.sub.example.com before *.example.com)
    * 3. The global default entry stored under key '*'
    */
+
   async getRateForHostname(hostname: string): Promise<AmountValue | undefined> {
     const wallet = await this.#getWallet();
     if (!wallet) {

--- a/src/background/services/rateList.ts
+++ b/src/background/services/rateList.ts
@@ -83,7 +83,6 @@ export class RateListService {
    * 2. Wildcard patterns, most-specific first (e.g. *.sub.example.com before *.example.com)
    * 3. The global default entry stored under key '*'
    */
-
   async getRateForHostname(hostname: string): Promise<AmountValue | undefined> {
     const wallet = await this.#getWallet();
     if (!wallet) {

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -35,7 +35,7 @@ export const PayWebsiteForm = () => {
     message: string;
   }>(null);
 
-  const onSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit: React.SubmitEventHandler = async (ev) => {
     ev.preventDefault();
     if (isSubmitting) return;
     setErrors({ amount: null, pay: null });
@@ -72,7 +72,7 @@ export const PayWebsiteForm = () => {
     <form
       ref={form}
       className={cn(
-        'space-y-2 rounded-md bg-gray-50 px-4 py-4',
+        'space-y-2 rounded-md bg-slate-100 px-4 py-4',
         !errors.pay && 'pb-12',
       )}
       onSubmit={onSubmit}

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -4,6 +4,7 @@ import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmountMemoized as InputAmount } from '@/pages/shared/components/InputAmount';
 import { IconTrash } from '@/pages/shared/components/Icons';
+import type { OtherSettingsHistoryState } from '@/popup/components/Settings/Settings';
 import { debounceAsync, normalizeHostname } from '@/shared/helpers';
 import { cn, formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { useMessage, useTelemetry, useTranslation } from '@/popup/lib/context';
@@ -161,7 +162,10 @@ export const RateOfPayComponent = ({
           onClick={() =>
             navigate('~/settings/other', {
               replace: true,
-              state: { open: 'sites-rate-of-pay' },
+              state: {
+                open: 'sites-rate-of-pay',
+                highlight: URL.parse(tab.url)?.hostname,
+              } satisfies OtherSettingsHistoryState,
             })
           }
         >

--- a/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
+++ b/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
@@ -8,11 +8,15 @@ import type { Host } from '@/shared/types';
 import { AddExceptionForm } from './RateOfPaySiteAddException';
 import { SitesList } from './RateOfPaySitesList';
 
-export function RateOfPayManageSites() {
+interface Props {
+  highlight?: 'new' | Host;
+}
+
+export function RateOfPayManageSites({ highlight }: Props) {
   const t = useTranslation();
-  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(highlight === 'new');
   const [highlightedHostname, setHighlightedHostname] = useState<Host | null>(
-    null,
+    highlight && highlight !== 'new' ? normalizeHostname(highlight) : null,
   );
   const { tab } = usePopupState();
 

--- a/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { Input } from '@/pages/shared/components/ui/Input';
 import { useMessage, useTranslation } from '@/popup/lib/context';
@@ -19,7 +19,7 @@ export function AddExceptionForm({
   const {
     walletAddress,
     rateOfPay: defaultRateOfPay,
-    sitesRateOfPay,
+    sitesRateOfPay = [],
     maxRateOfPay,
   } = usePopupState();
 
@@ -31,6 +31,12 @@ export function AddExceptionForm({
   });
   const [isRateValid, setIsRateValid] = useState(true);
   const isSiteValid = isValidHostname(hostname);
+
+  useEffect(() => {
+    document
+      .querySelector('[data-testid="rate-of-pay-site-add-exception-form"]')
+      ?.scrollIntoView();
+  }, []);
 
   const save: React.SubmitEventHandler = useCallback(
     (ev) => {
@@ -45,7 +51,11 @@ export function AddExceptionForm({
   );
 
   return (
-    <form className="flex flex-col gap-6" onSubmit={save}>
+    <form
+      className="flex flex-col gap-6"
+      onSubmit={save}
+      data-testid="rate-of-pay-site-add-exception-form"
+    >
       <div className="flex justify-between gap-2">
         <h3 className="font-medium text-secondary">
           {t('settings_sitePaymentRates_text_formTitle')}

--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -16,7 +16,7 @@ export function SettingsScreen() {
 
   React.useEffect(() => {
     if (state?.open === 'sites-rate-of-pay') {
-      document.getElementById('settings-data-collection')?.scrollIntoView();
+      document.getElementById('settings-site-payment-rates')?.scrollIntoView();
     }
   }, [state?.open]);
 

--- a/src/pages/popup/components/Settings/Settings.tsx
+++ b/src/pages/popup/components/Settings/Settings.tsx
@@ -1,34 +1,40 @@
 import React from 'react';
+import { useHistoryState } from 'wouter/use-browser-location';
 import { CaretDownIcon } from '@/pages/shared/components/Icons';
 import { useTranslation } from '@/popup/lib/context';
 import { DataCollectionSettings } from './SettingsDataCollection';
 import { RateOfPayManageSites } from './RateOfPayManageSites';
 
+export interface OtherSettingsHistoryState {
+  open?: 'sites-rate-of-pay';
+  highlight?: string;
+}
+
 export function SettingsScreen() {
   const t = useTranslation();
+  const state = useHistoryState<OtherSettingsHistoryState>();
 
   React.useEffect(() => {
-    const openSitePaymentRates = history.state?.open === 'sites-rate-of-pay';
-    const toOpen = openSitePaymentRates
-      ? document.getElementById('settings-site-payment-rates')!
-      : document.getElementById('settings-data-collection')!;
-    toOpen.setAttribute('open', '');
-    toOpen.scrollIntoView();
-  }, []);
+    if (state?.open === 'sites-rate-of-pay') {
+      document.getElementById('settings-data-collection')?.scrollIntoView();
+    }
+  }, [state?.open]);
 
   return (
     <div className="space-y-3 pb-8">
       <SettingsAccordion
         id="settings-data-collection"
         title={t('settings_dataCollection_title')}
+        open={state?.open !== 'sites-rate-of-pay'}
       >
         <DataCollectionSettings />
       </SettingsAccordion>
       <SettingsAccordion
         id="settings-site-payment-rates"
         title={t('settings_sitePaymentRates_title')}
+        open={state?.open === 'sites-rate-of-pay'}
       >
-        <RateOfPayManageSites />
+        <RateOfPayManageSites highlight={state?.highlight} />
       </SettingsAccordion>
     </div>
   );
@@ -38,11 +44,13 @@ function SettingsAccordion({
   title,
   id,
   children,
-}: React.PropsWithChildren<{ title: string; id: string }>) {
+  open = false,
+}: React.PropsWithChildren<{ title: string; id: string; open?: boolean }>) {
   return (
     <details
       className="border border-gray-200 p-4 rounded-md space-y-2 group not-open:pb-2"
       id={id}
+      open={open}
       name="other-settings"
     >
       <summary className="flex cursor-pointer items-center justify-between font-semibold text-xl text-alt">

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
-import { Settings } from '@/pages/shared/components/Icons';
+import { Link, Redirect as Navigate } from 'wouter';
 import {
   formatNumber,
   roundWithPrecision,
   formatCurrency,
+  cn,
 } from '@/pages/shared/lib/utils';
 import { PayWebsiteForm } from '@/popup/components/PayWebsiteForm';
 import { NotMonetized } from '@/popup/components/NotMonetized';
+import type { OtherSettingsHistoryState } from '@/popup/components/Settings/Settings';
 import { useTranslation } from '@/popup/lib/context';
 import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '../Popup';
-import { Redirect as Navigate } from 'wouter';
+import type { AmountValue, WalletInfo } from '@/shared/types';
 
 export default () => {
   const t = useTranslation();
@@ -68,56 +70,93 @@ export default () => {
 };
 
 const InfoBanner = () => {
-  const { rateOfPay, tab, balance, walletAddress } = usePopupState();
+  const t = useTranslation();
+  const { rateOfPay, tab, balance, walletAddress, hasSitesRateOfPay } =
+    usePopupState();
+
+  const hasExceptions = hasSitesRateOfPay || tab.rateOfPay;
 
   const rate = React.useMemo(() => {
-    const currentRateOfPay = tab.rateOfPay ?? rateOfPay;
-    const r = Number(currentRateOfPay) / 10 ** walletAddress.assetScale;
-    const roundedR = roundWithPrecision(r, walletAddress.assetScale);
+    return formattedAmount(rateOfPay, walletAddress);
+  }, [rateOfPay, walletAddress]);
 
-    return formatCurrency(
-      formatNumber(roundedR, walletAddress.assetScale, true),
-      walletAddress.assetCode,
-      walletAddress.assetScale,
-    );
-  }, [
-    rateOfPay,
-    tab.rateOfPay,
-    walletAddress.assetCode,
-    walletAddress.assetScale,
-  ]);
+  const tabRateOfPay = React.useMemo(() => {
+    return tab.rateOfPay ? formattedAmount(tab.rateOfPay, walletAddress) : null;
+  }, [tab.rateOfPay, walletAddress]);
 
   const remainingBalance = React.useMemo(() => {
-    const val = Number(balance) / 10 ** walletAddress.assetScale;
-    const rounded = roundWithPrecision(val, walletAddress.assetScale);
-    return formatCurrency(
-      formatNumber(rounded, walletAddress.assetScale, true),
-      walletAddress.assetCode,
-      walletAddress.assetScale,
-    );
-  }, [balance, walletAddress.assetCode, walletAddress.assetScale]);
+    return formattedAmount(balance, walletAddress);
+  }, [balance, walletAddress]);
 
   return (
-    <div className="space-y-2 rounded-md bg-button-base p-4 text-white">
-      <dl className="flex items-center justify-between px-10">
-        <div className="flex flex-col-reverse items-center">
-          <dt className="text-sm">Hourly rate</dt>
-          <dd className="font-medium tabular-nums">
-            {rate}
-            {/* For now: added * as indicator when custom rate is active, will be redesigned */}
-            {tab.rateOfPay ? '*' : ''}
-          </dd>
-        </div>
-        <div className="flex flex-col-reverse items-center">
-          <dt className="text-sm">Balance</dt>
-          <dd className="font-medium tabular-nums">{remainingBalance}</dd>
-        </div>
-      </dl>
+    <div className="grid grid-cols-2 h-40 items-center justify-between gap-2 text-medium">
+      <section className="flex flex-col h-full p-3 border border-gray-200 rounded-md">
+        <h3 className="text-sm mb-1">{t('home_title_balance')}</h3>
+        <p className="text-4xl font-medium tabular-nums">{remainingBalance}</p>
 
-      <p className="text-center text-xs italic text-white/90">
-        To adjust your budget or rate of pay, click on{' '}
-        <Settings className="inline-block h-4 w-4 fill-white align-top" />
-      </p>
+        <Link
+          className="mt-auto px-3 py-2 border border-current rounded-lg text-alt font-medium text-sm flex items-center justify-center"
+          to="/settings/budget"
+        >
+          {t('home_action_manageBudget')}
+        </Link>
+      </section>
+
+      <section className="flex flex-col h-full p-3 border border-gray-200 rounded-md">
+        <h3 className="text-sm mb-1">{t('home_title_hourlyRate')}</h3>
+        <p className="flex flex-col gap-1">
+          <span
+            className={cn(
+              'flex items-center gap-1',
+              !!tab.rateOfPay && 'text-alt',
+            )}
+          >
+            <span className="tabular-nums text-3xl font-medium">
+              {tabRateOfPay || rate}
+            </span>
+            <span className="text-xs font-normal">
+              {!tab.rateOfPay
+                ? t('home_text_hourlyRateDefault')
+                : t('home_text_hourlyRateException')}
+            </span>
+          </span>
+
+          {!!tab.rateOfPay && (
+            <span className="text-xs font-normal px-2 py-1 rounded-lg bg-slate-50 w-fit">
+              {t('home_text_hourlyRateDefault')}{' '}
+              <span className="tabular-nums">{rate}</span>
+            </span>
+          )}
+        </p>
+
+        <Link
+          className="mt-auto px-3 py-2 border border-current rounded-lg text-alt font-medium text-sm flex items-center justify-center"
+          to="/settings/other"
+          state={
+            {
+              open: 'sites-rate-of-pay',
+              highlight: hasExceptions ? URL.parse(tab.url)?.hostname : 'new',
+            } satisfies OtherSettingsHistoryState
+          }
+        >
+          {hasExceptions
+            ? t('home_action_manageExceptions')
+            : t('home_action_addException')}
+        </Link>
+      </section>
     </div>
   );
 };
+
+function formattedAmount(
+  amount: AmountValue,
+  walletAddress: Pick<WalletInfo, 'assetCode' | 'assetScale'>,
+): string {
+  const val = Number(amount) / 10 ** walletAddress.assetScale;
+  const rounded = roundWithPrecision(val, walletAddress.assetScale);
+  return formatCurrency(
+    formatNumber(rounded, walletAddress.assetScale, true),
+    walletAddress.assetCode,
+    walletAddress.assetScale,
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -235,6 +235,8 @@ export type PopupStore = Omit<
   }>;
   // set on request only, not on initial load (perf)
   sitesRateOfPay?: { hostname: Host; rate: AmountValue }[];
+  // ...but getting hasSitesRateOfPay is fast
+  hasSitesRateOfPay: boolean;
 };
 
 export type AppStore = Pick<


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1405
Closes https://github.com/interledger/web-monetization-extension/issues/1345
Closes https://github.com/interledger/web-monetization-extension/issues/1297 (story)

## Changes proposed in this pull request

- Update home screen design, markup
- Add an efficient "hasExceptions" data for `GET_DATA_POPUP` (as we need to show "manage exceptions" if there's any exception set, even if not current domain on home)
- Add ability to open form, highlight particular domain when visiting Settings -> Other from any other screen
