### PR TITLE
fix: limit max custom rate exceptions to 200

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -572,6 +572,9 @@
   "settings_sitePaymentRates_action_cancel": {
     "message": "Cancel"
   },
+  "settings_sitePaymentRates_maxExceptionsError": {
+    "message": "You have reached your custom rates limit. Delete one of your existing custom rates to add a new one."
+  },
   "settings_sitePaymentRates_inputSite_label": {
     "message": "Add website domain"
   },

--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -1,5 +1,4 @@
 export const DEFAULT_SCALE = 2;
-export const DEFAULT_INTERVAL_MS = 3_600_000;
 
 export const DEFAULT_BUDGET = '500';
 export const DEFAULT_RATE_OF_PAY = '60';

--- a/src/background/services/__tests__/rateList.test.ts
+++ b/src/background/services/__tests__/rateList.test.ts
@@ -65,6 +65,17 @@ mockedOpenDB.mockImplementation(async (_name, _v, { upgrade }) => {
           : undefined,
       );
     },
+    countFromIndex: (
+      _s: string,
+      _i: string,
+      range: { only: [assetCode: string, assetScale: number] },
+    ) => {
+      const [ac, as] = range.only;
+      const count = [...mockStore.values()].filter(
+        (e) => e.assetCode === ac && e.assetScale === as,
+      ).length;
+      return Promise.resolve(count);
+    },
   };
   upgrade(db);
   return db;
@@ -89,6 +100,8 @@ describe('RateListService CRUD', () => {
   it('setRate and getAll', async () => {
     const rateList = makeRateListService();
     await expect(rateList.isEmpty()).resolves.toBe(true);
+    await expect(rateList.count()).resolves.toBe(0);
+
     await rateList.setRate('example.com', '3');
     await rateList.setRate('other.com', '5');
     await expect(rateList.isEmpty()).resolves.toBe(false);
@@ -98,6 +111,7 @@ describe('RateListService CRUD', () => {
         { site: '*.other.com', rate: '5' },
       ]),
     );
+    await expect(rateList.count()).resolves.toBe(2);
   });
 
   it('setRate overwrites an existing entry', async () => {
@@ -107,6 +121,7 @@ describe('RateListService CRUD', () => {
     const all = await rateList.getAll();
     expect(all).toHaveLength(1);
     expect(all[0].rate).toBe('10');
+    await expect(rateList.count()).resolves.toBe(1);
   });
 
   it('deleteRate removes the entry', async () => {

--- a/src/background/services/background.ts
+++ b/src/background/services/background.ts
@@ -1,6 +1,7 @@
 import type { Browser, Runtime, Tabs } from 'webextension-polyfill';
 import { BUILD_TARGET } from '@/shared/defines';
 import { failure, success, type ToBackgroundMessage } from '@/shared/messages';
+import { MAX_CUSTOM_RATE_EXCEPTIONS } from '@/shared/config';
 import {
   errorWithKeyToJSON,
   getNextOccurrence,
@@ -321,6 +322,10 @@ export class Background {
           if (rate === null) {
             await this.rateList.deleteRate(hostname);
           } else {
+            const count = await this.rateList.count();
+            if (count === MAX_CUSTOM_RATE_EXCEPTIONS) {
+              throw new Error('Cannot add further custom rates');
+            }
             await this.rateList.setRate(hostname, rate);
           }
           this.events.emit('rateList.site_rate_update', { hostname, rate });

--- a/src/background/services/rateList.ts
+++ b/src/background/services/rateList.ts
@@ -45,6 +45,20 @@ export class RateListService {
     return entries.map(({ site, rate }) => ({ site, rate }));
   }
 
+  async count(): Promise<number> {
+    const wallet = await this.#getWallet();
+    if (!wallet) {
+      throw new Error('Cannot get count without a connected wallet');
+    }
+
+    const db = await this.#getDb();
+    return await db.countFromIndex(
+      'rates',
+      'by-currency',
+      IDBKeyRange.only([wallet.assetCode, wallet.assetScale]),
+    );
+  }
+
   async isEmpty(): Promise<boolean> {
     const wallet = await this.#getWallet();
     if (!wallet) return true;

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmountMemoized as InputAmount } from '@/pages/shared/components/InputAmount';
 import { IconTrash } from '@/pages/shared/components/Icons';
 import type { OtherSettingsHistoryState } from '@/popup/components/Settings/Settings';
+import { MAX_CUSTOM_RATE_EXCEPTIONS } from '@/shared/config';
 import { debounceAsync, normalizeHostname } from '@/shared/helpers';
 import { cn, formatNumber, roundWithPrecision } from '@/pages/shared/lib/utils';
 import { useMessage, useTelemetry, useTranslation } from '@/popup/lib/context';
@@ -195,7 +196,13 @@ const SiteRateOfPayInput = ({
   onRateChange: Props['onSiteRateChange'];
 }) => {
   const t = useTranslation();
-  const { rateOfPay, maxRateOfPay, walletAddress, tab } = usePopupState();
+  const {
+    rateOfPay,
+    maxRateOfPay,
+    walletAddress,
+    tab,
+    sitesRateOfPay = [],
+  } = usePopupState();
 
   const hostname = new URL(tab.url).hostname;
   const site = normalizeHostname(hostname);
@@ -228,6 +235,7 @@ const SiteRateOfPayInput = ({
         rateOfPay={tab.rateOfPay || rateOfPay}
         maxRateOfPay={maxRateOfPay}
         walletAddress={walletAddress}
+        disabled={sitesRateOfPay.length > MAX_CUSTOM_RATE_EXCEPTIONS}
       />
     </>
   );

--- a/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/pages/shared/components/ui/Button';
 import { Input } from '@/pages/shared/components/ui/Input';
 import { useMessage, useTranslation } from '@/popup/lib/context';
 import { usePopupState, dispatch } from '@/popup/lib/store';
+import { MAX_CUSTOM_RATE_EXCEPTIONS } from '@/shared/config';
 import { normalizeHostname } from '@/shared/helpers';
 import type { AmountValue, Host } from '@/shared/types';
 import { RateOfPayInput } from './RateOfPay';
@@ -49,6 +50,14 @@ export function AddExceptionForm({
     },
     [message, rate, hostname, onDone],
   );
+
+  if (sitesRateOfPay.length === MAX_CUSTOM_RATE_EXCEPTIONS) {
+    return (
+      <p className="px-3 py-2 rounded-xl bg-error border border-error">
+        {t('settings_sitePaymentRates_maxExceptionsError')}
+      </p>
+    );
+  }
 
   return (
     <form

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,0 +1,2 @@
+/** Maximum number of custom rate exceptions allowed in storage */
+export const MAX_CUSTOM_RATE_EXCEPTIONS = 200;


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Finishing up #1345
Don't want too many exceptions - bad for user experience as well as extension storage.

## Changes proposed in this pull request

- Limit to 200 (`MAX_CUSTOM_RATE_EXCEPTIONS`)
- Handle limit in manage exceptions screen
- Disable "add current site exception" input if reached limit
   - Ideally, we want a better error handling in this debounced input, but for now, this is ok.