### PR TITLE
fix(background): safety against monetization state race conditions

### DIFF
--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -91,6 +91,7 @@ export class Background {
     await this.monetizationService
       .resumePaymentSessionActiveTab()
       .catch(() => {}); // if tabs not ready yet
+    await this.updateVisualIndicatorsForCurrentTab().catch(() => {});
   }
 
   async onStart() {

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -221,10 +221,12 @@ export class MonetizationService {
       !this.canTryPayment(connected, state)
     ) {
       paymentManager.pause('paused-by-user');
+      this.events.emit('monetization.state_update', tabId);
       return;
     }
 
     paymentManager.resume();
+    this.events.emit('monetization.state_update', tabId);
   }
 
   async resumePaymentSessionsByTabId(tabId: number) {

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -148,7 +148,9 @@ export class TabEvents {
         .catch(() => undefined);
       if (siteRate) tabInfo.rateOfPay = siteRate;
     }
-    this.sendToPopup.send('SET_TAB_DATA', tabInfo);
+    if (tabInfo.tabId === this.windowState.getCurrentTabId()) {
+      this.sendToPopup.send('SET_TAB_DATA', tabInfo);
+    }
     const { continuousPaymentsEnabled, enabled, connected, state } =
       await this.storage.get([
         'continuousPaymentsEnabled',


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Closes https://github.com/interledger/web-monetization-extension/issues/964

## Changes proposed in this pull request

- In `tabEvents`: `SET_TAB_DATA` only when the tab being updated is actually the current tab, fixing the other tab overwriting current tab in popup bug. To reproduce, open multiple monetized websites, hopefully one setting up payment session slower than other, and you'll notice, when other tab becomes ready, `updateVisualIndicators` (and SET_TAB_DATA) be override current tab's state. So Bibi saw GitHub being monetized (while it was some other site getting monetization-ready while tab got switched).
- In `resumePaymentSession` hanndler, sometimes `onActivatedTab` could trigger a race condition which isn't corrected by later events. So, add some `monetization.state_update` events there.
- Do a visual indicator/tab data refresh on background start as well, just to be safe.