### PR TITLE
chore(scripts/build): remove typechecking in dev/build command

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build
-        run: pnpm build ${{ matrix.target }} --channel=nightly --no-typecheck
+        run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium ${{ matrix.project }} --with-deps
@@ -94,7 +94,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build
-        run: pnpm build --channel=nightly --no-typecheck
+        run: pnpm build --channel=nightly
 
       - name: Get built version
         uses: actions/github-script@v9

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: pnpm build ${{ matrix.browser }} --channel=nightly --no-typecheck
+        run: pnpm build ${{ matrix.browser }} --channel=nightly
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: pnpm build ${{ matrix.browser}} --channel=nightly --no-typecheck
+        run: pnpm build ${{ matrix.browser}} --channel=nightly
 
   test:
     name: Test

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build
-        run: pnpm build ${{ matrix.target }} --channel=nightly --no-typecheck
+        run: pnpm build ${{ matrix.target }} --channel=nightly
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium ${{ matrix.project }} --with-deps

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",
-    "@jgoz/esbuild-plugin-typecheck": "^4.0.4",
     "@octokit/openapi-webhooks-types": "^12.1.0",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/forms": "^0.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.3
         version: 2.5.3
-      '@jgoz/esbuild-plugin-typecheck':
-        specifier: ^4.0.4
-        version: 4.0.4(esbuild@0.28.1)(typescript@6.0.3)
       '@octokit/openapi-webhooks-types':
         specifier: ^12.1.0
         version: 12.1.0
@@ -527,16 +524,6 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
-
-  '@jgoz/esbuild-plugin-typecheck@4.0.4':
-    resolution: {integrity: sha512-ca38NAWnE/GchWjO5m7Wbny+yMOsYkoJOboQGheCjnnu5uDxqQWJSIegN+C+CWl8K/1naI/cMfTrAfDH1oRoVQ==}
-    peerDependencies:
-      '@jgoz/esbuild-plugin-livereload': '>=2.1.4'
-      esbuild: '>=0.25.0'
-      typescript: '>= 3.5'
-    peerDependenciesMeta:
-      '@jgoz/esbuild-plugin-livereload':
-        optional: true
 
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
@@ -2710,11 +2697,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@jgoz/esbuild-plugin-typecheck@4.0.4(esbuild@0.28.1)(typescript@6.0.3)':
-    dependencies:
-      esbuild: 0.28.1
-      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,7 +20,6 @@ import { getProdOptions } from './esbuild/prod.ts';
 sade('build [target]', true)
   .option('--channel', `One of: ${CHANNELS.join(', ')}`, 'nightly')
   .option('--dev', 'Dev-mode (watch, live-reload)', false)
-  .option('--typecheck', 'Typecheck code (can --no-typecheck in CI)', true)
   .example('chrome --channel=nightly')
   .example('firefox --channel=stable')
   .describe([`\`target\` should be one of ${TARGETS.join(', ')}`])
@@ -33,15 +32,7 @@ sade('build [target]', true)
 
     if (!options.target && !options.dev) {
       console.log(`Building all targets with channel: ${options.channel}`);
-      return Promise.all(
-        TARGETS.map((t, i) =>
-          build({
-            ...options,
-            typecheck: i === 0 && opts.typecheck,
-            target: t,
-          }),
-        ),
-      );
+      return Promise.all(TARGETS.map((t) => build({ ...options, target: t })));
     }
 
     // Default to chrome in dev build
@@ -61,11 +52,11 @@ sade('build [target]', true)
   })
   .parse(process.argv);
 
