### PR TITLE
feat(ConnectWalletForm): fetch wallet address as user types

### DIFF
--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -29,6 +29,7 @@ import {
 import { useTranslation } from '@/popup/lib/context';
 import { deepClone } from 'valtio/utils';
 import {
+  debounceAsync,
   ErrorWithKey,
   errorWithKey,
   isErrorWithKey,
@@ -505,6 +506,8 @@ function WalletAddressInput({
     [validateAndFetch, resetState],
   );
 
+  const debouncedCommit = useRef(debounceAsync(commit, 500)).current;
+
   useImperativeHandle(
     ref,
     () => ({ commit: () => commit(inputRef.current!.value) }),
@@ -515,20 +518,22 @@ function WalletAddressInput({
     (event) => {
       const input = event.currentTarget;
       const ev = event.nativeEvent as InputEvent;
-      const value = ev.data ?? input.value; // Chrome doesn't fire InputEvent on autocomplete!
-      if (
-        !value ||
-        (ev.inputType && ev.inputType !== 'insertReplacementText')
-      ) {
-        return; // not autocomplete
+
+      if (ev.inputType && ev.inputType !== 'insertReplacementText') {
+        // regular typing, not autocomplete. commit once the user pauses
+        void debouncedCommit(input.value);
+        return;
       }
+
+      const value = ev.data ?? input.value; // Chrome doesn't fire InputEvent on autocomplete!
+      if (!value) return;
       if (validateWalletAddressUrl(value)) {
         return; // not valid data from autocomplete, fallback to input blur based behavior
       }
       // use as autocompleted value
       void commit(value);
     },
-    [commit],
+    [commit, debouncedCommit],
   );
 
   const onPaste: OnPasteHandler = useCallback(


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

Before this PR, user has to move away from wallet address input (blur) to know if it's valid address, and know the currency/default budget.

## Changes proposed in this pull request

Validate/fetch automatically once user isn't typing for 500ms.