### PR TITLE
feat(bg/outgoingPaymentGrant): get spent grant amounts

### DIFF
--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -24,3 +24,5 @@ export const OUTGOING_PAYMENT_POLLING_MAX_ATTEMPTS = 8;
  * user is logged in, we could make it < 1min.
  */
 export const ACCEPT_GRANT_TIMEOUT = 3 * 60 * 1000;
+
+export const MAX_GET_GRANT_SPENT_AMOUNTS_RETRIES = 3;

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -321,6 +321,8 @@ export class MonetizationService {
       throw new Error('Unexpected: wallet address not found.');
     }
 
+    this.outgoingPaymentGrantService.getGrantSpentAmounts(walletAddress);
+
     const payableSessions = paymentManager.payableSessions;
     if (!payableSessions.length) {
       if (paymentManager.enabledSessions.length) {

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -321,8 +321,6 @@ export class MonetizationService {
       throw new Error('Unexpected: wallet address not found.');
     }
 
-    this.outgoingPaymentGrantService.getGrantSpentAmounts(walletAddress);
-
     const payableSessions = paymentManager.payableSessions;
     if (!payableSessions.length) {
       if (paymentManager.enabledSessions.length) {

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -14,7 +14,10 @@ import {
 } from '@interledger/open-payments';
 import type { Browser, Tabs } from 'webextension-polyfill';
 import type { Cradle } from '@/background/container';
-import { ACCEPT_GRANT_TIMEOUT, MAX_GET_GRANT_SPENT_AMOUNTS_RETRIES } from '@/background/config';
+import {
+  ACCEPT_GRANT_TIMEOUT,
+  MAX_GET_GRANT_SPENT_AMOUNTS_RETRIES,
+} from '@/background/config';
 import { OPEN_PAYMENTS_REDIRECT_URL } from '@/shared/defines';
 import { ensureEnd, ErrorWithKey, withResolvers } from '@/shared/helpers';
 import {

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -260,6 +260,27 @@ export class OutgoingPaymentGrantService {
     }
   }
 
+  async getGrantSpentAmounts(walletAddress: WalletAddress) {
+    try {
+      const spentAmounts = await this.openPaymentsService.client.outgoingPayment.getGrantSpentAmounts({
+        url: walletAddress.resourceServer,
+        accessToken: this.accessToken,
+      });
+
+      await this.storage.set({
+        supportsGrantSpentAmounts: true,
+      });
+
+      return spentAmounts;
+    } catch (error) {
+      this.logger.debug('Resource server does not support grant spent amounts endpoint', error);
+
+      await this.storage.set({
+        supportsGrantSpentAmounts: false,
+      });
+    }
+  }
+
   private async getInteractionInfo(
     url: string,
     onTabOpen: (tabId: TabId) => void,

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -10,15 +10,17 @@ import {
   type Grant,
   type PendingGrant,
   type WalletAddress,
-} from '@interledger/open-payments/dist/types';
+  type OutgoingPaymentGrantSpentAmounts,
+} from '@interledger/open-payments';
 import type { Browser, Tabs } from 'webextension-polyfill';
 import type { Cradle } from '@/background/container';
-import { ACCEPT_GRANT_TIMEOUT } from '@/background/config';
+import { ACCEPT_GRANT_TIMEOUT, MAX_GET_GRANT_SPENT_AMOUNTS_RETRIES } from '@/background/config';
 import { OPEN_PAYMENTS_REDIRECT_URL } from '@/shared/defines';
 import { ensureEnd, ErrorWithKey, withResolvers } from '@/shared/helpers';
 import {
   isInvalidClientError,
   isInvalidContinuationError,
+  isTokenExpiredError,
   isNotFoundError,
 } from '@/background/services/openPayments';
 import {
@@ -260,7 +262,17 @@ export class OutgoingPaymentGrantService {
     }
   }
 
-  async getGrantSpentAmounts(walletAddress: WalletAddress) {
+  async getGrantSpentAmounts(
+    walletAddress: WalletAddress,
+    retry = 0,
+  ): Promise<OutgoingPaymentGrantSpentAmounts | undefined> {
+    if (retry > MAX_GET_GRANT_SPENT_AMOUNTS_RETRIES) {
+      this.logger.warn(
+        `Failed to get grant spent amounts after ${retry} retries`,
+      );
+      return;
+    }
+
     try {
       const spentAmounts =
         await this.openPaymentsService.client.outgoingPayment.getGrantSpentAmounts(
@@ -276,14 +288,21 @@ export class OutgoingPaymentGrantService {
 
       return spentAmounts;
     } catch (error) {
-      this.logger.debug(
-        'Resource server does not support grant spent amounts endpoint',
-        error,
-      );
+      if (isTokenExpiredError(error)) {
+        await this.rotateToken();
+        return await this.getGrantSpentAmounts(walletAddress, retry + 1);
+      } else if (isNotFoundError(error)) {
+        this.logger.debug(
+          'Resource server does not support grant spent amounts endpoint',
+          error,
+        );
 
-      await this.storage.set({
-        supportsGrantSpentAmounts: false,
-      });
+        await this.storage.set({
+          supportsGrantSpentAmounts: false,
+        });
+      } else {
+        throw error;
+      }
     }
   }
 

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -262,10 +262,13 @@ export class OutgoingPaymentGrantService {
 
   async getGrantSpentAmounts(walletAddress: WalletAddress) {
     try {
-      const spentAmounts = await this.openPaymentsService.client.outgoingPayment.getGrantSpentAmounts({
-        url: walletAddress.resourceServer,
-        accessToken: this.accessToken,
-      });
+      const spentAmounts =
+        await this.openPaymentsService.client.outgoingPayment.getGrantSpentAmounts(
+          {
+            url: walletAddress.resourceServer,
+            accessToken: this.accessToken,
+          },
+        );
 
       await this.storage.set({
         supportsGrantSpentAmounts: true,
@@ -273,7 +276,10 @@ export class OutgoingPaymentGrantService {
 
       return spentAmounts;
     } catch (error) {
-      this.logger.debug('Resource server does not support grant spent amounts endpoint', error);
+      this.logger.debug(
+        'Resource server does not support grant spent amounts endpoint',
+        error,
+      );
 
       await this.storage.set({
         supportsGrantSpentAmounts: false,

--- a/src/background/services/storage.ts
+++ b/src/background/services/storage.ts
@@ -37,6 +37,7 @@ const defaultStorage = {
   oneTimeGrantSpentAmount: '0',
   rateOfPay: null,
   maxRateOfPay: null,
+  supportsGrantSpentAmounts: undefined,
 } satisfies Omit<Storage, 'uid' | 'publicKey' | 'privateKey' | 'keyId'>;
 
 export class StorageService {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -121,7 +121,7 @@ export interface Storage {
    * for grants to not require polling of outgoing payments.
    * @default undefined implies that support is unknown and needs to be checked.
    */
-  supportsGrantSpentAmounts?: boolean
+  supportsGrantSpentAmounts?: boolean;
 
   /** Key information */
   publicKey: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -115,6 +115,14 @@ export interface Storage {
   exceptionList: {
     [website: string]: Amount;
   };
+
+  /**
+   * If the current wallet address' resource server supports the "spent amounts" endpoint
+   * for grants to not require polling of outgoing payments.
+   * @default undefined implies that support is unknown and needs to be checked.
+   */
+  supportsGrantSpentAmounts?: boolean
+
   /** Key information */
   publicKey: string;
   privateKey: string;


### PR DESCRIPTION
## Context

To more reliably update the balance, we want to introduce usage of the Open Payments [/outgoing-payment-grant](https://openpayments.dev/apis/resource-server/operations/get-outgoing-payment-grant/) endpoint. 

Part of #737.

## Changes proposed in this pull request

This PR introduces the function to fetch the spent amounts, as well as a new storage property that indicates whether the current wallet address' resource server does support this new endpoint. This will then in a follow-up be used to guard polling the balance on the popup as well as not polling outgoing payments.

Follow-up PR will be opened once I have looked closer into the popup lifecycle, therefore already this PR, keeping it small.

## Testing

* Tested request towards Testnet
* Tested successful saving in storage
* Tested against GateHub (not supported yet), also correctly saved as "false"
* Tested reset on wallet disconnect
