### PR TITLE
fix(i18n): make i18n keys consistent

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -2,496 +2,501 @@
   "appDescription": {
     "message": "Support content you love. Pay as you browse!"
   },
-  "icon_state_monetizationActive": {
+  "icon_monetizationActive_text": {
     "message": "Active"
   },
-  "icon_state_monetizationInactive": {
+  "icon_monetizationInactive_text": {
     "message": "Inactive"
   },
-  "icon_state_actionRequired": {
+  "icon_actionRequired_text": {
     "message": "Action Required!"
   },
-  "tagline_text_1": {
+  "tagline_text__1": {
     "message": "Support content you love"
   },
-  "tagline_text_2": {
+  "tagline_text__2": {
     "message": "Pay as you browse"
   },
-  "missingHostPermission_state_text": {
+  "missingHostPermission_text": {
     "message": "Permission to access your data on all websites is required to use Web Monetization."
   },
-  "notMonetized_text_allInvalid": {
+  "notMonetized_allInvalid_text": {
     "message": "This page cannot receive payments from your wallet at this time. Please check back later.",
     "description": "We cannot send money (probable cause: un-peered wallets)"
   },
-  "notMonetized_text_noLinks": {
+  "notMonetized_noLinks_text": {
     "message": "This website is not monetized."
   },
-  "notMonetized_text_newTab": {
+  "notMonetized_newTab_text": {
     "message": "The extension does not support empty tabs."
   },
-  "notMonetized_text_internalPage": {
+  "notMonetized_internalPage_text": {
     "message": "The extension cannot access the browser's internal pages."
   },
-  "notMonetized_text_unsupportedScheme": {
+  "notMonetized_unsupportedScheme_text": {
     "message": "Web Monetization only works with websites using https://."
   },
-  "app_text_disabled": {
+  "app_disabled_text": {
     "message": "The extension is disabled. Click the power icon above to enable the extension and continue making payments."
   },
 
-  "home_title_balance": {
+  "home_balance_title": {
     "message": "Balance"
   },
-  "home_action_manageBudget": {
+  "home_manageBudget_action": {
     "message": "Manage budget"
   },
-  "home_title_hourlyRate": {
+  "home_hourlyRate_title": {
     "message": "Hourly rate"
   },
-  "home_action_addException": {
+  "home_addException_action": {
     "message": "Add custom rate"
   },
-  "home_action_manageExceptions": {
+  "home_manageExceptions_action": {
     "message": "Manage custom rates"
   },
-  "home_text_hourlyRateException": {
+  "home_hourlyRateException_text": {
     "message": "custom"
   },
-  "home_text_hourlyRateDefault": {
+  "home_hourlyRateDefault_text": {
     "message": "default"
   },
 
-  "keyRevoked_error_title": {
+  "keyRevoked_title": {
     "message": "Unauthorized access to the wallet."
   },
-  "keyRevoked_error_text": {
+  "keyRevoked_text": {
     "message": "It appears the key has been revoked from your wallet. Please authenticate by adding the key again, or disconnect."
   },
-  "keyRevoked_action_disconnect": {
+  "keyRevoked_disconnect_action": {
     "message": "Yes, let me disconnect my wallet"
   },
-  "keyRevoked_action_reconnect": {
+  "keyRevoked_reconnect_action": {
     "message": "It was a mistake, I’d like to reconnect my wallet"
   },
-  "keyRevoked_action_reconnectBtn": {
+  "keyRevoked_reconnectBtn_action": {
     "message": "Reconnect"
   },
-  "disconnectWallet_error_generic": {
+
+  "disconnectWallet_error": {
     "message": "We were unable to disconnect your wallet ($ERROR$).",
     "placeholders": {
       "ERROR": { "content": "$1", "example": "Internal server error" }
     }
   },
-  "pay_action_pay": {
+
+  "pay_action": {
     "message": "Send now"
   },
-  "pay_error_notEnoughFunds": {
+  "pay_notEnoughFunds_error": {
     "message": "Insufficient funds to complete the payment."
   },
-  "pay_error_outgoingPaymentFailed": {
+  "pay_outgoingPaymentFailed_error": {
     "message": "We were unable to process this transaction. Please try again!"
   },
-  "pay_warn_outgoingPaymentPollingIncomplete": {
+  "pay_outgoingPaymentPollingIncomplete_warn": {
     "message": "It looks like this is taking long. Check your wallet later to ensure the payment went through.",
     "description": "We were polling for completion, but it's not finished yet - could mean it'll never succeed or it'll take a long time to settle."
   },
-  "pay_error_general": {
+  "pay_error": {
     "message": "We were unable to process this transaction. Please try again!"
   },
-  "pay_error_invalidReceivers": {
+  "pay_invalidReceivers_error": {
     "message": "This page cannot receive payments from your wallet at this time. Please check back later.",
     "description": "We cannot send money (probable cause: un-peered wallets)"
   },
-  "pay_error_notMonetized": {
+  "pay_notMonetized_error": {
     "message": "This website is not monetized."
   },
-  "pay_state_success": {
+  "pay_success_text": {
     "message": "Thank you for your support!"
   },
+
   "outOfFunds_error_title": {
     "message": "Out of funds"
   },
   "outOfFunds_error_text": {
     "message": "Funds are depleted. You can no longer make payments."
   },
-  "outOfFunds_error_textHint": {
+  "outOfFunds_error_hint_text": {
     "message": "Please add funds."
   },
-  "outOfFunds_error_textDoNothing": {
+  "outOfFunds_recurringAutoRenew_text": {
     "message": "If you do nothing, $AMOUNT$ will automatically be renewed and available on $AUTO_RENEW_DATE$",
     "placeholders": {
       "AMOUNT": { "content": "$1", "example": "$2.05" },
       "AUTO_RENEW_DATE": { "content": "$2", "example": "Aug 22, 2024, 6:05 PM" }
     }
   },
-  "outOfFunds_action_optionOneTime": {
+  "outOfFunds_optionOneTime_action": {
     "message": "Let me top-up funds one time"
   },
-  "outOfFunds_action_optionRecurring": {
+  "outOfFunds_optionRecurring_action": {
     "message": "Let me add funds & auto-renew monthly"
   },
-  "outOfFundsAddFunds_label_walletAddress": {
+  "outOfFundsAddFunds_walletAddress_label": {
     "message": "Connected wallet address"
   },
-  "outOfFundsAddFunds_label_amount": {
+  "outOfFundsAddFunds_amount_label": {
     "message": "Amount"
   },
-  "outOfFundsAddFunds_label_amountDescriptionOneTime": {
+  "outOfFundsAddFunds_amount_oneTime_desc": {
     "message": "Enter the amount to add from the wallet."
   },
-  "outOfFundsAddFunds_label_amountDescriptionRecurring": {
+  "outOfFundsAddFunds_amount_recurring_desc": {
     "message": "Enter the amount to add from your wallet. This amount will renew automatically each month (next: $NEXT_RENEW_DATE$).",
     "placeholders": {
       "NEXT_RENEW_DATE": { "content": "$1", "example": "Aug 22, 2024" }
     }
   },
-  "outOfFundsAddFunds_action_addOneTime": {
+  "outOfFundsAddFunds_oneTime_action": {
     "message": "Add funds"
   },
-  "outOfFundsAddFunds_action_addRecurring": {
+  "outOfFundsAddFunds_recurring_action": {
     "message": "Add funds"
   },
-  "connectWallet_text_title": {
+
+  "connectWallet_title": {
     "message": "Let's get you set up!"
   },
-  "connectWallet_text_desc": {
+  "connectWallet_desc": {
     "message": "Just a few quick steps to connect the extension to your wallet"
   },
-  "connectWallet_label_walletAddress": {
+  "connectWallet_walletAddress_label": {
     "message": "Enter your wallet address/payment pointer"
   },
-  "connectWallet_labelGroup_amount": {
+  "connectWallet_amount_group_label": {
     "message": "Enter the amount to allocate from your wallet"
   },
-  "connectWallet_label_amount": {
+  "connectWallet_amount_label": {
     "message": "Amount"
   },
-  "connectWallet_label_recurring": {
+  "connectWallet_recurring_label": {
     "message": "Renew monthly"
   },
-  "connectWallet_label_publicKey": {
+  "connectWallet_publicKey_label": {
     "message": "Please copy this key, paste it manually into your wallet, and then connect."
   },
-  "connectWallet_text_publicKeyLearnMore": {
+  "connectWallet_publicKeyLearnMore_text": {
     "message": "Learn more."
   },
-  "connectWallet_action_connect": {
+  "connectWallet_connect_action": {
     "message": "Connect"
   },
-  "connectWallet_text_stepAcceptGrant": {
+  "connectWallet_stepAcceptGrant_text": {
     "message": "Waiting for your approval"
   },
-  "connectWallet_error_urlRequired": {
+  "connectWallet_url_required_error": {
     "message": "The wallet address is required."
   },
-  "connectWallet_error_urlInvalidUrl": {
+  "connectWallet_url_invalidUrl_error": {
     "message": "Invalid wallet address URL."
   },
-  "connectWallet_error_urlInvalidNotHttps": {
+  "connectWallet_url_invalidNotHttps_error": {
     "message": "The wallet address must be a valid https:// URL or a payment pointer."
   },
-  "connectWallet_error_amountRequired": {
+  "connectWallet_amount_required_error": {
     "message": "The amount is required."
   },
-  "connectWallet_error_amountInvalidNumber": {
+  "connectWallet_amount_invalidNumber_error": {
     "message": "Please enter a valid number for the amount."
   },
-  "connectWallet_error_amountMinimum": {
+  "connectWallet_amount_minimum_error": {
     "message": "A minimum amount of $AMOUNT$ is required.",
     "placeholders": {
       "AMOUNT": { "content": "$1", "example": "$2.05" }
     }
   },
-  "connectWallet_error_amountMaximum": {
+  "connectWallet_amount_maximum_error": {
     "message": "Amount must be under $AMOUNT$.",
     "placeholders": {
       "AMOUNT": { "content": "$1", "example": "$2.05" }
     }
   },
-  "connectWallet_error_failedAutoKeyAdd": {
+  "connectWallet_failedAutoKeyAdd_error": {
     "message": "Unable to automatically connect to your wallet."
   },
-  "connectWallet_error_failedAutoKeyAddWhy": {
+  "connectWallet_failedAutoKeyAdd_why_text": {
     "message": "Why?",
     "description": "Click here to see the reason why automatic key addition failed."
   },
-  "connectWallet_error_invalidClient": {
+  "connectWallet_invalidClient_error": {
     "message": "Connection failed. Please ensure the key is added to the correct wallet."
   },
-  "connectWallet_error_tabClosed": {
+  "connectWallet_tabClosed_error": {
     "message": "Wallet connection cancelled. The tab was closed before completion."
   },
-  "connectWallet_error_grantRejected": {
+  "connectWallet_grantRejected_error": {
     "message": "Wallet connection cancelled. The request was not authorized."
   },
-  "connectWallet_error_timeout": {
+  "connectWallet_timeout_error": {
     "message": "Connecting to wallet took too long. Please try again."
   },
-  "connectWallet_error_hashFailed": {
+  "connectWallet_hashFailed_error": {
     "message": "Connection failed. Please try again."
   },
-  "connectWallet_error_continuationFailed": {
+  "connectWallet_continuationFailed_error": {
     "message": "Connection failed. Please try again."
   },
-  "connectWallet_error_grantInvalid": {
+  "connectWallet_grantInvalid_error": {
     "message": "Connection failed. Please try again."
   },
-  "connectWalletKeyService_text_consentP1": {
+
+  "connectWalletKeyService_consent_text__1": {
     "message": "We will automatically connect with your wallet provider."
   },
-  "reconnectWalletKeyService_text_consentP1": {
+  "reconnectWalletKeyService_consent_text__1": {
     "message": "We will automatically reconnect with your wallet provider."
   },
-  "connectWalletKeyService_text_consentLearnMore": {
+  "connectWalletKeyService_consentLearnMore_text": {
     "message": "Learn more",
     "description": "Learn more about how this works"
   },
-  "connectWalletKeyService_text_consentP2": {
+  "connectWalletKeyService_consent_text__2": {
     "message": "By agreeing, you provide us consent to automatically access your wallet to securely add a key."
   },
-  "connectWalletKeyService_text_consentP3": {
+  "connectWalletKeyService_consent_text__3": {
     "message": "Please note, this process does not involve accessing or handling your funds."
   },
-  "connectWalletKeyService_label_consentAccept": {
+  "connectWalletKeyService_consentAccept_action": {
     "message": "Agree"
   },
-  "connectWalletKeyService_label_consentDecline": {
+  "connectWalletKeyService_consentDecline_action": {
     "message": "Decline"
   },
-  "connectWalletKeyService_text_stepAddKey": {
+  "connectWalletKeyService_stepAddKey_text": {
     "message": "Adding public key to wallet"
   },
-  "connectWalletKeyService_text_stepWaitingLogin": {
+  "connectWalletKeyService_stepWaitingLogin_text": {
     "message": "Waiting for you to login"
   },
-  "connectWalletKeyService_text_stepFindingWallet": {
+  "connectWalletKeyService_stepFindingWallet_text": {
     "message": "Finding wallet"
   },
-  "connectWalletKeyService_text_stepAddingKey": {
+  "connectWalletKeyService_stepAddingKey_text": {
     "message": "Adding key"
   },
-  "connectWalletKeyService_error_notImplemented": {
+  "connectWalletKeyService_notImplemented_error": {
     "message": "Automatic key addition is not yet implemented for the selected wallet provider."
   },
-  "connectWalletKeyService_error_noConsent": {
+  "connectWalletKeyService_noConsent_error": {
     "message": "You declined consent for automatic key addition."
   },
-  "connectWalletKeyService_error_failed": {
+  "connectWalletKeyService_failed_error": {
     "message": "Automatic key addition failed at step “$STEP_ID$” with message “$MESSAGE$”.",
     "placeholders": {
       "STEP_ID": { "content": "$1", "example": "Doing something" },
       "MESSAGE": { "content": "$2", "example": "Could not do something" }
     }
   },
-  "connectWalletKeyService_error_timeoutLogin": {
+  "connectWalletKeyService_timeoutLogin_error": {
     "message": "The login attempt has timed out."
   },
-  "connectWalletKeyService_error_skipAlreadyLoggedIn": {
+  "connectWalletKeyService_skipAlreadyLoggedIn_error": {
     "message": "You are already logged in."
   },
-  "connectWalletKeyService_error_accountNotFound": {
+  "connectWalletKeyService_accountNotFound_error": {
     "message": "Failed to find an account for the provided wallet address. Are you logged into a different account?"
   },
-  "postInstall_text_title": {
+
+  "postInstall_title": {
     "message": "Let's get you started with Web Monetization!"
   },
-  "postInstall_text_stepGetWallet_title": {
+  "postInstall_stepGetWallet_title": {
     "message": "Get a wallet compatible with Web Monetization"
   },
-  "postInstall_text_stepGetWallet_desc": {
+  "postInstall_stepGetWallet_desc": {
     "message": "If you don’t already have a Web Monetization-compatible wallet, please set one up, then return here to complete the setup."
   },
-  "postInstall_text_stepGetWallet_comingSoon": {
+  "postInstall_stepGetWallet_comingSoon_text": {
     "message": "More wallets will be added soon…"
   },
-  "postInstall_text_stepWalletAddress_title": {
+  "postInstall_stepWalletAddress_title": {
     "message": "Find your wallet address or payment pointer"
   },
-  "postInstall_text_stepPin_title": {
+  "postInstall_stepPin_title": {
     "message": "Pin extension to the browser toolbar"
   },
-  "postInstall_text_stepPin_desc": {
+  "postInstall_stepPin_desc": {
     "message": "Pin the Web Monetization Extension for easier access."
   },
-  "postInstall_text_stepPin_descComplete": {
+  "postInstall_stepPin_complete_text": {
     "message": "You're all set."
   },
-  "postInstall_text_stepPermissions_title": {
+  "postInstall_stepPermissions_title": {
     "message": "Permission to read all websites required"
   },
-  "postInstall_action_stepPermissions_grant": {
+  "postInstall_stepPermissions_grant_action": {
     "message": "Grant permission"
   },
-  "postInstall_text_stepPermissions_descComplete": {
+  "postInstall_stepPermissions_complete_text": {
     "message": "You've granted the necessary permissions!"
   },
-  "postInstall_action_submit": {
+  "postInstall_submit_action": {
     "message": "Connect your wallet"
   },
-  "postInstall_text_wallet_connected_1": {
+  "postInstall_walletConnected_text__1": {
     "message": "You've already connected your wallet."
   },
-  "postInstall_text_wallet_connected_2": {
+  "postInstall_walletConnected_text__2": {
     "message": "Access the extension from the browser toolbar."
   },
-  "postInstallConsent_text_title": {
+
+  "postInstallConsent_title": {
     "message": "Welcome to the Web Monetization extension"
   },
-  "postInstallConsent_text_header1": {
+  "postInstallConsent_header_text__1": {
     "message": "We’re transparent about what data is shared and how it’s used."
   },
-  "postInstallConsent_text_header2": {
+  "postInstallConsent_header_text__2": {
     "message": "By continuing, you consent to share the information below."
   },
-  "postInstallConsent_text_dataShared_title": {
+  "postInstallConsent_dataShared_title": {
     "message": "What’s shared by the extension"
   },
-  "postInstallConsent_text_dataShared_yourWallet_title": {
+  "postInstallConsent_dataShared_yourWallet_title": {
     "message": "With your wallet provider:"
   },
-  "postInstallConsent_text_dataShared_yourWallet_wa": {
+  "postInstallConsent_dataShared_yourWallet_wa_text": {
     "message": "Your wallet address."
   },
-  "postInstallConsent_text_dataShared_yourWallet_keyConsent": {
+  "postInstallConsent_dataShared_yourWallet_keyConsent_text": {
     "message": "Note: You will always be asked for consent before any connection."
   },
-  "postInstallConsent_text_dataShared_websiteWallets_title": {
+  "postInstallConsent_dataShared_websiteWallets_title": {
     "message": "With the website’s wallet provider:"
   },
-  "postInstallConsent_text_dataShared_websiteWallets_wa": {
+  "postInstallConsent_dataShared_websiteWallets_wa_text": {
     "message": "Your wallet address."
   },
-  "postInstallConsent_text_dataShared_websites_title": {
+  "postInstallConsent_dataShared_websites_title": {
     "message": "With the websites you visit:"
   },
-  "postInstallConsent_text_dataShared_websites_text": {
+  "postInstallConsent_dataShared_websites_desc": {
     "message": "Nothing. The extension never shares your wallet address, balance, or currency with the websites you visit. Your browsing history remains private in your browser."
   },
-  "postInstallConsent_text_dataShared_browser_title": {
+  "postInstallConsent_dataShared_browser_title": {
     "message": "What’s shared by your browser"
   },
-  "postInstallConsent_text_dataShared_browser_text": {
+  "postInstallConsent_dataShared_browser_desc": {
     "message": "Your IP address, language, and browser version are shared with your wallet provider and the website’s wallet provider while you use the extension."
   },
-  "postInstallConsent_text_dataShared_headers": {
+  "postInstallConsent_dataShared_headers_text": {
     "message": "Browsers send certain HTTP headers by default with each request that inform the servers about your language (`Accept-Language` header), browser version (`User-Agent` header) and more. Your IP address is also sent by default."
   },
-  "postInstallConsent_text_dataCollection_title": {
+  "postInstallConsent_dataCollection_title": {
     "message": "Analytics"
   },
-  "postInstallConsent_text_dataCollection_desc": {
+  "postInstallConsent_dataCollection_desc": {
     "message": "The extension gathers anonymous data about how you use it (e.g., clicks, interactions) to help us improve the app and your overall experience."
   },
-  "postInstallConsent_text_dataCollection_yes_heading": {
+  "postInstallConsent_dataCollection_yes_heading": {
     "message": "The Interledger Foundation:"
   },
-  "postInstallConsent_text_dataCollection_yes_text1": {
+  "postInstallConsent_dataCollection_yes_text__1": {
     "message": "Uses PostHog to collect usage and analytics data."
   },
-  "postInstallConsent_text_dataCollection_yes_text2": {
+  "postInstallConsent_dataCollection_yes_text__2": {
     "message": "Assigns each installation a unique ID, and associates your actions and interactions (events) with that ID."
   },
-  "postInstallConsent_text_dataCollection_no_heading": {
+  "postInstallConsent_dataCollection_no_heading": {
     "message": "We do not:"
   },
-  "postInstallConsent_text_dataCollection_no_text1": {
+  "postInstallConsent_dataCollection_no_text__1": {
     "message": "Collect any personally identifiable information, such as your name or wallet address."
   },
-  "postInstallConsent_text_dataCollection_no_text2": {
+  "postInstallConsent_dataCollection_no_text__2": {
     "message": "Store your IP address. It is only used to estimate your general location, and then it’s immediately discarded."
   },
-  "postInstallConsent_label_dataCollection_optIn": {
+  "postInstallConsent_dataCollection_optIn_label": {
     "message": "Opt-in to usage data collection"
   },
-  "postInstallConsent_text_dataCollection_footer": {
+  "postInstallConsent_dataCollection_footer": {
     "message": "This setting takes effect after you click Confirm and Continue. You can change your preferences any time by opening the extension through the browser toolbar → Settings → Data Collection."
   },
-  "postInstallConsent_text_permissions_title": {
+  "postInstallConsent_permissions_title": {
     "message": "Extension Permissions"
   },
-  "postInstallConsent_text_permissions_text": {
+  "postInstallConsent_permissions_text": {
     "message": "The extension needs basic permissions to work."
   },
-  "postInstallConsent_text_permissions_linkText": {
+  "postInstallConsent_permissions_link_text": {
     "message": "See details."
   },
-  "postInstallConsent_state_consentProvided": {
+  "postInstallConsent_consentProvided_text": {
     "message": "You have provided your consent to the above. Access the extension from the browser toolbar."
   },
-  "postInstallConsent_text_confirmation": {
+  "postInstallConsent_confirmation": {
     "message": "I confirm that I understand and consent to this data usage."
   },
-  "postInstallConsent_action_confirm": {
+  "postInstallConsent_confirm_action": {
     "message": "Confirm and continue"
   },
+
   "postConnect_connect_success_title": {
     "message": "Wallet Connected!"
   },
-  "postConnect_connect_success_msg": {
+  "postConnect_connect_success_text": {
     "message": "You’re all set to start using the extension."
   },
   "postConnect_addFunds_success_title": {
     "message": "Funds Added"
   },
-  "postConnect_addFunds_success_msg": {
+  "postConnect_addFunds_success_text": {
     "message": "Funds were successfully added to your budget."
   },
   "postConnect_updateBudget_success_title": {
     "message": "Budget Updated"
   },
-  "postConnect_updateBudget_success_msg": {
+  "postConnect_updateBudget_success_text": {
     "message": "Your new spending limits are now active."
   },
   "postConnect_reconnect_success_title": {
     "message": "Reconnected!"
   },
-  "postConnect_reconnect_success_msg": {
+  "postConnect_reconnect_success_text": {
     "message": "Your wallet is reconnected."
   },
-
   "postConnect_connect_cancel_grantRejected_title": {
     "message": "Connection cancelled"
   },
-  "postConnect_connect_cancel_grantRejected_msg": {
+  "postConnect_connect_cancel_grantRejected_text": {
     "message": "Wallet connection was cancelled. Please try again and follow the prompts to complete connection."
   },
   "postConnect_addFunds_cancel_grantRejected_title": {
     "message": "Fund addition cancelled"
   },
-  "postConnect_addFunds_cancel_grantRejected_msg": {
+  "postConnect_addFunds_cancel_grantRejected_text": {
     "message": "No funds were added to your budget."
   },
   "postConnect_updateBudget_cancel_grantRejected_title": {
     "message": "Budget update cancelled"
   },
-  "postConnect_updateBudget_cancel_grantRejected_msg": {
+  "postConnect_updateBudget_cancel_grantRejected_text": {
     "message": "Your budget settings were not changed."
   },
-
   "postConnect_connect_failure_timeout_title": {
     "message": "Wallet connection timed-out"
   },
-  "postConnect_connect_failure_timeout_msg": {
+  "postConnect_connect_failure_timeout_text": {
     "message": "The connection to your wallet provider timed out. Please check your connection and try again."
   },
   "postConnect_addFunds_failure_timeout_title": {
     "message": "Funds addition timed-out"
   },
-  "postConnect_addFunds_failure_timeout_msg": {
+  "postConnect_addFunds_failure_timeout_text": {
     "message": "Adding funds to your budget timed out. Please check your connection and try again."
   },
   "postConnect_updateBudget_failure_timeout_title": {
     "message": "Budget update timed-out"
   },
-  "postConnect_updateBudget_failure_timeout_msg": {
+  "postConnect_updateBudget_failure_timeout_text": {
     "message": "Updating your budget timed out. Please check your connection and try again."
   },
-
   "postConnect_connect_failure_keyAdd_title": {
     "message": "Key addition failed"
   },
-  "postConnect_connect_failure_keyAdd_msg": {
+  "postConnect_connect_failure_keyAdd_text": {
     "message": "We couldn’t add the public key to your wallet.$DETAILS$",
     "placeholders": {
       "DETAILS": { "content": "$1", "example": "Additional optional details" }
@@ -500,23 +505,22 @@
   "postConnect_reconnect_failure_keyAdd_title": {
     "message": "Wallet reconnection failed"
   },
-  "postConnect_reconnect_failure_keyAdd_msg": {
+  "postConnect_reconnect_failure_keyAdd_text": {
     "message": "We couldn’t add the public key to your wallet.$DETAILS$",
     "placeholders": {
       "DETAILS": { "content": "$1", "example": "Additional optional details" }
     }
   },
-
   "postConnect_connect_failure_other_title": {
     "message": "Wallet connection failed"
   },
-  "postConnect_connect_failure_other_msg": {
+  "postConnect_connect_failure_other_text": {
     "message": "Something went wrong while connecting. Please try again."
   },
   "postConnect_addFunds_failure_other_title": {
     "message": "Funds addition failed"
   },
-  "postConnect_addFunds_failure_other_msg": {
+  "postConnect_addFunds_failure_other_text": {
     "message": "Something went wrong while adding funds. Please try again.$DETAILS$",
     "placeholders": {
       "DETAILS": { "content": "$1", "example": "Additional optional details" }
@@ -525,7 +529,7 @@
   "postConnect_updateBudget_failure_other_title": {
     "message": "Budget update failed"
   },
-  "postConnect_updateBudget_failure_other_msg": {
+  "postConnect_updateBudget_failure_other_text": {
     "message": "Something went wrong while updating your budget. Please try again.$DETAILS$",
     "placeholders": {
       "DETAILS": { "content": "$1", "example": "Additional optional details" }
@@ -534,7 +538,7 @@
   "postConnect_reconnect_failure_other_title": {
     "message": "Wallet reconnection failed"
   },
-  "postConnect_reconnect_failure_other_msg": {
+  "postConnect_reconnect_failure_other_text": {
     "message": "We couldn’t verify your wallet. Please try again, or manually copy the public key and add it to your digital wallet account."
   },
 
@@ -544,16 +548,16 @@
   "settings_rate_continuousPayments_disabled_text": {
     "message": "Ongoing payments are now disabled. You can still make one time payments."
   },
-  "settings_rate_label_manageExceptions": {
+  "settings_rate_manageExceptions_action": {
     "message": "Manage custom rates"
   },
-  "settings_rate_label_addException": {
+  "settings_rate_addException_action": {
     "message": "Add custom rate"
   },
-  "settings_rate_label_inputDefaultRate": {
+  "settings_rate_inputDefaultRate_label": {
     "message": "Default rate"
   },
-  "settings_rate_action_removeException": {
+  "settings_rate_removeException_action": {
     "message": "Remove custom rate"
   },
 
@@ -563,16 +567,16 @@
   "settings_sitePaymentRates_desc": {
     "message": "Set a custom hourly rate for any site, we'll apply it automatically when you visit. You can go back to the default rate any time."
   },
-  "settings_sitePaymentRates_action_addException": {
+  "settings_sitePaymentRates_addException_action": {
     "message": "Add a site"
   },
-  "settings_sitePaymentRates_text_formTitle": {
+  "settings_sitePaymentRates_form_title": {
     "message": "Add a site"
   },
-  "settings_sitePaymentRates_action_cancel": {
+  "settings_sitePaymentRates_cancel_action": {
     "message": "Cancel"
   },
-  "settings_sitePaymentRates_maxExceptionsError": {
+  "settings_sitePaymentRates_maxExceptions_error": {
     "message": "You have reached your custom rates limit. Delete one of your existing custom rates to add a new one."
   },
   "settings_sitePaymentRates_inputSite_label": {
@@ -581,19 +585,19 @@
   "settings_sitePaymentRates_inputRate_label": {
     "message": "Custom rate"
   },
-  "settings_sitePaymentRates_action_save": {
+  "settings_sitePaymentRates_save_action": {
     "message": "Save"
   },
-  "settings_sitePaymentRates_inputSite_error_required": {
+  "settings_sitePaymentRates_inputSite_required_error": {
     "message": "Domain is required"
   },
-  "settings_sitePaymentRates_inputSite_error_invalid": {
+  "settings_sitePaymentRates_inputSite_invalid_error": {
     "message": "Enter a valid domain (e.g. example.com)"
   },
   "settings_sitePaymentRates_heading": {
     "message": "Your custom rates"
   },
-  "settings_sitePaymentRates_noExceptions": {
+  "settings_sitePaymentRates_noExceptions_text": {
     "message": "There are no custom rates added"
   },
 
@@ -603,25 +607,26 @@
   "settings_dataCollection_label": {
     "message": "Usage data & analytics"
   },
-  "settings_dataCollection_text": {
+  "settings_dataCollection_desc": {
     "message": "The extension gathers anonymous data about how you use it (e.g., clicks, interactions) to help us improve the app and your overall experience."
   },
-  "settings_dataCollection_text_learnMore": {
+  "settings_dataCollection_learnMore_text": {
     "message": "Read the full details in our"
   },
-  "consentRequired_text_title": {
+
+  "consentRequired_title": {
     "message": "Consent Required: Data Collection & Transmission"
   },
-  "consentRequired_text_titleUpdated": {
+  "consentRequired_updated_title": {
     "message": "Consent Required: Collection and usage of your data has been updated"
   },
-  "consentRequired_text_subtitle": {
+  "consentRequired_subtitle": {
     "message": "We want to be transparent about what data is shared and how it’s used."
   },
-  "consentRequired_text_msg": {
+  "consentRequired_text": {
     "message": "To use the the Web Monetization Extension, we require your consent to our data collection & transmission policy."
   },
-  "consentRequired_action_primary": {
+  "consentRequired_primary_action": {
     "message": "View data policy and consent"
   }
 }

--- a/src/background/services/keyAutoAdd.ts
+++ b/src/background/services/keyAutoAdd.ts
@@ -64,7 +64,7 @@ export class KeyAutoAddService {
         'keyId',
       ]);
       this.setTransientStateProgress(intent, {
-        key: 'connectWalletKeyService_text_stepAddKey',
+        key: 'connectWalletKeyService_stepAddKey_text',
         substitutions: [],
       });
       await this.process(
@@ -150,7 +150,7 @@ export class KeyAutoAddService {
         const { stepName, details: err } = message.payload;
         reject(
           new ErrorWithKey(
-            'connectWalletKeyService_error_failed',
+            'connectWalletKeyService_failed_error',
             [
               stepName,
               isErrorWithKey(err.error) ? this.t(err.error) : err.message,
@@ -326,5 +326,5 @@ function walletAddressToProvider(walletAddress: WalletInfo): string {
       return 'https://wallet.gatehub.net/#/wallets/';
   }
 
-  throw new ErrorWithKey('connectWalletKeyService_error_notImplemented');
+  throw new ErrorWithKey('connectWalletKeyService_notImplemented_error');
 }

--- a/src/background/services/monetization.ts
+++ b/src/background/services/monetization.ts
@@ -326,9 +326,9 @@ export class MonetizationService {
     const payableSessions = paymentManager.payableSessions;
     if (!payableSessions.length) {
       if (paymentManager.enabledSessions.length) {
-        throw new ErrorWithKey('pay_error_invalidReceivers');
+        throw new ErrorWithKey('pay_invalidReceivers_error');
       }
-      throw new ErrorWithKey('pay_error_notMonetized');
+      throw new ErrorWithKey('pay_notMonetized_error');
     }
 
     const amountToSend = BigInt(

--- a/src/background/services/outgoingPaymentGrant.ts
+++ b/src/background/services/outgoingPaymentGrant.ts
@@ -259,7 +259,7 @@ export class OutgoingPaymentGrantService {
       return { grant, nonce };
     } catch (error) {
       if (isInvalidClientError(error)) {
-        throw new ErrorWithKey('connectWallet_error_invalidClient');
+        throw new ErrorWithKey('connectWallet_invalidClient_error');
       }
       throw error;
     }

--- a/src/background/services/paymentManager.ts
+++ b/src/background/services/paymentManager.ts
@@ -312,17 +312,17 @@ export class PaymentManager {
       const isPollingLimitReached = pollingErrors.some(
         (err) =>
           (isErrorWithKey(err) &&
-            err.key === 'pay_warn_outgoingPaymentPollingIncomplete') ||
+            err.key === 'pay_outgoingPaymentPollingIncomplete_warn') ||
           isAbortSignalTimeout(err),
       );
 
       if (isNotEnoughFunds) {
-        throw new ErrorWithKey('pay_error_notEnoughFunds');
+        throw new ErrorWithKey('pay_notEnoughFunds_error');
       }
       if (isPollingLimitReached) {
-        throw new ErrorWithKey('pay_warn_outgoingPaymentPollingIncomplete');
+        throw new ErrorWithKey('pay_outgoingPaymentPollingIncomplete_warn');
       }
-      throw new ErrorWithKey('pay_error_general');
+      throw new ErrorWithKey('pay_error');
     }
 
     return { sentAmount, debitAmount, outgoingPayments };

--- a/src/background/services/paymentSession.ts
+++ b/src/background/services/paymentSession.ts
@@ -507,7 +507,7 @@ export class PaymentSession {
           outgoingPayment.failed &&
           outgoingPayment.sentAmount.value === '0'
         ) {
-          throw new ErrorWithKey('pay_error_outgoingPaymentFailed');
+          throw new ErrorWithKey('pay_outgoingPaymentFailed_error');
         }
         if (
           outgoingPayment.debitAmount.value === outgoingPayment.sentAmount.value
@@ -539,7 +539,7 @@ export class PaymentSession {
       }
     }
 
-    throw new ErrorWithKey('pay_warn_outgoingPaymentPollingIncomplete');
+    throw new ErrorWithKey('pay_outgoingPaymentPollingIncomplete_warn');
   }
 
   /**

--- a/src/background/services/tabEvents.ts
+++ b/src/background/services/tabEvents.ts
@@ -216,7 +216,7 @@ export class TabEvents {
       iconData = continuousPaymentsEnabled
         ? ICONS.enabled_warn
         : ICONS.disabled_warn;
-      const tabStateText = this.t('icon_state_actionRequired');
+      const tabStateText = this.t('icon_actionRequired_text');
       title = `${title} - ${tabStateText}`;
     } else if (
       tabInfo.status !== 'monetized' &&
@@ -235,8 +235,8 @@ export class TabEvents {
           : ICONS.disabled_noLinks;
       }
       const tabStateText = isTabMonetized
-        ? this.t('icon_state_monetizationActive')
-        : this.t('icon_state_monetizationInactive');
+        ? this.t('icon_monetizationActive_text')
+        : this.t('icon_monetizationInactive_text');
       title = `${title} - ${tabStateText}`;
     }
 

--- a/src/background/services/wallet.ts
+++ b/src/background/services/wallet.ts
@@ -113,10 +113,10 @@ export class WalletService {
     const isKeyAdded = await isKeyAddedToWallet(walletAddress.id, keyId);
     if (!isKeyAdded) {
       if (!autoKeyAdd) {
-        throw new ErrorWithKey('connectWallet_error_invalidClient');
+        throw new ErrorWithKey('connectWallet_invalidClient_error');
       }
       if (!KeyAutoAddService.supports(walletAddress)) {
-        throw new ErrorWithKey('connectWalletKeyService_error_notImplemented');
+        throw new ErrorWithKey('connectWalletKeyService_notImplemented_error');
       }
     }
 
@@ -126,7 +126,7 @@ export class WalletService {
     if (!isKeyAdded && autoKeyAdd) {
       try {
         this.setConnectStateProgress('connect', {
-          key: 'connectWalletKeyService_text_stepAddKey',
+          key: 'connectWalletKeyService_stepAddKey_text',
           substitutions: [],
         });
         await closeAppTabs(this.browser);
@@ -167,7 +167,7 @@ export class WalletService {
       await closeAppTabs(this.browser);
 
       this.setConnectStateProgress('connect', {
-        key: 'connectWallet_text_stepAcceptGrant',
+        key: 'connectWallet_stepAcceptGrant_text',
         substitutions: [],
       });
       await this.outgoingPaymentGrantService.completeOutgoingPaymentGrant(
@@ -226,7 +226,7 @@ export class WalletService {
       throw new Error('reconnectWallet_error_walletAddressMissing');
     }
     if (!KeyAutoAddService.supports(walletAddress)) {
-      throw new ErrorWithKey('connectWalletKeyService_error_notImplemented');
+      throw new ErrorWithKey('connectWalletKeyService_notImplemented_error');
     }
 
     this.setConnectStateProgress('reconnect', 'Reconnecting wallet');
@@ -266,7 +266,7 @@ export class WalletService {
       }
 
       if (isInvalidClientError(error)) {
-        throw new ErrorWithKey('connectWallet_error_invalidClient');
+        throw new ErrorWithKey('connectWallet_invalidClient_error');
       }
       throw error;
     }
@@ -296,7 +296,7 @@ export class WalletService {
       if (force) return;
 
       if (isOpenPaymentsClientError(err)) {
-        throw new ErrorWithKey('disconnectWallet_error_generic', [
+        throw new ErrorWithKey('disconnectWallet_error', [
           err.status ? `HTTP ${err.status} - ${err.message}` : err.message,
         ]);
       }
@@ -498,7 +498,7 @@ export class WalletService {
       await this.outgoingPaymentGrantService.rotateToken();
     } catch (error) {
       if (isInvalidClientError(error)) {
-        throw new Error('connectWallet_error_invalidClient', { cause: error });
+        throw new Error('connectWallet_invalidClient_error', { cause: error });
       }
       throw error;
     }

--- a/src/content/keyAutoAdd/fynbos.ts
+++ b/src/content/keyAutoAdd/fynbos.ts
@@ -27,13 +27,13 @@ const waitForLogin: Run<void> = async (
     setNotificationSize('fullscreen');
   } catch (error) {
     if (isTimedOut(error)) {
-      throw new ErrorWithKey('connectWalletKeyService_error_timeoutLogin');
+      throw new ErrorWithKey('connectWalletKeyService_timeoutLogin_error');
     }
     throw new Error(error);
   }
 
   if (alreadyLoggedIn) {
-    skip(errorWithKey('connectWalletKeyService_error_skipAlreadyLoggedIn'));
+    skip(errorWithKey('connectWalletKeyService_skipAlreadyLoggedIn_error'));
   }
 };
 
@@ -56,7 +56,7 @@ const findWallet: Run<void> = async (
 
   const data = decodeReactRouterData<IndexRouteData>(rawData);
   if (data?.['routes/_index']?.data?.walletInfo?.url !== walletAddressUrl) {
-    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
+    throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error');
   }
 };
 

--- a/src/content/keyAutoAdd/gatehub.ts
+++ b/src/content/keyAutoAdd/gatehub.ts
@@ -40,13 +40,13 @@ const waitForLogin: Run<void> = async (
     setNotificationSize('fullscreen');
   } catch (error) {
     if (isTimedOut(error)) {
-      throw new ErrorWithKey('connectWalletKeyService_error_timeoutLogin');
+      throw new ErrorWithKey('connectWalletKeyService_timeoutLogin_error');
     }
     throw new Error(error);
   }
 
   if (alreadyLoggedIn) {
-    skip(errorWithKey('connectWalletKeyService_error_skipAlreadyLoggedIn'));
+    skip(errorWithKey('connectWalletKeyService_skipAlreadyLoggedIn_error'));
   }
 };
 
@@ -57,7 +57,7 @@ const findWallet: Run<void> = async (
   setNotificationSize('fullscreen');
   const wallets = await getUserWallets();
   if (!wallets.length) {
-    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+    throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error', [
       'No active wallet found',
     ]);
   }
@@ -73,7 +73,7 @@ const findWallet: Run<void> = async (
     if (walletBelongsToUser) return; // ok
   }
 
-  throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
+  throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error');
 };
 
 const addKey: Run<void> = async ({ nickName, walletAddressUrl, publicKey }) => {

--- a/src/content/keyAutoAdd/lib/helpers/gatehub.ts
+++ b/src/content/keyAutoAdd/lib/helpers/gatehub.ts
@@ -84,7 +84,7 @@ export async function getUserPaymentPointers(wallet: {
 
 function handleError(error: unknown): never {
   if (error instanceof GraphQlError) {
-    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound', [
+    throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error', [
       error.message,
     ]);
   }

--- a/src/content/keyAutoAdd/mmaon.ts
+++ b/src/content/keyAutoAdd/mmaon.ts
@@ -25,13 +25,13 @@ const waitForLogin: Run<void> = async (
     setNotificationSize('fullscreen');
   } catch (error) {
     if (isTimedOut(error)) {
-      throw new ErrorWithKey('connectWalletKeyService_error_timeoutLogin');
+      throw new ErrorWithKey('connectWalletKeyService_timeoutLogin_error');
     }
     throw new Error(error);
   }
 
   if (alreadyLoggedIn) {
-    skip(errorWithKey('connectWalletKeyService_error_skipAlreadyLoggedIn'));
+    skip(errorWithKey('connectWalletKeyService_skipAlreadyLoggedIn_error'));
   }
 };
 
@@ -49,7 +49,7 @@ const findWallet: Run<void> = async (
   const accountInfo: { address: string } = await res.json();
 
   if (accountInfo.address !== accountAddress) {
-    throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
+    throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error');
   }
 };
 

--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -51,13 +51,13 @@ const waitForLogin: Run<void> = async (
     setNotificationSize('fullscreen');
   } catch (error) {
     if (isTimedOut(error)) {
-      throw new ErrorWithKey('connectWalletKeyService_error_timeoutLogin');
+      throw new ErrorWithKey('connectWalletKeyService_timeoutLogin_error');
     }
     throw new Error(error);
   }
 
   if (alreadyLoggedIn) {
-    skip(errorWithKey('connectWalletKeyService_error_skipAlreadyLoggedIn'));
+    skip(errorWithKey('connectWalletKeyService_skipAlreadyLoggedIn_error'));
   }
 };
 
@@ -136,7 +136,7 @@ const findWallet: Run<{ accountId: string; walletId: string }> = async (
       }
     }
   }
-  throw new ErrorWithKey('connectWalletKeyService_error_accountNotFound');
+  throw new ErrorWithKey('connectWalletKeyService_accountNotFound_error');
 };
 
 const addKey: Run<void> = async ({ publicKey, nickName }, { output }) => {

--- a/src/pages/app/pages/PostConnect.tsx
+++ b/src/pages/app/pages/PostConnect.tsx
@@ -146,19 +146,19 @@ function mapSuccessMessage(
   const SUCCESS_MSGS: Record<WalletStatus['intent'], MessageContent> = {
     connect: {
       heading: t('postConnect_connect_success_title'),
-      info: t('postConnect_connect_success_msg'),
+      info: t('postConnect_connect_success_text'),
     },
     add_funds: {
       heading: t('postConnect_addFunds_success_title'),
-      info: t('postConnect_addFunds_success_msg'),
+      info: t('postConnect_addFunds_success_text'),
     },
     update_budget: {
       heading: t('postConnect_updateBudget_success_title'),
-      info: t('postConnect_updateBudget_success_msg'),
+      info: t('postConnect_updateBudget_success_text'),
     },
     reconnect: {
       heading: t('postConnect_reconnect_success_title'),
-      info: t('postConnect_reconnect_success_msg'),
+      info: t('postConnect_reconnect_success_text'),
     },
   };
   return SUCCESS_MSGS[status.intent];
@@ -182,19 +182,19 @@ function mapCancelMessage(
     connect: {
       grant_rejected: {
         heading: t('postConnect_connect_cancel_grantRejected_title'),
-        info: t('postConnect_connect_cancel_grantRejected_msg'),
+        info: t('postConnect_connect_cancel_grantRejected_text'),
       },
     },
     add_funds: {
       grant_rejected: {
         heading: t('postConnect_addFunds_cancel_grantRejected_title'),
-        info: t('postConnect_addFunds_cancel_grantRejected_msg'),
+        info: t('postConnect_addFunds_cancel_grantRejected_text'),
       },
     },
     update_budget: {
       grant_rejected: {
         heading: t('postConnect_updateBudget_cancel_grantRejected_title'),
-        info: t('postConnect_updateBudget_cancel_grantRejected_msg'),
+        info: t('postConnect_updateBudget_cancel_grantRejected_text'),
       },
     },
     reconnect: {
@@ -221,7 +221,7 @@ function mapFailureMessage(
       if (code === 'timeout') {
         return {
           heading: t('postConnect_connect_failure_timeout_title'),
-          info: t('postConnect_connect_failure_timeout_msg'),
+          info: t('postConnect_connect_failure_timeout_text'),
         };
       }
       if (code === 'key_add_failed') {
@@ -230,21 +230,21 @@ function mapFailureMessage(
           : details?.message;
         return {
           heading: t('postConnect_connect_failure_keyAdd_title'),
-          info: t('postConnect_connect_failure_keyAdd_msg', [
+          info: t('postConnect_connect_failure_keyAdd_text', [
             infoPlus ? `\n${infoPlus}` : '',
           ]),
         };
       }
       return {
         heading: t('postConnect_connect_failure_other_title'),
-        info: t('postConnect_connect_failure_other_msg'),
+        info: t('postConnect_connect_failure_other_text'),
       };
     },
     add_funds(code, details) {
       if (code === 'timeout') {
         return {
           heading: t('postConnect_addFunds_failure_timeout_title'),
-          info: t('postConnect_addFunds_failure_timeout_msg'),
+          info: t('postConnect_addFunds_failure_timeout_text'),
         };
       }
       const infoPlus = isErrorWithKey(details)
@@ -252,7 +252,7 @@ function mapFailureMessage(
         : details?.message;
       return {
         heading: t('postConnect_addFunds_failure_other_title'),
-        info: t('postConnect_addFunds_failure_other_msg', [
+        info: t('postConnect_addFunds_failure_other_text', [
           infoPlus ? `\n${infoPlus}` : '',
         ]),
       };
@@ -264,21 +264,21 @@ function mapFailureMessage(
           : details?.message;
         return {
           heading: t('postConnect_reconnect_failure_keyAdd_title'),
-          info: t('postConnect_reconnect_failure_keyAdd_msg', [
+          info: t('postConnect_reconnect_failure_keyAdd_text', [
             infoPlus ? `\n${infoPlus}` : '',
           ]),
         };
       }
       return {
         heading: t('postConnect_reconnect_failure_other_title'),
-        info: t('postConnect_reconnect_failure_other_msg'),
+        info: t('postConnect_reconnect_failure_other_text'),
       };
     },
     update_budget(code, details) {
       if (code === 'timeout') {
         return {
           heading: t('postConnect_updateBudget_failure_timeout_title'),
-          info: t('postConnect_updateBudget_failure_timeout_msg'),
+          info: t('postConnect_updateBudget_failure_timeout_text'),
         };
       }
       const infoPlus = isErrorWithKey(details)
@@ -286,7 +286,7 @@ function mapFailureMessage(
         : details?.message;
       return {
         heading: t('postConnect_updateBudget_failure_other_title'),
-        info: t('postConnect_updateBudget_failure_other_msg', [
+        info: t('postConnect_updateBudget_failure_other_text', [
           infoPlus ? `\n${infoPlus}` : '',
         ]),
       };

--- a/src/pages/app/pages/PostInstall.tsx
+++ b/src/pages/app/pages/PostInstall.tsx
@@ -48,10 +48,10 @@ const Header = () => {
         alt=""
       />
       <p className="text-xl font-bold text-secondary-dark landscape:mb-2 landscape:text-3xl landscape:2xl:mb-3 landscape:2xl:text-4xl">
-        {t('tagline_text_1')}
+        {t('tagline_text__1')}
       </p>
       <p className="text-xl font-light text-secondary-dark landscape:text-3xl landscape:2xl:text-4xl">
-        {t('tagline_text_2')}
+        {t('tagline_text__2')}
       </p>
     </div>
   );
@@ -68,7 +68,7 @@ const Main = () => {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 rounded-lg sm:border border-gray-200 sm:bg-gray-50/75 p-3 sm:shadow-md backdrop-blur-0 sm:p-8">
       <h2 className="rounded-2xl bg-gray-100 p-4 text-center text-lg font-medium">
-        {t('postInstall_text_title')}
+        {t('postInstall_title')}
       </h2>
 
       <Steps />
@@ -189,13 +189,13 @@ const Steps = () => {
               className="group pr-1 text-primary outline-current hover:underline"
               onClick={(ev) => ev.stopPropagation()}
             >
-              {t('postInstall_text_stepGetWallet_title')}{' '}
+              {t('postInstall_stepGetWallet_title')}{' '}
               <ExternalIcon className="inline-block size-4 align-baseline transition-transform hover:scale-125 group-focus:scale-125" />
             </a>
           </React.Fragment>
         }
       >
-        <p>{t('postInstall_text_stepGetWallet_desc')}</p>
+        <p>{t('postInstall_stepGetWallet_desc')}</p>
         <div
           className={cn(
             'grid gap-4 justify-center mt-4 mx-auto group/wallet',
@@ -227,7 +227,7 @@ const Steps = () => {
           ))}
         </div>
         <p className="text-slate-400 text-sm text-right">
-          {t('postInstall_text_stepGetWallet_comingSoon')}
+          {t('postInstall_stepGetWallet_comingSoon_text')}
         </p>
       </Step>
 
@@ -236,7 +236,7 @@ const Steps = () => {
         index={1}
         open={isOpen === STEP_ID[1]}
         onClick={onClick}
-        title={t('postInstall_text_stepWalletAddress_title')}
+        title={t('postInstall_stepWalletAddress_title')}
       >
         <picture>
           <source
@@ -259,12 +259,12 @@ const Steps = () => {
           index={2}
           open={isOpen === STEP_ID[2]}
           onClick={onClick}
-          title={t('postInstall_text_stepPin_title')}
+          title={t('postInstall_stepPin_title')}
         >
           <p>
-            {t('postInstall_text_stepPin_desc')}
+            {t('postInstall_stepPin_desc')}
             {isPinnedToToolbar && (
-              <span> {t('postInstall_text_stepPin_descComplete')}</span>
+              <span> {t('postInstall_stepPin_complete_text')}</span>
             )}
           </p>
           <img
@@ -288,13 +288,13 @@ const Steps = () => {
           index={3}
           open={isOpen === STEP_ID[3]}
           onClick={onClick}
-          title={t('postInstall_text_stepPermissions_title')}
+          title={t('postInstall_stepPermissions_title')}
         >
           <p>
-            {t('missingHostPermission_state_text')}{' '}
+            {t('missingHostPermission_text')}{' '}
             {hasAllHostsPermission ? (
               <span className="text-secondary-dark">
-                {t('postInstall_text_stepPermissions_descComplete')}
+                {t('postInstall_stepPermissions_complete_text')}
               </span>
             ) : (
               <button
@@ -302,7 +302,7 @@ const Steps = () => {
                 className="block w-fit rounded-md bg-orange-100 px-2 py-1.5 mt-1 font-medium text-orange-800 hover:bg-orange-200 focus:bg-orange-200 focus:outline-hidden hover:shadow-md focus:shadow-md"
                 onClick={() => requestAllHostsPermission(browser)}
               >
-                {t('postInstall_action_stepPermissions_grant')}
+                {t('postInstall_stepPermissions_grant_action')}
               </button>
             )}
           </p>
@@ -315,7 +315,7 @@ const Steps = () => {
         index={isSafari ? 4 : isFirefoxAndroid ? 2 : 3}
         open={isOpen === STEP_ID[4]}
         onClick={onClick}
-        title={t('postInstall_action_submit')}
+        title={t('postInstall_submit_action')}
         highlighted={focusConnect}
       >
         <StepConnectWallet selectedWallet={selectedWallet} />
@@ -467,10 +467,10 @@ function StepConnectWallet({
     return (
       <div className="text-center pt-4 pb-8">
         <p className="font-medium text-secondary-dark landscape:mb-2 landscape:text-xl landscape:2xl:mb-3 landscape:2xl:text-xl">
-          {t('postInstall_text_wallet_connected_1')}
+          {t('postInstall_walletConnected_text__1')}
         </p>
         <p className="text-secondary-dark landscape:text-xl landscape:2xl:text-xl">
-          {t('postInstall_text_wallet_connected_2')}
+          {t('postInstall_walletConnected_text__2')}
         </p>
       </div>
     );

--- a/src/pages/app/pages/PostInstallConsent.tsx
+++ b/src/pages/app/pages/PostInstallConsent.tsx
@@ -35,7 +35,7 @@ const Header = () => {
         alt=""
       />
       <h1 className="text-2xl font-bold text-secondary-dark landscape:mb-2 landscape:text-3xl landscape:2xl:mb-3 landscape:2xl:text-4xl">
-        {t('postInstallConsent_text_title')}
+        {t('postInstallConsent_title')}
       </h1>
     </header>
   );
@@ -49,8 +49,8 @@ const Main = () => {
     <main className="mx-auto w-full max-w-3xl p-3 sm:p-8">
       <div className="space-y-4 mb-48">
         <div className="space-y-1">
-          <p>{t('postInstallConsent_text_header1')}</p>
-          <p>{t('postInstallConsent_text_header2')}</p>
+          <p>{t('postInstallConsent_header_text__1')}</p>
+          <p>{t('postInstallConsent_header_text__2')}</p>
         </div>
 
         <DataShared />
@@ -72,28 +72,28 @@ function DataShared() {
   return (
     <div className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
-        {t('postInstallConsent_text_dataShared_title')}
+        {t('postInstallConsent_dataShared_title')}
       </h3>
       <div className="space-y-1">
         <h4 className="font-medium text-lg">
-          {t('postInstallConsent_text_dataShared_yourWallet_title')}
+          {t('postInstallConsent_dataShared_yourWallet_title')}
         </h4>
-        <p>{t('postInstallConsent_text_dataShared_yourWallet_wa')}</p>
-        <p>{t('postInstallConsent_text_dataShared_yourWallet_keyConsent')}</p>
+        <p>{t('postInstallConsent_dataShared_yourWallet_wa_text')}</p>
+        <p>{t('postInstallConsent_dataShared_yourWallet_keyConsent_text')}</p>
       </div>
 
       <div className="space-y-1">
         <h4 className="font-medium text-lg">
-          {t('postInstallConsent_text_dataShared_websiteWallets_title')}
+          {t('postInstallConsent_dataShared_websiteWallets_title')}
         </h4>
-        <p>{t('postInstallConsent_text_dataShared_websiteWallets_wa')}</p>
+        <p>{t('postInstallConsent_dataShared_websiteWallets_wa_text')}</p>
       </div>
 
       <div className="space-y-1">
         <h4 className="font-medium text-lg">
-          {t('postInstallConsent_text_dataShared_websites_title')}
+          {t('postInstallConsent_dataShared_websites_title')}
         </h4>
-        <p>{t('postInstallConsent_text_dataShared_websites_text')}</p>
+        <p>{t('postInstallConsent_dataShared_websites_desc')}</p>
       </div>
     </div>
   );
@@ -104,12 +104,12 @@ function DataSharedBrowser() {
   return (
     <div className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
-        {t('postInstallConsent_text_dataShared_browser_title')}
+        {t('postInstallConsent_dataShared_browser_title')}
       </h3>
       <p>
-        {t('postInstallConsent_text_dataShared_browser_text')}{' '}
+        {t('postInstallConsent_dataShared_browser_desc')}{' '}
         <InformationTooltip
-          text={t('postInstallConsent_text_dataShared_headers')}
+          text={t('postInstallConsent_dataShared_headers_text')}
         />
       </p>
     </div>
@@ -137,33 +137,33 @@ function Telemetry({ ref }: { ref: TelemetryConsentRef }) {
   return (
     <form className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
-        {t('postInstallConsent_text_dataCollection_title')}
+        {t('postInstallConsent_dataCollection_title')}
       </h3>
-      <p>{t('postInstallConsent_text_dataCollection_desc')}</p>
+      <p>{t('postInstallConsent_dataCollection_desc')}</p>
 
       <div className="space-y-1">
         <h4 className="font-medium text-lg">
-          {t('postInstallConsent_text_dataCollection_yes_heading')}
+          {t('postInstallConsent_dataCollection_yes_heading')}
         </h4>
         <ul className="list-disc ml-4">
           <li>
             {replaceWithJSX(
-              t('postInstallConsent_text_dataCollection_yes_text1'),
+              t('postInstallConsent_dataCollection_yes_text__1'),
               /\bPostHog\b/,
               linkToPostHog,
             )}
           </li>
-          <li>{t('postInstallConsent_text_dataCollection_yes_text2')}</li>
+          <li>{t('postInstallConsent_dataCollection_yes_text__2')}</li>
         </ul>
       </div>
 
       <div className="space-y-1">
         <h4 className="font-medium text-lg">
-          {t('postInstallConsent_text_dataCollection_no_heading')}
+          {t('postInstallConsent_dataCollection_no_heading')}
         </h4>
         <ul className="list-disc ml-4">
-          <li>{t('postInstallConsent_text_dataCollection_no_text1')}</li>
-          <li>{t('postInstallConsent_text_dataCollection_no_text2')}</li>
+          <li>{t('postInstallConsent_dataCollection_no_text__1')}</li>
+          <li>{t('postInstallConsent_dataCollection_no_text__2')}</li>
         </ul>
       </div>
 
@@ -171,7 +171,7 @@ function Telemetry({ ref }: { ref: TelemetryConsentRef }) {
         htmlFor="consent-field-telemetry"
         className="my-6 font-medium text-lg flex items-center gap-4"
       >
-        <span>{t('postInstallConsent_label_dataCollection_optIn')}</span>
+        <span>{t('postInstallConsent_dataCollection_optIn_label')}</span>
         <SwitchButton
           form="consent-form"
           id="consent-field-telemetry"
@@ -183,7 +183,7 @@ function Telemetry({ ref }: { ref: TelemetryConsentRef }) {
         />
       </label>
 
-      <p>{t('postInstallConsent_text_dataCollection_footer')}</p>
+      <p>{t('postInstallConsent_dataCollection_footer')}</p>
     </form>
   );
 }
@@ -193,17 +193,17 @@ function Permissions() {
   return (
     <div className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
-        {t('postInstallConsent_text_permissions_title')}
+        {t('postInstallConsent_permissions_title')}
       </h3>
       <p>
-        {t('postInstallConsent_text_permissions_text')}{' '}
+        {t('postInstallConsent_permissions_text')}{' '}
         <a
           href="https://github.com/interledger/web-monetization-extension/blob/main/docs/PERMISSIONS.md"
           className="group pr-1 text-primary outline-current hover:underline"
           target="_blank"
           rel="noreferrer noopener"
         >
-          {t('postInstallConsent_text_permissions_linkText')}
+          {t('postInstallConsent_permissions_link_text')}
         </a>
       </p>
     </div>
@@ -254,7 +254,7 @@ function AcceptForm({
       return (
         <div className="max-w-2xl flex gap-2" role="alert">
           <InfoCircle className="size-6 flex-shrink-0" />
-          <p>{t('postInstallConsent_state_consentProvided')}</p>
+          <p>{t('postInstallConsent_consentProvided_text')}</p>
         </div>
       );
     }
@@ -268,10 +268,10 @@ function AcceptForm({
     >
       <label className="flex gap-2 items-start">
         <input type="checkbox" required className="rounded-xs mt-1" />
-        <span className="">{t('postInstallConsent_text_confirmation')}</span>
+        <span className="">{t('postInstallConsent_confirmation')}</span>
       </label>
       <Button type="submit" className="w-full sm:w-auto">
-        {t('postInstallConsent_action_confirm')}
+        {t('postInstallConsent_confirm_action')}
       </Button>
     </form>
   );

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -220,7 +220,7 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
           await handleSubmit();
         }}
         onDecline={() => {
-          const error = errorWithKey('connectWalletKeyService_error_noConsent');
+          const error = errorWithKey('connectWalletKeyService_noConsent_error');
           setErrors({ keyPair: toErrorInfo(error) });
           setShowConsent(false);
         }}
@@ -239,10 +239,10 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
 
       <div className={cn(!!errors.connect && 'sr-only')}>
         <h2 className="text-center text-lg text-strong">
-          {t('connectWallet_text_title')}
+          {t('connectWallet_title')}
         </h2>
         <p className="text-center text-sm text-weak">
-          {t('connectWallet_text_desc')}
+          {t('connectWallet_desc')}
         </p>
       </div>
 
@@ -264,7 +264,7 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
 
       <fieldset className="space-y-2">
         <legend className="flex items-center px-2 font-medium leading-6 text-medium">
-          {t('connectWallet_labelGroup_amount')}
+          {t('connectWallet_amount_group_label')}
         </legend>
         <div className="flex gap-y-4 gap-x-6 flex-col @sm:flex-row @sm:items-center">
           <AmountInput
@@ -282,7 +282,7 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
             className="flex items-center gap-x-4 px-2"
           >
             <span className="font-medium text-medium @sm:font-normal grow @sm:grow-0 @sm:order-last">
-              {t('connectWallet_label_recurring')}
+              {t('connectWallet_recurring_label')}
             </span>
             <SwitchButton
               id="connectRecurring"
@@ -306,14 +306,14 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
       {showManualKeyCopy && (
         <ManualKeyPairNeeded
           error={{
-            message: t('connectWallet_error_failedAutoKeyAdd'),
+            message: t('connectWallet_failedAutoKeyAdd_error'),
             details: errors.keyPair,
-            whyText: t('connectWallet_error_failedAutoKeyAddWhy'),
+            whyText: t('connectWallet_failedAutoKeyAdd_why_text'),
           }}
           retry={resetState}
           hideError={!errors.keyPair}
-          text={t('connectWallet_label_publicKey')}
-          learnMoreText={t('connectWallet_text_publicKeyLearnMore')}
+          text={t('connectWallet_publicKey_label')}
+          learnMoreText={t('connectWallet_publicKeyLearnMore_text')}
           publicKey={publicKey}
         />
       )}
@@ -333,7 +333,7 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
           loading={isSubmitting}
           loadingText={<ConnectSubmitLoadingText />}
         >
-          {t('connectWallet_action_connect')}
+          {t('connectWallet_connect_action')}
         </Button>
       </div>
     </form>
@@ -556,7 +556,7 @@ function WalletAddressInput({
     <Input
       ref={inputRef}
       type="text"
-      label={t('connectWallet_label_walletAddress')}
+      label={t('connectWallet_walletAddress_label')}
       id="connectWalletAddressUrl"
       placeholder={placeholder}
       errorMessage={error?.message}
@@ -670,7 +670,7 @@ function AmountInput({
     <InputAmount
       ref={inputRef}
       id="connectAmount"
-      label={t('connectWallet_label_amount')}
+      label={t('connectWallet_amount_label')}
       labelHidden={true}
       amount={defaultAmount}
       className="@sm:max-w-48"
@@ -742,27 +742,27 @@ function mapErrorFailure(
 ): ErrorWithKeyLike {
   switch (state.code) {
     case 'timeout':
-      return new ErrorWithKey('connectWallet_error_timeout');
+      return new ErrorWithKey('connectWallet_timeout_error');
     case 'grant_continuation_failed':
-      return new ErrorWithKey('connectWallet_error_continuationFailed');
+      return new ErrorWithKey('connectWallet_continuationFailed_error');
     case 'grant_hash_failed':
-      return new ErrorWithKey('connectWallet_error_hashFailed');
+      return new ErrorWithKey('connectWallet_hashFailed_error');
     case 'grant_invalid':
-      return new ErrorWithKey('connectWallet_error_grantInvalid');
+      return new ErrorWithKey('connectWallet_grantInvalid_error');
     case 'key_add_failed': {
       if (isErrorWithKey(state.details)) {
         return new ErrorWithKey(
-          'connectWalletKeyService_error_failed',
+          'connectWalletKeyService_failed_error',
           deepClone(state.details.substitutions || []),
           deepClone(state.details),
         );
       } else {
-        return new ErrorWithKey('connectWalletKeyService_error_failed');
+        return new ErrorWithKey('connectWalletKeyService_failed_error');
       }
     }
     default:
       // TODO: better error message
-      return new ErrorWithKey('connectWallet_error_invalidClient');
+      return new ErrorWithKey('connectWallet_invalidClient_error');
   }
 }
 
@@ -771,36 +771,36 @@ function mapErrorCancel(
 ): ErrorWithKeyLike {
   switch (state.code) {
     case 'grant_rejected':
-      return new ErrorWithKey('connectWallet_error_grantRejected');
+      return new ErrorWithKey('connectWallet_grantRejected_error');
     case 'tab_closed':
-      return new ErrorWithKey('connectWallet_error_tabClosed');
+      return new ErrorWithKey('connectWallet_tabClosed_error');
     default:
-      return new ErrorWithKey('connectWallet_error_grantRejected'); // TODO: better error for unknown cancel reason
+      return new ErrorWithKey('connectWallet_grantRejected_error'); // TODO: better error for unknown cancel reason
   }
 }
 
 function canRetryAutoKeyAdd(err?: ErrorInfo['info']) {
   if (!err) return false;
   return (
-    err.key === 'connectWalletKeyService_error_noConsent' ||
-    err.cause?.key === 'connectWalletKeyService_error_timeoutLogin' ||
-    err.cause?.key === 'connectWalletKeyService_error_accountNotFound'
+    err.key === 'connectWalletKeyService_noConsent_error' ||
+    err.cause?.key === 'connectWalletKeyService_timeoutLogin_error' ||
+    err.cause?.key === 'connectWalletKeyService_accountNotFound_error'
   );
 }
 
 function validateWalletAddressUrl(value: string): null | ErrorWithKeyLike {
   if (!value) {
-    return errorWithKey('connectWallet_error_urlRequired');
+    return errorWithKey('connectWallet_url_required_error');
   }
   let url: URL;
   try {
     url = new URL(toWalletAddressUrl(value));
   } catch {
-    return errorWithKey('connectWallet_error_urlInvalidUrl');
+    return errorWithKey('connectWallet_url_invalidUrl_error');
   }
 
   if (url.protocol !== 'https:') {
-    return errorWithKey('connectWallet_error_urlInvalidNotHttps');
+    return errorWithKey('connectWallet_url_invalidNotHttps_error');
   }
 
   return null;

--- a/src/pages/popup/components/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/components/ErrorKeyRevoked.tsx
@@ -118,7 +118,7 @@ const MainScreen = ({
       }
       setErrorMsg(msg);
     } else if (state.type === 'cancel' && state.code === 'tab_closed') {
-      const msg = t('connectWallet_error_tabClosed');
+      const msg = t('connectWallet_tabClosed_error');
       setErrorMsg(msg);
     }
   }, [transientState.connect, toErrorInfo, t]);
@@ -140,10 +140,10 @@ const MainScreen = ({
       <div className="flex gap-2 rounded-md bg-error p-2">
         <WarningSign className="size-6 text-error" />
         <h3 className="text-base font-medium text-error">
-          {t('keyRevoked_error_title')}
+          {t('keyRevoked_title')}
         </h3>
       </div>
-      <p className="text-sm text-medium">{t('keyRevoked_error_text')}</p>
+      <p className="text-sm text-medium">{t('keyRevoked_text')}</p>
 
       <FadeInOut
         visible={!!errorMsg}
@@ -154,7 +154,7 @@ const MainScreen = ({
 
       <form className="flex flex-col items-stretch gap-4">
         <Button onClick={() => requestDisconnect()} loading={loading}>
-          {t('keyRevoked_action_disconnect')}
+          {t('keyRevoked_disconnect_action')}
         </Button>
         <Button
           onClick={async () => {
@@ -162,7 +162,7 @@ const MainScreen = ({
             setScreen('consent-reconnect');
           }}
         >
-          {t('keyRevoked_action_reconnect')}
+          {t('keyRevoked_reconnect_action')}
         </Button>
       </form>
     </div>
@@ -250,7 +250,7 @@ const ManualReconnectScreen = ({
       </FadeInOut>
 
       <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
-        {t('keyRevoked_action_reconnectBtn')}
+        {t('keyRevoked_reconnectBtn_action')}
       </Button>
     </FadeInOut>
   );

--- a/src/pages/popup/components/OutOfFunds.tsx
+++ b/src/pages/popup/components/OutOfFunds.tsx
@@ -36,7 +36,7 @@ export const OutOfFunds = ({
       />
       <div className="px-2 text-xs text-medium">
         <p>{t('outOfFunds_error_text')}</p>
-        <p>{t('outOfFunds_error_textHint')}</p>
+        <p>{t('outOfFunds_error_hint_text')}</p>
         {grantRecurring?.value && (
           <p className="mt-1" data-testid="out-of-funds-recurring-info">
             <RecurringAutoRenewInfo
@@ -50,10 +50,10 @@ export const OutOfFunds = ({
       <div className="w-100 h-0.5 bg-disabled" />
 
       <Button onClick={() => onChooseOption(true)}>
-        {t('outOfFunds_action_optionRecurring')}
+        {t('outOfFunds_optionRecurring_action')}
       </Button>
       <Button onClick={() => onChooseOption(false)}>
-        {t('outOfFunds_action_optionOneTime')}
+        {t('outOfFunds_optionOneTime_action')}
       </Button>
     </div>
   );
@@ -110,7 +110,7 @@ export function AddFunds({
     >
       <Input
         type="url"
-        label={t('outOfFundsAddFunds_label_walletAddress')}
+        label={t('outOfFundsAddFunds_walletAddress_label')}
         value={info.id}
         readOnly
         disabled
@@ -119,13 +119,13 @@ export function AddFunds({
       <InputAmount
         id="amount_outOfFunds"
         walletAddress={info}
-        label={t('outOfFundsAddFunds_label_amount')}
+        label={t('outOfFundsAddFunds_amount_label')}
         description={
           recurring
-            ? t('outOfFundsAddFunds_label_amountDescriptionRecurring', [
+            ? t('outOfFundsAddFunds_amount_recurring_desc', [
                 getNextOccurrenceDate('P1M'),
               ])
-            : t('outOfFundsAddFunds_label_amountDescriptionOneTime')
+            : t('outOfFundsAddFunds_amount_oneTime_desc')
         }
         amount={amount}
         placeholder="5.00"
@@ -152,8 +152,8 @@ export function AddFunds({
         loading={isSubmitting}
       >
         {recurring
-          ? t('outOfFundsAddFunds_action_addRecurring')
-          : t('outOfFundsAddFunds_action_addOneTime')}
+          ? t('outOfFundsAddFunds_recurring_action')
+          : t('outOfFundsAddFunds_oneTime_action')}
       </Button>
     </form>
   );
@@ -175,7 +175,7 @@ function RecurringAutoRenewInfo({
     timeStyle: 'short',
   });
 
-  return t('outOfFunds_error_textDoNothing', [
+  return t('outOfFunds_recurringAutoRenew_text', [
     `${currencySymbol}${amount}`,
     renewDateLocalized,
   ]);

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -55,7 +55,7 @@ export const PayWebsiteForm = () => {
     } else {
       setAmount('');
       const { type } = response.payload;
-      setPayStatus({ type, message: t('pay_state_success') });
+      setPayStatus({ type, message: t('pay_success_text') });
       form.current?.reset();
     }
     telemetry.capture('one_time_pay', {
@@ -127,9 +127,9 @@ export const PayWebsiteForm = () => {
         )}
         disabled={isSubmitting || !amount || !!errors.amount}
         loading={isSubmitting}
-        aria-label={t('pay_action_pay')}
+        aria-label={t('pay_action')}
       >
-        {t('pay_action_pay')}
+        {t('pay_action')}
       </Button>
     </form>
   );

--- a/src/pages/popup/components/Settings/RateOfPay.tsx
+++ b/src/pages/popup/components/Settings/RateOfPay.tsx
@@ -125,7 +125,7 @@ export const RateOfPayComponent = ({
       >
         <RateOfPayInput
           id="rateOfPay"
-          label={t('settings_rate_label_inputDefaultRate')}
+          label={t('settings_rate_inputDefaultRate_label')}
           onRateChange={onRateChange}
           rateOfPay={rateOfPay}
           maxRateOfPay={maxRateOfPay}
@@ -153,7 +153,7 @@ export const RateOfPayComponent = ({
           className="w-full font-semibold"
           onClick={() => setEditingSiteRate(true)}
         >
-          {t('settings_rate_label_addException')}
+          {t('settings_rate_addException_action')}
         </Button>
       ) : (
         <Button
@@ -170,7 +170,7 @@ export const RateOfPayComponent = ({
             })
           }
         >
-          {t('settings_rate_label_manageExceptions')}
+          {t('settings_rate_manageExceptions_action')}
         </Button>
       )}
     </div>
@@ -214,7 +214,7 @@ const SiteRateOfPayInput = ({
           htmlFor="rateOfPaySite"
           className="flex items-center px-2 font-medium leading-6 text-medium"
         >
-          {site} ({t('home_text_hourlyRateException')})
+          {site} ({t('home_hourlyRateException_text')})
         </label>
         <button
           onClick={() => onRateChange({ rate: null, hostname })}
@@ -222,7 +222,7 @@ const SiteRateOfPayInput = ({
           className="p-1 text-alt"
         >
           <span className="sr-only">
-            {t('settings_rate_action_removeException')}
+            {t('settings_rate_removeException_action')}
           </span>
           <IconTrash className="size-4" />
         </button>

--- a/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
+++ b/src/pages/popup/components/Settings/RateOfPayManageSites.tsx
@@ -47,7 +47,7 @@ export function RateOfPayManageSites({ highlight }: Props) {
             onClick={() => setIsFormOpen(true)}
           >
             <IconPlus className="size-4 p-0.5" />
-            {t('settings_sitePaymentRates_action_addException')}
+            {t('settings_sitePaymentRates_addException_action')}
           </Button>
         ) : (
           <AddExceptionForm

--- a/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySiteAddException.tsx
@@ -54,7 +54,7 @@ export function AddExceptionForm({
   if (sitesRateOfPay.length === MAX_CUSTOM_RATE_EXCEPTIONS) {
     return (
       <p className="px-3 py-2 rounded-xl bg-error border border-error">
-        {t('settings_sitePaymentRates_maxExceptionsError')}
+        {t('settings_sitePaymentRates_maxExceptions_error')}
       </p>
     );
   }
@@ -67,14 +67,14 @@ export function AddExceptionForm({
     >
       <div className="flex justify-between gap-2">
         <h3 className="font-medium text-secondary">
-          {t('settings_sitePaymentRates_text_formTitle')}
+          {t('settings_sitePaymentRates_form_title')}
         </h3>
         <button
           className="underline text-error"
           type="button"
           onClick={() => onDone()}
         >
-          {t('settings_sitePaymentRates_action_cancel')}
+          {t('settings_sitePaymentRates_cancel_action')}
         </button>
       </div>
 
@@ -97,7 +97,7 @@ export function AddExceptionForm({
         variant="default"
         disabled={!isSiteValid || !isRateValid}
       >
-        {t('settings_sitePaymentRates_action_save')}
+        {t('settings_sitePaymentRates_save_action')}
       </Button>
     </form>
   );
@@ -115,10 +115,10 @@ function SiteInput({
 
   const validate = (val: string): string => {
     if (!val) {
-      return t('settings_sitePaymentRates_inputSite_error_required');
+      return t('settings_sitePaymentRates_inputSite_required_error');
     }
     if (!isValidHostname(val)) {
-      return t('settings_sitePaymentRates_inputSite_error_invalid');
+      return t('settings_sitePaymentRates_inputSite_invalid_error');
     }
     return '';
   };

--- a/src/pages/popup/components/Settings/RateOfPaySitesList.tsx
+++ b/src/pages/popup/components/Settings/RateOfPaySitesList.tsx
@@ -52,7 +52,7 @@ export function SitesList({
   if (!sitesRateOfPay.length) {
     return (
       <p className="text-xs italic text-slate-600">
-        {t('settings_sitePaymentRates_noExceptions')}
+        {t('settings_sitePaymentRates_noExceptions_text')}
       </p>
     );
   }
@@ -125,7 +125,7 @@ function SiteEntry({
       >
         <IconTrash className="size-4" />
         <span className="sr-only">
-          {t('settings_rate_action_removeException')}
+          {t('settings_rate_removeException_action')}
         </span>
       </button>
     </>

--- a/src/pages/popup/components/Settings/SettingsDataCollection.tsx
+++ b/src/pages/popup/components/Settings/SettingsDataCollection.tsx
@@ -51,8 +51,8 @@ export function DataCollectionSettings() {
       </label>
 
       <p className="text-sm">
-        {t('settings_dataCollection_text')}{' '}
-        {t('settings_dataCollection_text_learnMore')}{' '}
+        {t('settings_dataCollection_desc')}{' '}
+        {t('settings_dataCollection_learnMore_text')}{' '}
         <button
           type="button"
           onClick={() =>

--- a/src/pages/popup/pages/ConsentRequired.tsx
+++ b/src/pages/popup/pages/ConsentRequired.tsx
@@ -16,14 +16,14 @@ export default () => {
         <WarningSign className="size-6 text-yellow-700 shrink-0 self-center" />
         <h3 className="text-base font-medium text-yellow-700">
           {isUpdated
-            ? t('consentRequired_text_titleUpdated')
-            : t('consentRequired_text_title')}
+            ? t('consentRequired_updated_title')
+            : t('consentRequired_title')}
         </h3>
       </div>
 
-      <p className="">{t('consentRequired_text_subtitle')}</p>
+      <p className="">{t('consentRequired_subtitle')}</p>
 
-      <p className="pt-2">{t('consentRequired_text_msg')}</p>
+      <p className="pt-2">{t('consentRequired_text')}</p>
 
       <Button
         type="button"
@@ -32,7 +32,7 @@ export default () => {
           message.send('OPEN_APP', { path: '/post-install/consent' })
         }
       >
-        {t('consentRequired_action_primary')}
+        {t('consentRequired_primary_action')}
       </Button>
     </div>
   );

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -35,21 +35,21 @@ export default () => {
   }
 
   if (!enabled) {
-    return <NotMonetized text={t('app_text_disabled')} />;
+    return <NotMonetized text={t('app_disabled_text')} />;
   }
 
   if (tab.status !== 'monetized') {
     switch (tab.status) {
       case 'all_sessions_invalid':
-        return <NotMonetized text={t('notMonetized_text_allInvalid')} />;
+        return <NotMonetized text={t('notMonetized_allInvalid_text')} />;
       case 'internal_page':
-        return <NotMonetized text={t('notMonetized_text_internalPage')} />;
+        return <NotMonetized text={t('notMonetized_internalPage_text')} />;
       case 'new_tab':
-        return <NotMonetized text={t('notMonetized_text_newTab')} />;
+        return <NotMonetized text={t('notMonetized_newTab_text')} />;
       case 'unsupported_scheme':
-        return <NotMonetized text={t('notMonetized_text_unsupportedScheme')} />;
+        return <NotMonetized text={t('notMonetized_unsupportedScheme_text')} />;
       default:
-        return <NotMonetized text={t('notMonetized_text_noLinks')} />;
+        return <NotMonetized text={t('notMonetized_noLinks_text')} />;
     }
   }
 
@@ -91,19 +91,19 @@ const InfoBanner = () => {
   return (
     <div className="grid grid-cols-2 h-40 items-center justify-between gap-2 text-medium">
       <section className="flex flex-col h-full p-3 border border-gray-200 rounded-md">
-        <h3 className="text-sm mb-1">{t('home_title_balance')}</h3>
+        <h3 className="text-sm mb-1">{t('home_balance_title')}</h3>
         <p className="text-4xl font-medium tabular-nums">{remainingBalance}</p>
 
         <Link
           className="mt-auto px-3 py-2 border border-current rounded-lg text-alt font-medium text-sm flex items-center justify-center"
           to="/settings/budget"
         >
-          {t('home_action_manageBudget')}
+          {t('home_manageBudget_action')}
         </Link>
       </section>
 
       <section className="flex flex-col h-full p-3 border border-gray-200 rounded-md">
-        <h3 className="text-sm mb-1">{t('home_title_hourlyRate')}</h3>
+        <h3 className="text-sm mb-1">{t('home_hourlyRate_title')}</h3>
         <p className="flex flex-col gap-1">
           <span
             className={cn(
@@ -116,14 +116,14 @@ const InfoBanner = () => {
             </span>
             <span className="text-xs font-normal">
               {!tab.rateOfPay
-                ? t('home_text_hourlyRateDefault')
-                : t('home_text_hourlyRateException')}
+                ? t('home_hourlyRateDefault_text')
+                : t('home_hourlyRateException_text')}
             </span>
           </span>
 
           {!!tab.rateOfPay && (
             <span className="text-xs font-normal px-2 py-1 rounded-lg bg-slate-50 w-fit">
-              {t('home_text_hourlyRateDefault')}{' '}
+              {t('home_hourlyRateDefault_text')}{' '}
               <span className="tabular-nums">{rate}</span>
             </span>
           )}
@@ -140,8 +140,8 @@ const InfoBanner = () => {
           }
         >
           {hasExceptions
-            ? t('home_action_manageExceptions')
-            : t('home_action_addException')}
+            ? t('home_manageExceptions_action')
+            : t('home_addException_action')}
         </Link>
       </section>
     </div>

--- a/src/pages/popup/pages/MissingHostPermission.tsx
+++ b/src/pages/popup/pages/MissingHostPermission.tsx
@@ -23,7 +23,7 @@ export default () => {
         <div className="ml-3 flex flex-col gap-2">
           <h3 className="font-medium text-orange-800">Permission needed</h3>
           <div className="text-orange-700">
-            <p>{t('missingHostPermission_state_text')}</p>
+            <p>{t('missingHostPermission_text')}</p>
           </div>
         </div>
       </div>

--- a/src/pages/shared/components/AutoKeyAddConsent.tsx
+++ b/src/pages/shared/components/AutoKeyAddConsent.tsx
@@ -6,8 +6,8 @@ import type { TranslationKeys } from '@/shared/helpers';
 type Intent = 'CONNECT_WALLET' | 'RECONNECT_WALLET';
 
 const consentMessage: Record<Intent, TranslationKeys> = {
-  CONNECT_WALLET: 'connectWalletKeyService_text_consentP1',
-  RECONNECT_WALLET: 'reconnectWalletKeyService_text_consentP1',
+  CONNECT_WALLET: 'connectWalletKeyService_consent_text__1',
+  RECONNECT_WALLET: 'reconnectWalletKeyService_consent_text__1',
 };
 
 type Props = {
@@ -32,21 +32,21 @@ export const AutoKeyAddConsent = ({ onAccept, onDecline, intent }: Props) => {
           target="_blank"
           rel="noreferrer"
         >
-          {t('connectWalletKeyService_text_consentLearnMore')}
+          {t('connectWalletKeyService_consentLearnMore_text')}
         </a>
       </p>
 
       <div className="space-y-2 pt-12 text-medium">
-        <p>{t('connectWalletKeyService_text_consentP2')}</p>
-        <p>{t('connectWalletKeyService_text_consentP3')}</p>
+        <p>{t('connectWalletKeyService_consent_text__2')}</p>
+        <p>{t('connectWalletKeyService_consent_text__3')}</p>
       </div>
 
       <div className="mx-auto flex flex-col @sm:flex-row @sm:w-3/4 justify-around gap-4">
         <Button onClick={onAccept}>
-          {t('connectWalletKeyService_label_consentAccept')}
+          {t('connectWalletKeyService_consentAccept_action')}
         </Button>
         <Button onClick={onDecline} variant="destructive">
-          {t('connectWalletKeyService_label_consentDecline')}
+          {t('connectWalletKeyService_consentDecline_action')}
         </Button>
       </div>
     </form>

--- a/src/pages/shared/components/InputAmount.tsx
+++ b/src/pages/shared/components/InputAmount.tsx
@@ -253,19 +253,19 @@ export function validateAmount(
   max?: number,
 ): null | ErrorWithKeyLike {
   if (!value) {
-    return errorWithKey('connectWallet_error_amountRequired');
+    return errorWithKey('connectWallet_amount_required_error');
   }
   const val = Number(value);
   if (Number.isNaN(val)) {
-    return errorWithKey('connectWallet_error_amountInvalidNumber');
+    return errorWithKey('connectWallet_amount_invalidNumber_error');
   }
   if (val < min) {
-    return errorWithKey('connectWallet_error_amountMinimum', [
+    return errorWithKey('connectWallet_amount_minimum_error', [
       formatCurrency(min, walletAddress.assetCode, walletAddress.assetScale),
     ]);
   }
   if (max && val > max) {
-    return errorWithKey('connectWallet_error_amountMaximum', [
+    return errorWithKey('connectWallet_amount_maximum_error', [
       formatCurrency(max, walletAddress.assetCode, walletAddress.assetScale),
     ]);
   }

--- a/src/shared/helpers/i18n.ts
+++ b/src/shared/helpers/i18n.ts
@@ -5,7 +5,7 @@ export type TranslationKeys = keyof typeof Translations;
 
 export type ErrorKeys = Extract<
   TranslationKeys,
-  `${string}_${'error' | 'warn'}_${string}`
+  `${string}_error` | `${string}_warn`
 >;
 
 export interface I18nInfo {

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -34,7 +34,7 @@ test.describe('should fail to connect if:', () => {
 
     await expect(connectButton).toBeDisabled();
     await expect(popup.locator('p.text-error')).toHaveText(
-      i18n.getMessage('connectWallet_error_urlInvalidUrl'),
+      i18n.getMessage('connectWallet_url_invalidUrl_error'),
     );
 
     await expect(background).toHaveStorage({ connected: false });

--- a/tests/e2e/connect.spec.ts
+++ b/tests/e2e/connect.spec.ts
@@ -48,7 +48,7 @@ test('connects with correct details provided', async ({
 
   await page.goto('https://webmonetization.org/play/');
   await expect(popup.locator('h3')).toHaveText(
-    i18n.getMessage('notMonetized_text_noLinks'),
+    i18n.getMessage('notMonetized_noLinks_text'),
   );
 
   await disconnectWallet(popup);

--- a/tests/e2e/connectAutoKeyFynbos.spec.ts
+++ b/tests/e2e/connectAutoKeyFynbos.spec.ts
@@ -70,7 +70,7 @@ test('Connect to Fynbos with automatic key addition when not logged-in to wallet
     ).toBeVisible();
     await popup
       .getByRole('button', {
-        name: i18n.getMessage('connectWalletKeyService_label_consentAccept'),
+        name: i18n.getMessage('connectWalletKeyService_consentAccept_action'),
       })
       .click();
   });

--- a/tests/e2e/connectAutoKeyMmaon.spec.ts
+++ b/tests/e2e/connectAutoKeyMmaon.spec.ts
@@ -56,7 +56,7 @@ test.skip('Connect to MMAON wallet with automatic key addition when not logged-i
 
     await popup
       .getByRole('button', {
-        name: i18n.getMessage('connectWalletKeyService_label_consentAccept'),
+        name: i18n.getMessage('connectWalletKeyService_consentAccept_action'),
       })
       .click();
   });

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -87,7 +87,7 @@ for (const testCase of TEST_CASES) {
         await popup
           .getByRole('button', {
             name: i18n.getMessage(
-              'connectWalletKeyService_label_consentAccept',
+              'connectWalletKeyService_consentAccept_action',
             ),
           })
           .click();

--- a/tests/e2e/not-monetized.spec.ts
+++ b/tests/e2e/not-monetized.spec.ts
@@ -15,10 +15,10 @@ test('shows not-monetized status', async ({
 }) => {
   const warning = popup.getByTestId('not-monetized-message');
   const msg = {
-    newTab: i18n.getMessage('notMonetized_text_newTab'),
-    internalPage: i18n.getMessage('notMonetized_text_internalPage'),
-    unsupportedScheme: i18n.getMessage('notMonetized_text_unsupportedScheme'),
-    noLinks: i18n.getMessage('notMonetized_text_noLinks'),
+    newTab: i18n.getMessage('notMonetized_newTab_text'),
+    internalPage: i18n.getMessage('notMonetized_internalPage_text'),
+    unsupportedScheme: i18n.getMessage('notMonetized_unsupportedScheme_text'),
+    noLinks: i18n.getMessage('notMonetized_noLinks_text'),
   };
 
   const newPage = async () => {

--- a/tests/e2e/out-of-funds.spec.ts
+++ b/tests/e2e/out-of-funds.spec.ts
@@ -99,10 +99,10 @@ for (const testCase of TEST_CASES) {
       const toRecurring = testCase.to.recurring;
 
       const addRecurringButton = popup.getByRole('button', {
-        name: i18n.getMessage('outOfFunds_action_optionRecurring'),
+        name: i18n.getMessage('outOfFunds_optionRecurring_action'),
       });
       const addOneTimeButton = popup.getByRole('button', {
-        name: i18n.getMessage('outOfFunds_action_optionOneTime'),
+        name: i18n.getMessage('outOfFunds_optionOneTime_action'),
       });
 
       const monetizationCallback = await setupPlayground(
@@ -164,7 +164,7 @@ for (const testCase of TEST_CASES) {
 
         await test.step('check add-funds screen', async () => {
           const inputField = popup.getByRole('textbox', {
-            name: i18n.getMessage('outOfFundsAddFunds_label_amount'),
+            name: i18n.getMessage('outOfFundsAddFunds_amount_label'),
           });
           await expect(inputField).toBeVisible();
           await expect(inputField).toHaveValue(initialAmountFormatted);
@@ -185,13 +185,13 @@ for (const testCase of TEST_CASES) {
               { dateStyle: 'medium' },
             );
             const msg = i18n.getMessage(
-              'outOfFundsAddFunds_label_amountDescriptionRecurring',
+              'outOfFundsAddFunds_amount_recurring_desc',
               [nextOccurrenceDate],
             );
             await expect(desc).toHaveText(msg);
           } else {
             const msg = i18n.getMessage(
-              'outOfFundsAddFunds_label_amountDescriptionOneTime',
+              'outOfFundsAddFunds_amount_oneTime_desc',
             );
             await expect(desc).toHaveText(msg);
           }
@@ -202,8 +202,8 @@ for (const testCase of TEST_CASES) {
         await test.step('complete new grant', async () => {
           const submitButton = popup.getByRole('button', {
             name: toRecurring
-              ? i18n.getMessage('outOfFundsAddFunds_action_addRecurring')
-              : i18n.getMessage('outOfFundsAddFunds_action_addOneTime'),
+              ? i18n.getMessage('outOfFundsAddFunds_recurring_action')
+              : i18n.getMessage('outOfFundsAddFunds_oneTime_action'),
           });
           await submitButton.click();
 

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -79,17 +79,17 @@ export async function fillPopup(
 export function getPopupFields(popup: Popup, i18n: BrowserIntl) {
   return {
     walletAddressUrl: popup.getByLabel(
-      i18n.getMessage('connectWallet_label_walletAddress'),
+      i18n.getMessage('connectWallet_walletAddress_label'),
     ),
-    amount: popup.getByLabel(i18n.getMessage('connectWallet_label_amount'), {
+    amount: popup.getByLabel(i18n.getMessage('connectWallet_amount_label'), {
       exact: true,
     }),
     recurring: popup.getByLabel(
-      i18n.getMessage('connectWallet_label_recurring'),
+      i18n.getMessage('connectWallet_recurring_label'),
     ),
     connectButton: popup
       .locator('button')
-      .getByText(i18n.getMessage('connectWallet_action_connect')),
+      .getByText(i18n.getMessage('connectWallet_connect_action')),
   };
 }
 

--- a/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/reconnectAutoKeyTestWallet.spec.ts
@@ -44,7 +44,7 @@ test('Reconnect to test wallet with automatic key addition', async ({
       ).toBeVisible();
       await popup
         .getByRole('button', {
-          name: i18n.getMessage('connectWalletKeyService_label_consentAccept'),
+          name: i18n.getMessage('connectWalletKeyService_consentAccept_action'),
         })
         .click();
     });
@@ -134,7 +134,7 @@ test('Reconnect to test wallet with automatic key addition', async ({
 
   await test.step('asks for key-add consent to reconnect wallet', async () => {
     const reconnectButton = popup.getByRole('button', {
-      name: i18n.getMessage('keyRevoked_action_reconnect'),
+      name: i18n.getMessage('keyRevoked_reconnect_action'),
     });
     await expect(reconnectButton).toBeVisible();
     await reconnectButton.click();
@@ -144,7 +144,7 @@ test('Reconnect to test wallet with automatic key addition', async ({
     ).toBeVisible();
     await popup
       .getByRole('button', {
-        name: i18n.getMessage('connectWalletKeyService_label_consentAccept'),
+        name: i18n.getMessage('connectWalletKeyService_consentAccept_action'),
       })
       .click();
 

--- a/tests/e2e/simple.spec.ts
+++ b/tests/e2e/simple.spec.ts
@@ -133,7 +133,7 @@ test('does not monetize when global payments toggle in unchecked', async ({
       .uncheck({ force: true }); // TODO: remove force; normally this should not be necessary
 
     await expect(popup.getByTestId('not-monetized-message')).toHaveText(
-      i18n.getMessage('app_text_disabled'),
+      i18n.getMessage('app_disabled_text'),
     );
     await expect(background).toHaveStorage({
       continuousPaymentsEnabled: true,
@@ -237,8 +237,8 @@ test.describe('one-time payment', () => {
     });
     await expect(alertMsg).toBeVisible();
     await expect(alertMsg).toHaveEitherText([
-      i18n.getMessage('pay_state_success'),
-      i18n.getMessage('pay_warn_outgoingPaymentPollingIncomplete'),
+      i18n.getMessage('pay_success_text'),
+      i18n.getMessage('pay_outgoingPaymentPollingIncomplete_warn'),
     ]);
   });
 
@@ -264,7 +264,7 @@ test.describe('one-time payment', () => {
 
       await expect(alertMsg).toBeVisible();
       await expect(alertMsg).toHaveText(
-        i18n.getMessage('pay_error_notEnoughFunds'),
+        i18n.getMessage('pay_notEnoughFunds_error'),
       );
 
       await expect(monetizationCallback).toHaveBeenCalledTimes(0);
@@ -294,7 +294,7 @@ test.describe('one-time payment', () => {
 
       await expect(alertMsg).toBeVisible();
       await expect(alertMsg).toHaveText(
-        i18n.getMessage('pay_error_notEnoughFunds'),
+        i18n.getMessage('pay_notEnoughFunds_error'),
       );
 
       await expect(monetizationCallback).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Context

Keys in locales file became inconsistent over time.

## Changes proposed in this pull request

Use this grammar everywhere, no exceptions: `{feature}_{name}_{type}`
- `type` can be one of: title, desc, text, label, action, error, warn. Removed state/msg (folded into text).
- For numbered items: `{name}_{type}__{index}` (double underscore)


Next up: find hardcoded strings in app, and add them to locales file.