-async function build({ target, channel, typecheck }: BuildArgs) {
+async function build({ target, channel }: BuildArgs) {
   const OUTPUT_DIR = path.join(DIST_DIR, target);
   const result = await esbuild.build({
     ...options,
-    ...getProdOptions({ outDir: OUTPUT_DIR, target, channel, typecheck }),
+    ...getProdOptions({ outDir: OUTPUT_DIR, target, channel }),
     outdir: OUTPUT_DIR,
   });
 
@@ -77,11 +68,11 @@ async function build({ target, channel, typecheck }: BuildArgs) {
   }
 }
 
-async function buildWatch({ target, channel, typecheck }: BuildArgs) {
+async function buildWatch({ target, channel }: BuildArgs) {
   const OUTPUT_DIR = path.join(DEV_DIR, target);
   const ctx = await esbuild.context({
     ...options,
-    ...getDevOptions({ outDir: OUTPUT_DIR, target, channel, typecheck }),
+    ...getDevOptions({ outDir: OUTPUT_DIR, target, channel }),
     outdir: OUTPUT_DIR,
   });
 

--- a/scripts/esbuild/config.ts
+++ b/scripts/esbuild/config.ts
@@ -27,7 +27,6 @@ export type BuildArgs = {
   target: Target;
   channel: Channel;
   dev: boolean;
-  typecheck: boolean;
 };
 
 export const options: BuildOptions = {

--- a/scripts/esbuild/dev.ts
+++ b/scripts/esbuild/dev.ts
@@ -7,7 +7,6 @@ export const getDevOptions = ({
   outDir,
   target,
   channel,
-  typecheck,
 }: Omit<BuildArgs, 'dev'> & {
   outDir: string;
 }): BuildOptions => {
@@ -20,7 +19,6 @@ export const getDevOptions = ({
       dev: true,
       target,
       channel,
-      typecheck,
     }).concat([liveReloadPlugin({ target })]),
     define: {
       NODE_ENV: JSON.stringify('development'),

--- a/scripts/esbuild/plugins.ts
+++ b/scripts/esbuild/plugins.ts
@@ -5,7 +5,6 @@ import type { Plugin as ESBuildPlugin } from 'esbuild';
 import { nodeBuiltin } from 'esbuild-node-builtin';
 import esbuildStylePlugin from 'esbuild-style-plugin';
 import { copy } from 'esbuild-plugin-copy';
-import { typecheckPlugin } from '@jgoz/esbuild-plugin-typecheck';
 import tailwindcss from '@tailwindcss/postcss';
 
 import {
@@ -22,7 +21,6 @@ export const getPlugins = ({
   target,
   channel,
   dev,
-  typecheck,
 }: BuildArgs & {
   outDir: string;
 }): ESBuildPlugin[] => {
@@ -88,7 +86,6 @@ export const getPlugins = ({
     }),
     processManifestPlugin({ outDir, dev, target, channel }),
     safariSupportPlugin({ outDir, target }),
-    typecheck ? typecheckPlugin({ buildMode: 'readonly', watch: dev }) : null,
   ].filter((e) => e !== null);
 };
 
@@ -118,7 +115,7 @@ function processManifestPlugin({
   outDir,
   target,
   channel,
-}: Omit<BuildArgs, 'typecheck'> & { outDir: string }): ESBuildPlugin {
+}: BuildArgs & { outDir: string }): ESBuildPlugin {
   return {
     name: 'process-manifest',
     setup(build) {

--- a/scripts/esbuild/prod.ts
+++ b/scripts/esbuild/prod.ts
@@ -15,7 +15,6 @@ export const getProdOptions = ({
   outDir,
   target,
   channel,
-  typecheck,
 }: Omit<BuildArgs, 'dev'> & {
   outDir: string;
 }): BuildOptions => {
@@ -28,7 +27,6 @@ export const getProdOptions = ({
       dev: false,
       target,
       channel,
-      typecheck,
     }).concat([
       preservePolyfillClassNamesPlugin({ outDir }),
       zipPlugin({ outDir, target, channel }),


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

The `@jgoz/esbuild-plugin-typecheck` package isn't [very fast](https://github.com/jgoz/esbuild-plugins/issues/142), and not really needed in our dev script. Build scripts typically run `pnpm typecheck` separately (like before release, in PRs). So, let's remove one dependency.
We might consider a pre-commit hook with TypeScript v7 soon.

## Changes proposed in this pull request

- Remove `@jgoz/esbuild-plugin-typecheck` dependency
- Update build script and its usage.