### PR TITLE
fix(popup): add custom-rate iff url is available, style fixes

### DIFF
--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -71,10 +71,7 @@ export const PayWebsiteForm = () => {
   return (
     <form
       ref={form}
-      className={cn(
-        'space-y-2 rounded-md bg-slate-100 px-4 py-4',
-        !errors.pay && 'pb-12',
-      )}
+      className="space-y-2 rounded-md bg-slate-100 px-4 py-4"
       onSubmit={onSubmit}
       data-testid="pay-form"
     >
@@ -106,6 +103,7 @@ export const PayWebsiteForm = () => {
         walletAddress={walletAddress}
         amount={amount}
         placeholder="0.00"
+        className="bg-white"
         min={roundWithPrecision(
           Number(tab.minSendAmount) / 10 ** walletAddress.assetScale,
           walletAddress.assetScale,

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -145,7 +145,7 @@ export const RateOfPayComponent = ({
         </div>
       )}
 
-      {!tab.rateOfPay ? (
+      {!tab.rateOfPay && URL.parse(tab.url)?.hostname ? (
         <Button
           type="button"
           variant="default"
@@ -207,7 +207,7 @@ const SiteRateOfPayInput = ({
           htmlFor="rateOfPaySite"
           className="flex items-center px-2 font-medium leading-6 text-medium"
         >
-          {site} (exception)
+          {site} ({t('home_text_hourlyRateException')})
         </label>
         <button
           onClick={() => onRateChange({ rate: null, hostname })}

--- a/src/pages/popup/components/layout/MainLayout.tsx
+++ b/src/pages/popup/components/layout/MainLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Header } from './Header';
 
 const Divider = () => {
-  return <div className="w-100 h-1 bg-divider-gradient" />;
+  return <div className="w-100 h-1 bg-divider-gradient shrink-0" />;
 };
 
 export const MainLayout = ({ children }: { children: React.ReactNode }) => {


### PR DESCRIPTION
## Context

Finishing up #1345
Misc fixes related to custom site rates

## Changes proposed in this pull request

1. The pay website form should have input with white background, not gray
1. When custom rates list is opened, the Divider was getting hidden. Ensure it remains visible.
1. Allow setting custom rate from RateOfPay screen only if valid URL. Earlier, if tried to open settings from a blank or extension page, clicking "Add custom rate" crashed popup.
1. Removed a hardcoded "exception" in copy