### PR TITLE
perf(ConnectWalletForm): prevent unnecessary rerenders

### DIFF
--- a/src/pages/app/pages/PostInstall.tsx
+++ b/src/pages/app/pages/PostInstall.tsx
@@ -6,9 +6,14 @@ import {
   ExternalIcon,
 } from '@/pages/shared/components/Icons';
 import { isConsentRequired, type BrowserName } from '@/shared/helpers';
-import { getResponseOrThrow } from '@/shared/messages';
 import { useBrowser, useBrowserInfo, useTranslation } from '@/app/lib/context';
-import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
+import {
+  ConnectStateContext,
+  ConnectWalletForm,
+  getSavedValues,
+  saveValue,
+  useConnectWalletFormActions,
+} from '@/popup/components/ConnectWalletForm';
 import { cn } from '@/pages/shared/lib/utils';
 import { useMessage } from '@/app/lib/context';
 import { useAppState } from '@/app/lib/store';
@@ -455,13 +460,8 @@ function StepConnectWallet({
 }: {
   selectedWallet: WalletOption;
 }) {
-  const message = useMessage();
   const t = useTranslation();
-  const {
-    transientState: { connect: connectState },
-    connected,
-    publicKey,
-  } = useAppState();
+  const { connected } = useAppState();
 
   if (connected) {
     return (
@@ -477,32 +477,44 @@ function StepConnectWallet({
   }
 
   return (
+    <StepConnectWalletForm
+      walletAddressPlaceholder={selectedWallet.walletAddressPlaceholder}
+    />
+  );
+}
+
+function StepConnectWalletForm({
+  walletAddressPlaceholder,
+}: {
+  walletAddressPlaceholder: string;
+}) {
+  const message = useMessage();
+  const {
+    transientState: { connect: connectState },
+    publicKey,
+  } = useAppState();
+
+  const initialConnectState = React.useRef(connectState).current;
+  const defaultValues = React.useMemo(getSavedValues, []);
+  const { getWalletInfo, connectWallet, clearConnectState } =
+    useConnectWalletFormActions(message);
+
+  return (
     <div className="@container sm:h-popup mx-auto sm:w-popup pt-4 overflow-hidden">
-      <ConnectWalletForm
-        publicKey={publicKey}
-        // @ts-expect-error we know, it's complicated
-        state={connectState}
-        defaultValues={{
-          recurring:
-            localStorage?.getItem('connect.recurring') === 'true' || false,
-          amount: localStorage?.getItem('connect.amount') || undefined,
-          walletAddressUrl:
-            localStorage?.getItem('connect.walletAddressUrl') || undefined,
-          autoKeyAddConsent:
-            localStorage?.getItem('connect.autoKeyAddConsent') === 'true',
-        }}
-        saveValue={(key, val) => {
-          localStorage?.setItem(`connect.${key}`, val.toString());
-        }}
-        getWalletInfo={(walletAddressUrl) =>
-          message
-            .send('GET_CONNECT_WALLET_ADDRESS_INFO', walletAddressUrl)
-            .then(getResponseOrThrow)
-        }
-        walletAddressPlaceholder={selectedWallet.walletAddressPlaceholder}
-        connectWallet={(data) => message.send('CONNECT_WALLET', data)}
-        clearConnectState={() => message.send('RESET_CONNECT_STATE')}
-      />
+      {/* @ts-expect-error we know, it's complicated */}
+      <ConnectStateContext.Provider value={connectState}>
+        <ConnectWalletForm
+          publicKey={publicKey}
+          // @ts-expect-error we know, it's complicated
+          initialState={initialConnectState}
+          defaultValues={defaultValues}
+          saveValue={saveValue}
+          getWalletInfo={getWalletInfo}
+          walletAddressPlaceholder={walletAddressPlaceholder}
+          connectWallet={connectWallet}
+          clearConnectState={clearConnectState}
+        />
+      </ConnectStateContext.Provider>
     </div>
   );
 }

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+} from 'react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { Input } from '@/pages/shared/components/ui/Input';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
@@ -26,9 +31,12 @@ import {
   toWalletAddressUrl,
   type ErrorWithKeyLike,
 } from '@/shared/helpers';
+import { getResponseOrThrow } from '@/shared/messages';
 import type {
   ConnectWalletPayload,
   ConnectWalletAddressInfo,
+  MessageManager,
+  PopupToBackgroundMessage,
   Response,
 } from '@/shared/messages';
 import type {
@@ -52,12 +60,16 @@ type OnInputHandler = NonNullable<
   React.DOMAttributes<HTMLInputElement>['onInput']
 >;
 
-interface ConnectWalletFormProps {
+// carries the frequently-updating transient connect state.
+export const ConnectStateContext = createContext<ConnectTransientState>(null);
+const useConnectState = () => useContext(ConnectStateContext);
+
+interface Props {
   publicKey: string;
   defaultValues: Partial<Inputs>;
-  state?: ConnectTransientState;
+  initialState?: ConnectTransientState;
   walletAddressPlaceholder?: string;
-  saveValue?: (key: keyof Inputs, val: Inputs[typeof key]) => void;
+  saveValue: (key: keyof Inputs, val: Inputs[typeof key]) => void;
   getWalletInfo: (
     walletAddressUrl: string,
   ) => Promise<ConnectWalletAddressInfo>;
@@ -65,18 +77,19 @@ interface ConnectWalletFormProps {
   clearConnectState: () => Promise<unknown>;
   onConnect?: () => void;
 }
+export type { Props as ConnectWalletFormProps };
 
-export const ConnectWalletForm = ({
+export const ConnectWalletForm = React.memo(function ConnectWalletForm({
   publicKey,
   defaultValues,
-  state,
+  initialState,
   walletAddressPlaceholder = 'https://walletprovider.com/MyWallet',
   getWalletInfo,
   connectWallet,
   clearConnectState,
-  saveValue = () => {},
-  onConnect = () => {},
-}: ConnectWalletFormProps) => {
+  saveValue,
+  onConnect,
+}: Props) {
   const t = useTranslation();
   const toErrorInfo = React.useMemo(() => toErrorInfoFactory(t), [t]);
 
@@ -91,7 +104,7 @@ export const ConnectWalletForm = ({
   );
 
   const [autoKeyShareFailed, setAutoKeyShareFailed] = React.useState(
-    state?.type === 'failure' && state.code === 'key_add_failed',
+    initialState?.type === 'failure' && initialState.code === 'key_add_failed',
   );
   const [keyAddNeeded, setKeyAddNeeded] = React.useState(true);
   const [showConsent, setShowConsent] = React.useState(false);
@@ -116,27 +129,12 @@ export const ConnectWalletForm = ({
     connect: null,
   });
 
-  React.useEffect(() => {
-    if (state?.type === 'failure' && state.code === 'key_add_failed') {
-      const errInfo = toErrorInfo(mapErrorFailure(state));
-      setErrors((prev) => ({ ...prev, keyPair: errInfo }));
-    }
-    if (state?.type === 'failure' && state.code !== 'key_add_failed') {
-      const errInfo = toErrorInfo(mapErrorFailure(state));
-      setErrors((prev) => ({ ...prev, connect: errInfo }));
-    }
-    if (state?.type === 'cancel') {
-      const errInfo = toErrorInfo(mapErrorCancel(state));
-      setErrors((prev) => ({ ...prev, connect: errInfo }));
-    }
-  }, [state, toErrorInfo]);
-
   const [isValidating, setIsValidating] = React.useState({
     walletAddressUrl: false,
     amount: false,
   });
   const [isSubmitting, setIsSubmitting] = React.useState(
-    state?.type === 'progress',
+    initialState?.type === 'progress',
   );
 
   const handleAmountChange = React.useCallback(
@@ -240,7 +238,7 @@ export const ConnectWalletForm = ({
     [handleWalletAddressUrlChange, resetState, walletAddressUrl],
   );
 
-  const handleSubmit = async (ev?: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (ev?: React.SubmitEvent<HTMLFormElement>) => {
     ev?.preventDefault();
 
     let walletAddressInput = walletAddressUrl;
@@ -310,10 +308,10 @@ export const ConnectWalletForm = ({
         autoKeyAdd: autoKeyAddConsent.current,
       });
       if (res.success) {
-        onConnect();
+        onConnect?.();
       } else {
         if (!isErrorWithKey(res.error)) throw new Error(res.message);
-        // Otherwise, errors are handled by `state` + `useEffect`
+        // Otherwise, errors are handled by `ConnectStateErrorSync`
       }
     } catch (error) {
       setErrors((prev) => ({ ...prev, connect: toErrorInfo(error.message) }));
@@ -359,6 +357,8 @@ export const ConnectWalletForm = ({
       className="my-auto flex flex-col gap-4"
       onSubmit={handleSubmit}
     >
+      <ConnectStateErrorSync setErrors={setErrors} toErrorInfo={toErrorInfo} />
+
       <div className={cn(!!errors.connect && 'sr-only')}>
         <h2 className="text-center text-lg text-strong">
           {t('connectWallet_text_title')}
@@ -498,20 +498,94 @@ export const ConnectWalletForm = ({
             !amount
           }
           loading={isSubmitting}
-          loadingText={
-            state?.type === 'progress'
-              ? typeof state.currentStep === 'string'
-                ? state.currentStep
-                : t(state.currentStep.key, [...state.currentStep.substitutions])
-              : undefined
-          }
+          loadingText={<ConnectSubmitLoadingText />}
         >
           {t('connectWallet_action_connect')}
         </Button>
       </div>
     </form>
   );
+});
+
+function ConnectStateErrorSync({
+  setErrors,
+  toErrorInfo,
+}: {
+  setErrors: React.Dispatch<React.SetStateAction<Errors>>;
+  toErrorInfo: ReturnType<typeof toErrorInfoFactory>;
+}) {
+  const state = useConnectState();
+
+  useEffect(() => {
+    if (state?.type === 'failure' && state.code === 'key_add_failed') {
+      const errInfo = toErrorInfo(mapErrorFailure(state));
+      setErrors((prev) => ({ ...prev, keyPair: errInfo }));
+    }
+    if (state?.type === 'failure' && state.code !== 'key_add_failed') {
+      const errInfo = toErrorInfo(mapErrorFailure(state));
+      setErrors((prev) => ({ ...prev, connect: errInfo }));
+    }
+    if (state?.type === 'cancel') {
+      const errInfo = toErrorInfo(mapErrorCancel(state));
+      setErrors((prev) => ({ ...prev, connect: errInfo }));
+    }
+  }, [state, toErrorInfo, setErrors]);
+
+  return null;
+}
+
+function ConnectSubmitLoadingText() {
+  const t = useTranslation();
+  const state = useConnectState();
+
+  if (state?.type !== 'progress') return null;
+  return typeof state.currentStep === 'string'
+    ? state.currentStep
+    : t(state.currentStep.key, [...state.currentStep.substitutions]);
+}
+
+export const saveValue: Props['saveValue'] = (key, val) => {
+  localStorage?.setItem(`connect.${key}`, String(val));
 };
+export const getSavedValues = (): Props['defaultValues'] => {
+  return {
+    recurring: localStorage?.getItem('connect.recurring') === 'true' || false,
+    amount: localStorage?.getItem('connect.amount') || undefined,
+    walletAddressUrl:
+      localStorage?.getItem('connect.walletAddressUrl') || undefined,
+    autoKeyAddConsent:
+      localStorage?.getItem('connect.autoKeyAddConsent') === 'true',
+  };
+};
+
+type ConnectWalletMessages = Pick<
+  PopupToBackgroundMessage,
+  'GET_CONNECT_WALLET_ADDRESS_INFO' | 'CONNECT_WALLET' | 'RESET_CONNECT_STATE'
+>;
+
+export function useConnectWalletFormActions(
+  message: MessageManager<ConnectWalletMessages>,
+) {
+  const getWalletInfo: Props['getWalletInfo'] = useCallback(
+    async (waUrl) => {
+      const res = await message.send('GET_CONNECT_WALLET_ADDRESS_INFO', waUrl);
+      return getResponseOrThrow(res);
+    },
+    [message],
+  );
+
+  const connectWallet: Props['connectWallet'] = useCallback(
+    (data) => message.send('CONNECT_WALLET', data),
+    [message],
+  );
+
+  const clearConnectState: Props['clearConnectState'] = useCallback(
+    () => message.send('RESET_CONNECT_STATE'),
+    [message],
+  );
+
+  return { getWalletInfo, connectWallet, clearConnectState };
+}
 
 interface AmountInputProps {
   amount: string;

--- a/src/pages/popup/pages/ConnectWallet.tsx
+++ b/src/pages/popup/pages/ConnectWallet.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { useLocation } from 'wouter';
-import { getResponseOrThrow } from '@/shared/messages';
-import { ConnectWalletForm } from '@/popup/components/ConnectWalletForm';
+import {
+  ConnectStateContext,
+  ConnectWalletForm,
+  getSavedValues,
+  saveValue,
+  useConnectWalletFormActions,
+} from '@/popup/components/ConnectWalletForm';
 import { useMessage } from '@/popup/lib/context';
 import { usePopupState } from '@/popup/lib/store';
 import { ROUTES_PATH } from '@/popup/Popup';
@@ -14,37 +19,33 @@ export default () => {
     publicKey,
   } = usePopupState();
 
+  const initialConnectState = React.useRef(connectState).current;
+  const defaultValues = React.useMemo(getSavedValues, []);
+  const { getWalletInfo, connectWallet, clearConnectState } =
+    useConnectWalletFormActions(message);
+
+  const onConnect = React.useCallback(() => {
+    // The popup closes due to redirects on connect, so we don't need to
+    // update any state manually.
+    // But we reload it, as it's open all-time when running E2E tests
+    navigate(ROUTES_PATH.HOME);
+    window.location.reload();
+  }, [navigate]);
+
   return (
-    <ConnectWalletForm
-      publicKey={publicKey}
-      // @ts-expect-error we know, it's complicated
-      state={connectState}
-      defaultValues={{
-        recurring:
-          localStorage?.getItem('connect.recurring') === 'true' || false,
-        amount: localStorage?.getItem('connect.amount') || undefined,
-        walletAddressUrl:
-          localStorage?.getItem('connect.walletAddressUrl') || undefined,
-        autoKeyAddConsent:
-          localStorage?.getItem('connect.autoKeyAddConsent') === 'true',
-      }}
-      saveValue={(key, val) => {
-        localStorage?.setItem(`connect.${key}`, val.toString());
-      }}
-      getWalletInfo={(walletAddressUrl) =>
-        message
-          .send('GET_CONNECT_WALLET_ADDRESS_INFO', walletAddressUrl)
-          .then(getResponseOrThrow)
-      }
-      connectWallet={(data) => message.send('CONNECT_WALLET', data)}
-      onConnect={() => {
-        // The popup closes due to redirects on connect, so we don't need to
-        // update any state manually.
-        // But we reload it, as it's open all-time when running E2E tests
-        navigate(ROUTES_PATH.HOME);
-        window.location.reload();
-      }}
-      clearConnectState={() => message.send('RESET_CONNECT_STATE')}
-    />
+    // @ts-expect-error we know, it's complicated
+    <ConnectStateContext.Provider value={connectState}>
+      <ConnectWalletForm
+        publicKey={publicKey}
+        // @ts-expect-error we know, it's complicated
+        initialState={initialConnectState}
+        defaultValues={defaultValues}
+        saveValue={saveValue}
+        getWalletInfo={getWalletInfo}
+        connectWallet={connectWallet}
+        onConnect={onConnect}
+        clearConnectState={clearConnectState}
+      />
+    </ConnectStateContext.Provider>
   );
 };

--- a/src/pages/shared/components/ui/Button.tsx
+++ b/src/pages/shared/components/ui/Button.tsx
@@ -40,7 +40,7 @@ export interface ButtonProps
   extends VariantProps<typeof buttonVariants>,
     React.ComponentPropsWithRef<'button'> {
   loading?: boolean;
-  loadingText?: string;
+  loadingText?: React.ReactNode;
   /** Optional only when children are passed */
   'aria-label'?: string;
 }


### PR DESCRIPTION
## Context

Part of https://github.com/interledger/web-monetization-extension/issues/957

`ConnectWalletForm` re-rendered its entire tree every few seconds while a wallet connection was in progress, because the connect status (which updates frequenty during connect process) was passed as a prop. We can't simply use `usePopupState` in the form, as the form is used in app as well (where we need `useAppState`).

The problem mostly shows with how we've to keep so many checks with wallet address input, as re-renders keep triggering fetch/validate wallet address calls.

## Changes proposed in this pull request

- Introduced a `ConnectStateContext` that carries the transient connect state, consumed only by two small leaf components (`ConnectStateErrorSync` for syncing failure/cancel errors into local error state, and `ConnectSubmitLoadingText` for the submit button's progress text).. instead of the whole form.
- Wrapped `ConnectWalletForm` in `React.memo` so it actually skips re-rendering when its (now-stable) props don't change. The context split alone wasn't enough without this, since the parent page still re-render on every tick (when transientState changed in useAppState/usePopupState)
- Exported some shared helpers used in both App and Popup (`useConnectWalletFormActions`, `saveValue` etc.)


Follow up: `ConnectWalletForm` is 750 lines long. Need to simplify and make it smaller - extract components, functions; and make it more testable. Also look for further flow simplifications.