### PR TITLE
feat(i18n): basic markup in translation strings, add more strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "date-fns": "^4.4.0",
     "http-message-signatures": "^1.0.6",
     "idb": "^8.0.3",
+    "imd": "npm:@sidvishnoi/imd@^0.0.2",
     "iso8601-duration": "^2.1.4",
     "loglevel": "^1.9.2",
     "posthog-js": "1.396.1",
@@ -59,6 +60,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/webextension-polyfill": "^0.12.5",
+    "@vitest/coverage-v8": "^4.1.10",
     "archiver": "^8.0.0",
     "esbuild": "^0.28.1",
     "esbuild-node-builtin": "^0.1.1",
@@ -73,8 +75,7 @@
     "totp-generator": "2.0.1",
     "typescript": "npm:typescript@^6.0.3",
     "typescript7": "npm:typescript@^7.0.2",
-    "vitest": "^4.1.10",
-    "@vitest/coverage-v8": "^4.1.10"
+    "vitest": "^4.1.10"
   },
   "engines": {
     "pnpm": "^11.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       idb:
         specifier: ^8.0.3
         version: 8.0.3
+      imd:
+        specifier: npm:@sidvishnoi/imd@^0.0.2
+        version: '@sidvishnoi/imd@0.0.2(preact@10.29.2)(react@19.2.7)'
       iso8601-duration:
         specifier: ^2.1.4
         version: 2.1.4
@@ -798,6 +801,18 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@sidvishnoi/imd@0.0.2':
+    resolution: {integrity: sha512-cs0giWaoHVC65BMiQIWKjk21B4TKCCNtTd62zLPUyBy/BP4aDKgYxbXAgmfHCdch9fx2PB957ys8U2yg8XUCYg==}
+    engines: {node: '>=24'}
+    peerDependencies:
+      preact: '>=10'
+      react: '>=18'
+    peerDependenciesMeta:
+      preact:
+        optional: true
+      react:
+        optional: true
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3034,6 +3049,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@sidvishnoi/imd@0.0.2(preact@10.29.2)(react@19.2.7)':
+    optionalDependencies:
+      preact: 10.29.2
+      react: 19.2.7
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ allowBuilds:
   '@actions/github-script@https://codeload.github.com/actions/github-script/tar.gz/3a2844b7e9c422d3c10d287c895573f7108da1b3': true
   core-js: false
   esbuild: false
+
+minimumReleaseAgeExclude:
+  - '@sidvishnoi/imd@0.0.2'

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -482,12 +482,6 @@
   "postConnect_title": {
     "message": "Web Monetization extension"
   },
-  "postConnect_empty_text": {
-    "message": "Nothing to see here"
-  },
-  "postConnect_unmapped_text": {
-    "message": "No mapping from status to messages!!"
-  },
   "postConnect_retry_action": {
     "message": "Try again"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -2,6 +2,7 @@
   "appDescription": {
     "message": "Support content you love. Pay as you browse!"
   },
+  "app_loading_text": { "message": "Loading" },
   "icon_monetizationActive_text": {
     "message": "Active"
   },
@@ -11,11 +12,8 @@
   "icon_actionRequired_text": {
     "message": "Action Required!"
   },
-  "tagline_text__1": {
-    "message": "Support content you love"
-  },
-  "tagline_text__2": {
-    "message": "Pay as you browse"
+  "missingHostPermission_title": {
+    "message": "Permission needed"
   },
   "missingHostPermission_text": {
     "message": "Permission to access your data on all websites is required to use Web Monetization."
@@ -40,6 +38,29 @@
     "message": "The extension is disabled. Click the power icon above to enable the extension and continue making payments."
   },
 
+  "tagline_text__1": {
+    "message": "Support content you love"
+  },
+  "tagline_text__2": {
+    "message": "Pay as you browse"
+  },
+
+  "header_brand_text": {
+    "message": "Web Monetization"
+  },
+  "header_back_action": {
+    "message": "Back"
+  },
+  "header_settings_action": {
+    "message": "Settings"
+  },
+  "header_togglePayments_disable_action": {
+    "message": "Disable extension"
+  },
+  "header_togglePayments_enable_action": {
+    "message": "Enable extension"
+  },
+
   "home_balance_title": {
     "message": "Balance"
   },
@@ -61,6 +82,12 @@
   "home_hourlyRateDefault_text": {
     "message": "default"
   },
+  "home_hourlyRateDefaultRate_text": {
+    "message": "default <span>$RATE$</span>",
+    "placeholders": {
+      "RATE": { "content": "$1", "example": "$2.05" }
+    }
+  },
 
   "keyRevoked_title": {
     "message": "Unauthorized access to the wallet."
@@ -76,6 +103,18 @@
   },
   "keyRevoked_reconnectBtn_action": {
     "message": "Reconnect"
+  },
+  "keyRevoked_unknown_error": {
+    "message": "Unknown error"
+  },
+  "keyRevoked_reconnecting_text": {
+    "message": "Reconnecting to wallet: <span>$ID$</span>",
+    "placeholders": {
+      "ID": { "content": "$1", "example": "https://wallet.example.com/alice" }
+    }
+  },
+  "keyRevoked_copyKey_text": {
+    "message": "*Before* you reconnect, copy the public key below and add it to your wallet."
   },
 
   "disconnectWallet_error": {
@@ -110,6 +149,12 @@
   },
   "pay_success_text": {
     "message": "Thank you for your support!"
+  },
+  "pay_amount_label": {
+    "message": "Support <span>$URL$</span>",
+    "placeholders": {
+      "URL": { "content": "$1", "example": "example.com" }
+    }
   },
 
   "outOfFunds_error_title": {
@@ -175,13 +220,13 @@
     "message": "Renew monthly"
   },
   "connectWallet_publicKey_label": {
-    "message": "Please copy this key, paste it manually into your wallet, and then connect."
-  },
-  "connectWallet_publicKeyLearnMore_text": {
-    "message": "Learn more."
+    "message": "Please copy this key, paste it manually into your wallet, and then connect. [Learn more](https://webmonetization.org/supporters/get-started/#resolve-a-key-addition-failure)."
   },
   "connectWallet_connect_action": {
     "message": "Connect"
+  },
+  "connectWallet_retry_action": {
+    "message": "Try again?"
   },
   "connectWallet_stepAcceptGrant_text": {
     "message": "Waiting for your approval"
@@ -241,16 +286,11 @@
   "connectWallet_grantInvalid_error": {
     "message": "Connection failed. Please try again."
   },
-
   "connectWalletKeyService_consent_text__1": {
-    "message": "We will automatically connect with your wallet provider."
+    "message": "We will automatically connect with your wallet provider. [Learn more](https://webmonetization.org/supporters/get-started/#resolve-a-key-addition-failure)"
   },
   "reconnectWalletKeyService_consent_text__1": {
-    "message": "We will automatically reconnect with your wallet provider."
-  },
-  "connectWalletKeyService_consentLearnMore_text": {
-    "message": "Learn more",
-    "description": "Learn more about how this works"
+    "message": "We will automatically reconnect with your wallet provider. [Learn more](https://webmonetization.org/supporters/get-started/#resolve-a-key-addition-failure)"
   },
   "connectWalletKeyService_consent_text__2": {
     "message": "By agreeing, you provide us consent to automatically access your wallet to securely add a key."
@@ -302,6 +342,9 @@
   "postInstall_title": {
     "message": "Let's get you started with Web Monetization!"
   },
+  "postInstall_step_text": {
+    "message": "Step "
+  },
   "postInstall_stepGetWallet_title": {
     "message": "Get a wallet compatible with Web Monetization"
   },
@@ -313,6 +356,12 @@
   },
   "postInstall_stepWalletAddress_title": {
     "message": "Find your wallet address or payment pointer"
+  },
+  "postInstall_stepWalletAddress_screenshot_text": {
+    "message": "Screenshot of wallet address for $WALLET_NAME$",
+    "placeholders": {
+      "WALLET_NAME": { "content": "$1", "example": "Fynbos" }
+    }
   },
   "postInstall_stepPin_title": {
     "message": "Pin extension to the browser toolbar"
@@ -394,7 +443,7 @@
     "message": "The Interledger Foundation:"
   },
   "postInstallConsent_dataCollection_yes_text__1": {
-    "message": "Uses PostHog to collect usage and analytics data."
+    "message": "Uses [PostHog](https://posthog.com/) to collect usage and analytics data."
   },
   "postInstallConsent_dataCollection_yes_text__2": {
     "message": "Assigns each installation a unique ID, and associates your actions and interactions (events) with that ID."
@@ -418,10 +467,7 @@
     "message": "Extension Permissions"
   },
   "postInstallConsent_permissions_text": {
-    "message": "The extension needs basic permissions to work."
-  },
-  "postInstallConsent_permissions_link_text": {
-    "message": "See details."
+    "message": "The extension needs basic permissions to work. [See details](https://github.com/interledger/web-monetization-extension/blob/main/docs/PERMISSIONS.md)."
   },
   "postInstallConsent_consentProvided_text": {
     "message": "You have provided your consent to the above. Access the extension from the browser toolbar."
@@ -433,6 +479,21 @@
     "message": "Confirm and continue"
   },
 
+  "postConnect_title": {
+    "message": "Web Monetization extension"
+  },
+  "postConnect_empty_text": {
+    "message": "Nothing to see here"
+  },
+  "postConnect_unmapped_text": {
+    "message": "No mapping from status to messages!!"
+  },
+  "postConnect_retry_action": {
+    "message": "Try again"
+  },
+  "postConnect_changeDetails_action": {
+    "message": "Change the wallet address or budget amount"
+  },
   "postConnect_connect_success_title": {
     "message": "Wallet Connected!"
   },
@@ -608,10 +669,61 @@
     "message": "Usage data & analytics"
   },
   "settings_dataCollection_desc": {
-    "message": "The extension gathers anonymous data about how you use it (e.g., clicks, interactions) to help us improve the app and your overall experience."
+    "message": "The extension gathers anonymous data about how you use it (e.g., clicks, interactions) to help us improve the app and your overall experience. Read the full details in our [data policy](/post-install/consent)."
   },
-  "settings_dataCollection_learnMore_text": {
-    "message": "Read the full details in our"
+
+  "settings_tabs_wallet_text": {
+    "message": "Wallet"
+  },
+  "settings_tabs_budget_text": {
+    "message": "Budget"
+  },
+  "settings_tabs_rate_text": {
+    "message": "Rate"
+  },
+  "settings_tabs_other_text": {
+    "message": "Settings"
+  },
+
+  "settings_wallet_addressId_text": {
+    "message": "Wallet address ID: $ID$",
+    "placeholders": {
+      "ID": { "content": "$1", "example": "https://wallet.example.com/alice" }
+    }
+  },
+  "settings_wallet_disconnect_action": {
+    "message": "Disconnect"
+  },
+  "settings_wallet_disconnect_ariaLabel_action": {
+    "message": "Disconnect your wallet"
+  },
+  "settings_wallet_forceDisconnect_action": {
+    "message": "Force disconnect?"
+  },
+  "settings_wallet_advanced_text": {
+    "message": "Advanced"
+  },
+  "settings_wallet_publicKey_label": {
+    "message": "Public key"
+  },
+
+  "settings_budget_amount_label": {
+    "message": "Budget amount"
+  },
+  "settings_budget_monthly_label": {
+    "message": "Monthly"
+  },
+  "settings_budget_renewDate_text": {
+    "message": "Your budget will renew on <time>$RENEW_DATE$</time>.",
+    "placeholders": {
+      "RENEW_DATE": { "content": "$1", "example": "Aug 22, 2024" }
+    }
+  },
+  "settings_budget_submit_action": {
+    "message": "Submit changes"
+  },
+  "settings_budget_remainingBalance_label": {
+    "message": "Remaining balance"
   },
 
   "consentRequired_title": {
@@ -628,5 +740,15 @@
   },
   "consentRequired_primary_action": {
     "message": "View data policy and consent"
+  },
+
+  "code_copy_action": {
+    "message": "copy"
+  },
+  "inputAmount_currency_text": {
+    "message": "Currency: $CODE$",
+    "placeholders": {
+      "CODE": { "content": "$1", "example": "USD" }
+    }
   }
 }

--- a/src/pages/app/App.tsx
+++ b/src/pages/app/App.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/pages/shared/lib/context';
 import browser from '@/shared/browser';
 import { MessageContextProvider, WaitForStateLoad } from '@/app/lib/context';
-import { Route, Router, Switch } from 'wouter';
+import { Redirect, Route, Router, Switch } from 'wouter';
 import { useHashLocation } from 'wouter/use-hash-location';
 import * as PAGES from './pages/index';
 
@@ -23,6 +23,9 @@ const Routes = () => (
     <Route path={P.DEFAULT} component={C.PostInstall} />
     <Route path={P.CONSENT} component={C.Consent} />
     <Route path={P.POST_CONNECT} component={C.PostConnect} />
+    <Route>
+      <Redirect to={P.DEFAULT} />
+    </Route>
   </Switch>
 );
 

--- a/src/pages/app/lib/context.tsx
+++ b/src/pages/app/lib/context.tsx
@@ -8,6 +8,7 @@ import {
 import {
   TelemetryContextProvider,
   useBrowser,
+  useTranslation,
 } from '@/pages/shared/lib/context';
 import { dispatch } from './store';
 
@@ -18,6 +19,7 @@ export {
 } from '@/pages/shared/lib/context';
 
 export function WaitForStateLoad({ children }: React.PropsWithChildren) {
+  const t = useTranslation();
   const message = useMessage();
   const [isLoading, setIsLoading] = React.useState(true);
   const [telemetryConfig, setTelemetryConfig] = React.useState<{
@@ -41,7 +43,7 @@ export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   }, [message]);
 
   if (isLoading) {
-    return 'Loading';
+    return t('app_loading_text');
   }
 
   return (

--- a/src/pages/app/pages/PostConnect.tsx
+++ b/src/pages/app/pages/PostConnect.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { deepClone } from 'valtio/utils';
 import { cva } from 'class-variance-authority';
+import { Redirect } from 'wouter';
 import { navigate } from 'wouter/use-hash-location';
 import { isErrorWithKey } from '@/shared/helpers';
 import { useMessage, useTranslation } from '@/app/lib/context';
@@ -17,12 +18,12 @@ export default function PostConnect() {
   const { transientState } = useAppState();
 
   if (!transientState.connect || transientState.connect.type === 'progress') {
-    return <p>{t('postConnect_empty_text')}</p>;
+    return <Redirect to="/" />;
   }
 
   const params = mapStatusToMessage(transientState.connect as WalletStatus, t);
   if (!params) {
-    return <p>{t('postConnect_unmapped_text')}</p>;
+    return <Redirect to="/" />;
   }
 
   return (

--- a/src/pages/app/pages/PostConnect.tsx
+++ b/src/pages/app/pages/PostConnect.tsx
@@ -17,24 +17,20 @@ export default function PostConnect() {
   const { transientState } = useAppState();
 
   if (!transientState.connect || transientState.connect.type === 'progress') {
-    return <p>Nothing to see here</p>;
+    return <p>{t('postConnect_empty_text')}</p>;
   }
 
   const params = mapStatusToMessage(transientState.connect as WalletStatus, t);
   if (!params) {
-    return <p>No mapping from status to messages!!</p>;
+    return <p>{t('postConnect_unmapped_text')}</p>;
   }
 
   return (
     <div className="bg-white md:bg-gray-50 flex h-screen w-screen flex-col items-center justify-center gap-6 md:gap-14 p-3 md:p-4">
       <header className="flex gap-2 items-center w-fit mx-auto mt-8 md:mt-16 md:mb-14 text-center">
-        <img
-          src="/assets/images/logo.svg"
-          alt="Web Monetization"
-          className="h-6 md:h-16"
-        />
+        <img src="/assets/images/logo.svg" alt="" className="h-6 md:h-16" />
         <h1 className="text-base md:text-4xl font-bold text-secondary-dark">
-          Web Monetization extension
+          {t('postConnect_title')}
         </h1>
       </header>
 
@@ -59,7 +55,7 @@ export default function PostConnect() {
                 return message.send(action, payload);
               }}
             >
-              Try again
+              {t('postConnect_retry_action')}
             </button>
           )}
 
@@ -75,7 +71,7 @@ export default function PostConnect() {
                 variant: params.retryPossible === 'auto' ? 'outline' : 'solid',
               })}
             >
-              Change the wallet address or budget amount
+              {t('postConnect_changeDetails_action')}
             </a>
           )}
         </div>

--- a/src/pages/app/pages/PostInstall.tsx
+++ b/src/pages/app/pages/PostInstall.tsx
@@ -247,7 +247,9 @@ const Steps = () => {
           />
           <img
             {...selectedWallet.walletAddressScreenshot}
-            alt={`Screenshot of wallet address for ${selectedWallet.name}`}
+            alt={t('postInstall_stepWalletAddress_screenshot_text', [
+              selectedWallet.name,
+            ])}
             className="mx-auto p-4 shadow-2xl sm:w-auto w-9/12"
           />
         </picture>
@@ -447,9 +449,10 @@ function Step({
 }
 
 function StepNumber({ number }: { number: number }) {
+  const t = useTranslation();
   return (
     <span className="inline-block shrink-0 rounded-lg bg-black/5 p-1 align-middle text-sm outline outline-1 outline-gray-800/10 font-normal">
-      <span className="sr-only">Step </span>
+      <span className="sr-only">{t('postInstall_step_text')}</span>
       {number}.
     </span>
   );

--- a/src/pages/app/pages/PostInstallConsent.tsx
+++ b/src/pages/app/pages/PostInstallConsent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Redirect } from 'wouter';
+import { md } from 'imd/react';
 import { isConsentRequired } from '@/shared/helpers';
 import { getResponseOrThrow } from '@/shared/messages';
 import {
@@ -123,17 +124,6 @@ function Telemetry({ ref }: { ref: TelemetryConsentRef }) {
     typeof consentTelemetry === 'undefined' || consentTelemetry,
   );
 
-  const linkToPostHog = (
-    <a
-      href="https://posthog.com/"
-      className="pr-1 text-primary outline-current hover:underline"
-      target="_blank"
-      rel="noreferrer noopener"
-    >
-      PostHog
-    </a>
-  );
-
   return (
     <form className="space-y-2">
       <h3 className="font-semibold text-xl text-alt">
@@ -147,11 +137,18 @@ function Telemetry({ ref }: { ref: TelemetryConsentRef }) {
         </h4>
         <ul className="list-disc ml-4">
           <li>
-            {replaceWithJSX(
-              t('postInstallConsent_dataCollection_yes_text__1'),
-              /\bPostHog\b/,
-              linkToPostHog,
-            )}
+            {md(t('postInstallConsent_dataCollection_yes_text__1'), {
+              link: (children, href) => (
+                <a
+                  href={href}
+                  className="pr-1 text-primary outline-current hover:underline"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  {children}
+                </a>
+              ),
+            })}
           </li>
           <li>{t('postInstallConsent_dataCollection_yes_text__2')}</li>
         </ul>
@@ -196,15 +193,18 @@ function Permissions() {
         {t('postInstallConsent_permissions_title')}
       </h3>
       <p>
-        {t('postInstallConsent_permissions_text')}{' '}
-        <a
-          href="https://github.com/interledger/web-monetization-extension/blob/main/docs/PERMISSIONS.md"
-          className="group pr-1 text-primary outline-current hover:underline"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          {t('postInstallConsent_permissions_link_text')}
-        </a>
+        {md(t('postInstallConsent_permissions_text'), {
+          link: (children, href) => (
+            <a
+              href={href}
+              className="group pr-1 text-primary outline-current hover:underline"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {children}
+            </a>
+          ),
+        })}
       </p>
     </div>
   );
@@ -283,17 +283,6 @@ function InformationTooltip({ text }: { text: string }) {
       <InfoCircle className="inline-block h-5 w-5 ml-1 -mt-1 text-gray-500" />
     </span>
   );
-}
-
-function replaceWithJSX(
-  text: string,
-  pattern: RegExp,
-  replacement: React.ReactNode,
-) {
-  return text
-    .split(pattern)
-    .flatMap((item) => [item, replacement])
-    .slice(0, -1);
 }
 
 type TelemetryConsentRef = React.RefObject<HTMLInputElement | null>;

--- a/src/pages/popup/components/ConnectWalletForm.tsx
+++ b/src/pages/popup/components/ConnectWalletForm.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { md } from 'imd/react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { Input } from '@/pages/shared/components/ui/Input';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
@@ -312,9 +313,9 @@ export const ConnectWalletForm = React.memo(function ConnectWalletForm({
             whyText: t('connectWallet_failedAutoKeyAdd_why_text'),
           }}
           retry={resetState}
+          retryText={t('connectWallet_retry_action')}
           hideError={!errors.keyPair}
           text={t('connectWallet_publicKey_label')}
-          learnMoreText={t('connectWallet_publicKeyLearnMore_text')}
           publicKey={publicKey}
         />
       )}
@@ -694,10 +695,10 @@ const ManualKeyPairNeeded: React.FC<{
   error: { message: string; details: null | ErrorInfo; whyText: string };
   hideError?: boolean;
   retry: () => Promise<void>;
+  retryText: string;
   text: string;
-  learnMoreText: string;
   publicKey: string;
-}> = ({ error, hideError, text, learnMoreText, publicKey, retry }) => {
+}> = ({ error, hideError, text, retryText, publicKey, retry }) => {
   const ErrorDetails = () => {
     if (!error?.details) return null;
     return (
@@ -712,7 +713,7 @@ const ManualKeyPairNeeded: React.FC<{
             onClick={retry}
             className="ml-1 inline-block text-primary underline"
           >
-            Try again?
+            {retryText}
           </button>
         )}
       </details>
@@ -727,15 +728,18 @@ const ManualKeyPairNeeded: React.FC<{
         </div>
       )}
       <p className="px-2 text-left text-xs">
-        {text}{' '}
-        <a
-          href="https://webmonetization.org/supporters/get-started/#resolve-a-key-addition-failure"
-          className="text-primary"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {learnMoreText}
-        </a>
+        {md(text, {
+          link: (children, href) => (
+            <a
+              href={href}
+              className="text-primary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {children}
+            </a>
+          ),
+        })}
       </p>
       <Code className="text-xs" value={publicKey} />
     </div>

--- a/src/pages/popup/components/ErrorKeyRevoked.tsx
+++ b/src/pages/popup/components/ErrorKeyRevoked.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { deepClone } from 'valtio/utils';
 import { isErrorWithKey } from '@/shared/helpers';
 import { AutoKeyAddConsent } from '@/pages/shared/components/AutoKeyAddConsent';
@@ -111,7 +112,7 @@ const MainScreen = ({
     const state = transientState.connect;
     if (state?.intent !== 'reconnect') return;
     if (state.type === 'failure') {
-      let msg = 'Unknown error';
+      let msg = t('keyRevoked_unknown_error');
       if (isErrorWithKey(state.details)) {
         const errInfo = toErrorInfo(deepClone(state.details));
         if (errInfo) msg = errInfo.message;
@@ -196,13 +197,13 @@ const ManualReconnectScreen = ({
     if (state?.intent !== 'reconnect') return;
     if (state.type !== 'failure') return;
 
-    let message = 'Unknown error';
+    let message = t('keyRevoked_unknown_error');
     if (isErrorWithKey(state.details)) {
       const errInfo = toErrorInfo(state.details);
       if (errInfo) message = errInfo.message;
     }
     setErrors({ root: { message } });
-  }, [transientState?.connect, toErrorInfo]);
+  }, [transientState?.connect, toErrorInfo, t]);
 
   const requestManualReconnect = async () => {
     setErrors({ root: null });
@@ -232,13 +233,16 @@ const ManualReconnectScreen = ({
     >
       <div className="space-y-1 text-sm">
         <p className="px-2">
-          Reconnecting to wallet:{' '}
-          <span className="underline">{info.walletAddress?.id}</span>
+          {md(
+            t('keyRevoked_reconnecting_text', [info.walletAddress?.id ?? '']),
+            {
+              html: ({ children }) => (
+                <span className="underline">{children}</span>
+              ),
+            },
+          )}
         </p>
-        <p className="px-2">
-          <strong>Before</strong> you reconnect, copy the public key below and
-          add it to your wallet.
-        </p>
+        <p className="px-2">{md(t('keyRevoked_copyKey_text'))}</p>
         <Code className="text-xs" value={info.publicKey} />
       </div>
 

--- a/src/pages/popup/components/PayWebsiteForm.tsx
+++ b/src/pages/popup/components/PayWebsiteForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
 import { FadeInOut } from '@/pages/shared/components/FadeInOut';
@@ -96,8 +97,11 @@ export const PayWebsiteForm = () => {
         id="payAmount"
         label={
           <p className="overflow-hidden text-ellipsis whitespace-nowrap">
-            Support{' '}
-            <span className="text-ellipsis text-primary">{tab.url}</span>
+            {md(t('pay_amount_label', [tab.url]), {
+              html: ({ children }) => (
+                <span className="text-ellipsis text-primary">{children}</span>
+              ),
+            })}
           </p>
         }
         walletAddress={walletAddress}

--- a/src/pages/popup/components/Settings/Budget.tsx
+++ b/src/pages/popup/components/Settings/Budget.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { InputAmount } from '@/pages/shared/components/InputAmount';
@@ -117,7 +118,7 @@ const BudgetAmount = ({
       <div className="flex gap-y-4 gap-x-6 flex-col @sm:flex-row @sm:items-center">
         <InputAmount
           id="budgetAmount"
-          label="Budget amount"
+          label={t('settings_budget_amount_label')}
           walletAddress={walletAddress}
           className="@sm:max-w-48"
           amount={amount}
@@ -140,7 +141,7 @@ const BudgetAmount = ({
           className="flex items-center gap-x-4 px-2 @sm:mt-7"
         >
           <span className="font-medium text-medium @sm:font-normal flex-grow @sm:flex-grow-0 @sm:order-last">
-            Monthly
+            {t('settings_budget_monthly_label')}
           </span>
           <SwitchButton
             id="budgetRecurring"
@@ -158,23 +159,7 @@ const BudgetAmount = ({
           />
         </label>
       </div>
-      {renewDate && (
-        <p className="px-2 text-xs" data-testid="renew-date-msg">
-          Your budget will renew on{' '}
-          <time
-            dateTime={renewDate.toISOString()}
-            title={renewDate.toLocaleString(undefined, {
-              dateStyle: 'medium',
-              timeStyle: 'short',
-            })}
-          >
-            {renewDate.toLocaleString(undefined, {
-              dateStyle: 'medium',
-            })}
-          </time>
-          .
-        </p>
-      )}
+      {renewDate && <RenewDateMessage renewDate={renewDate} />}
 
       <div className="space-y-1 pt-4">
         {errors.root?.message && <ErrorMessage error={errors.root.message} />}
@@ -189,12 +174,37 @@ const BudgetAmount = ({
           }
           loading={isSubmitting}
         >
-          Submit changes
+          {t('settings_budget_submit_action')}
         </Button>
       </div>
     </form>
   );
 };
+
+function RenewDateMessage({ renewDate }: { renewDate: Date }) {
+  const t = useTranslation();
+
+  const formattedDate = renewDate.toLocaleString(undefined, {
+    dateStyle: 'medium',
+  });
+  const title = renewDate.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+  const datetime = renewDate.toISOString();
+
+  return (
+    <p className="px-2 text-xs" data-testid="renew-date-msg">
+      {md(t('settings_budget_renewDate_text', [formattedDate]), {
+        html: ({ children }) => (
+          <time dateTime={datetime} title={title}>
+            {children}
+          </time>
+        ),
+      })}
+    </p>
+  );
+}
 
 type RemainingBalanceProps = Pick<PopupState, 'balance' | 'walletAddress'>;
 
@@ -202,6 +212,7 @@ const RemainingBalance = ({
   balance,
   walletAddress,
 }: RemainingBalanceProps) => {
+  const t = useTranslation();
   const amount = transformBalance(balance, walletAddress.assetScale);
   return (
     <div className="space-y-2">
@@ -209,7 +220,7 @@ const RemainingBalance = ({
         id="remainingBalance"
         onChange={() => {}}
         onError={() => {}}
-        label="Remaining balance"
+        label={t('settings_budget_remainingBalance_label')}
         className="max-w-56"
         walletAddress={walletAddress}
         amount={amount}

--- a/src/pages/popup/components/Settings/SettingsDataCollection.tsx
+++ b/src/pages/popup/components/Settings/SettingsDataCollection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import {
   useBrowser,
@@ -51,17 +52,17 @@ export function DataCollectionSettings() {
       </label>
 
       <p className="text-sm">
-        {t('settings_dataCollection_desc')}{' '}
-        {t('settings_dataCollection_learnMore_text')}{' '}
-        <button
-          type="button"
-          onClick={() =>
-            message.send('OPEN_APP', { path: '/post-install/consent' })
-          }
-          className="underline text-alt"
-        >
-          data policy.
-        </button>
+        {md(t('settings_dataCollection_desc'), {
+          link: (children, href) => (
+            <button
+              type="button"
+              onClick={() => message.send('OPEN_APP', { path: href })}
+              className="underline text-alt"
+            >
+              {children}
+            </button>
+          ),
+        })}
       </p>
     </>
   );

--- a/src/pages/popup/components/Settings/WalletInformation.tsx
+++ b/src/pages/popup/components/Settings/WalletInformation.tsx
@@ -58,13 +58,13 @@ export const WalletInformation = ({
       >
         <Input
           className="bg-disabled"
-          label="Connected wallet address"
+          label={t('outOfFundsAddFunds_walletAddress_label')}
           disabled={true}
           readOnly={true}
           value={walletAddress?.url}
           title={
             walletAddress && walletAddress.id !== walletAddress.url
-              ? `Wallet address ID: ${walletAddress.id}`
+              ? t('settings_wallet_addressId_text', [walletAddress.id])
               : undefined
           }
         />
@@ -73,11 +73,11 @@ export const WalletInformation = ({
           type="submit"
           variant="destructive"
           className="w-full"
-          aria-label="Disconnect your wallet"
+          aria-label={t('settings_wallet_disconnect_ariaLabel_action')}
           disabled={isSubmitting}
           loading={isSubmitting}
         >
-          Disconnect
+          {t('settings_wallet_disconnect_action')}
         </Button>
 
         {disconnectError && (
@@ -88,7 +88,7 @@ export const WalletInformation = ({
               onClick={() => disconnectWallet(true)}
               className="ml-1 inline-block underline"
             >
-              Force disconnect?
+              {t('settings_wallet_forceDisconnect_action')}
             </button>
           </p>
         )}
@@ -96,13 +96,13 @@ export const WalletInformation = ({
 
       <details className="border-t border-gray-200">
         <summary className="flex cursor-pointer items-center justify-between px-2 py-2 text-sm text-weak hover:text-strong">
-          <span>Advanced</span>
+          <span>{t('settings_wallet_advanced_text')}</span>
           <span className="-rotate-90">
             <ArrowBack className="h-4 w-4" />
           </span>
         </summary>
         <div className="space-y-2">
-          <Label>Public key</Label>
+          <Label>{t('settings_wallet_publicKey_label')}</Label>
           <Code className="text-xs" value={publicKey} />
         </div>
       </details>

--- a/src/pages/popup/components/TogglePaymentsButton.tsx
+++ b/src/pages/popup/components/TogglePaymentsButton.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { Power } from '@/pages/shared/components/Icons';
 import { cn } from '@/pages/shared/lib/utils';
-import { useMessage } from '@/popup/lib/context';
+import { useMessage, useTranslation } from '@/popup/lib/context';
 import { dispatch, usePopupState } from '@/popup/lib/store';
 
 export const TogglePaymentsButton = () => {
+  const t = useTranslation();
   const { enabled } = usePopupState();
   const message = useMessage();
-  const title = enabled ? 'Disable extension' : 'Enable extension';
+  const title = enabled
+    ? t('header_togglePayments_disable_action')
+    : t('header_togglePayments_enable_action');
 
   return (
     <label

--- a/src/pages/popup/components/layout/Header.tsx
+++ b/src/pages/popup/components/layout/Header.tsx
@@ -4,10 +4,11 @@ import { ArrowBack, Settings } from '@/pages/shared/components/Icons';
 import { HeaderEmpty } from './HeaderEmpty';
 import { TogglePaymentsButton } from '@/popup/components/TogglePaymentsButton';
 import { ROUTES_PATH } from '@/popup/Popup';
-import { useBrowser } from '@/popup/lib/context';
+import { useBrowser, useTranslation } from '@/popup/lib/context';
 import { usePopupState } from '@/popup/lib/store';
 
 const NavigationButton = () => {
+  const t = useTranslation();
   const [pathname] = useLocation();
   const { connected, state } = usePopupState();
 
@@ -17,25 +18,31 @@ const NavigationButton = () => {
 
     if (pathname.includes('/s/')) {
       return (
-        <Link to={pathname.split('/s/')[0]} aria-label="Back">
+        <Link
+          to={pathname.split('/s/')[0]}
+          aria-label={t('header_back_action')}
+        >
           <ArrowBack className="h-6 touch:h-8 text-gray-500" />
         </Link>
       );
     }
 
     return pathname.startsWith(ROUTES_PATH.SETTINGS) ? (
-      <Link to={ROUTES_PATH.HOME} aria-label="Back">
+      <Link to={ROUTES_PATH.HOME} aria-label={t('header_back_action')}>
         <ArrowBack className="h-6 touch:h-8 text-gray-500" />
       </Link>
     ) : (
       <React.Fragment>
         {connected && <TogglePaymentsButton />}
-        <Link to={ROUTES_PATH.SETTINGS} aria-label="Settings">
+        <Link
+          to={ROUTES_PATH.SETTINGS}
+          aria-label={t('header_settings_action')}
+        >
           <Settings className="h-6 touch:h-8" />
         </Link>
       </React.Fragment>
     );
-  }, [pathname, connected, state]);
+  }, [pathname, connected, state, t]);
 };
 
 export const Header = () => {

--- a/src/pages/popup/components/layout/HeaderEmpty.tsx
+++ b/src/pages/popup/components/layout/HeaderEmpty.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import { useTranslation } from '@/pages/shared/lib/context';
 
 export const HeaderEmpty = ({
   logo,
   children,
 }: React.PropsWithChildren<{ logo: string }>) => {
+  const t = useTranslation();
   return (
     <header className="flex h-8 flex-row items-center justify-between">
       <div className="flex flex-row items-center gap-3">
-        <img src={logo} alt="Web Monetization Logo" className="h-6" />
-        <p className="text-xl text-strong">Web Monetization</p>
+        <img src={logo} alt="" className="h-6" />
+        <p className="text-xl text-strong">{t('header_brand_text')}</p>
       </div>
       <div className="flex flex-row items-center gap-3">{children}</div>
     </header>

--- a/src/pages/popup/components/layout/SettingsLayout.tsx
+++ b/src/pages/popup/components/layout/SettingsLayout.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Link, useLocation } from 'wouter';
 import { cn } from '@/pages/shared/lib/utils';
 import { useLocalStorage } from '@/pages/shared/lib/hooks';
+import { useTranslation } from '@/popup/lib/context';
 
 export const SETTINGS_TABS = [
-  { id: 'wallet', title: 'Wallet' },
-  { id: 'budget', title: 'Budget' },
-  { id: 'rate', title: 'Rate' },
-  { id: 'other', title: 'Settings' },
+  { id: 'wallet', titleKey: 'settings_tabs_wallet_text' },
+  { id: 'budget', titleKey: 'settings_tabs_budget_text' },
+  { id: 'rate', titleKey: 'settings_tabs_rate_text' },
+  { id: 'other', titleKey: 'settings_tabs_other_text' },
 ] as const;
 
 export type SettingsTabId = (typeof SETTINGS_TABS)[number]['id'];
@@ -19,6 +20,7 @@ export const isValidSettingsTabId = (
 export const SETTINGS_TAB_STORAGE_KEY = 'settings.tabId';
 
 export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
+  const t = useTranslation();
   const [pathname, navigate] = useLocation();
   const tabId = pathname === '/' ? undefined : pathname.slice(1);
 
@@ -44,7 +46,7 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex flex-1 flex-col">
       <div role="tablist" className="mb-8 flex border-b border-gray-200">
-        {SETTINGS_TABS.map(({ id, title }) => (
+        {SETTINGS_TABS.map(({ id, titleKey }) => (
           <Link
             key={id}
             id={`settings-tab-${id}`}
@@ -59,7 +61,7 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
               'cursor-pointer whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium focus:outline-hidden focus-visible:outline',
             )}
           >
-            {title}
+            {t(titleKey)}
           </Link>
         ))}
       </div>

--- a/src/pages/popup/lib/context.tsx
+++ b/src/pages/popup/lib/context.tsx
@@ -8,6 +8,7 @@ import {
 import {
   TelemetryContextProvider,
   useBrowser,
+  useTranslation,
 } from '@/pages/shared/lib/context';
 import { dispatch } from './store';
 
@@ -19,6 +20,7 @@ export {
 } from '@/pages/shared/lib/context';
 
 export function WaitForStateLoad({ children }: React.PropsWithChildren) {
+  const t = useTranslation();
   const message = useMessage();
   const [isLoading, setIsLoading] = React.useState(true);
   const [telemetryConfig, setTelemetryConfig] = React.useState<{
@@ -47,7 +49,7 @@ export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   }, [message]);
 
   if (isLoading) {
-    return 'Loading';
+    return t('app_loading_text');
   }
 
   return (

--- a/src/pages/popup/pages/Home.tsx
+++ b/src/pages/popup/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { Link, Redirect as Navigate } from 'wouter';
 import {
   formatNumber,
@@ -60,8 +61,8 @@ export default () => {
       style={{ height: 'calc(100% + 1rem)' }}
     >
       <header className="text-center text-3xl text-secondary-dark">
-        <h2 className="font-bold">Pay as you browse</h2>
-        <p className="font-light">Support content you love</p>
+        <h2 className="font-bold">{t('tagline_text__2')}</h2>
+        <p className="font-light">{t('tagline_text__1')}</p>
       </header>
       <InfoBanner />
       <PayWebsiteForm />
@@ -123,8 +124,11 @@ const InfoBanner = () => {
 
           {!!tab.rateOfPay && (
             <span className="text-xs font-normal px-2 py-1 rounded-lg bg-slate-50 w-fit">
-              {t('home_hourlyRateDefault_text')}{' '}
-              <span className="tabular-nums">{rate}</span>
+              {md(t('home_hourlyRateDefaultRate_text', [rate]), {
+                html: ({ children }) => (
+                  <span className="tabular-nums">{children}</span>
+                ),
+              })}
             </span>
           )}
         </p>

--- a/src/pages/popup/pages/MissingHostPermission.tsx
+++ b/src/pages/popup/pages/MissingHostPermission.tsx
@@ -21,7 +21,9 @@ export default () => {
           <WarningSign className="size-8 text-orange-500" />
         </div>
         <div className="ml-3 flex flex-col gap-2">
-          <h3 className="font-medium text-orange-800">Permission needed</h3>
+          <h3 className="font-medium text-orange-800">
+            {t('missingHostPermission_title')}
+          </h3>
           <div className="text-orange-700">
             <p>{t('missingHostPermission_text')}</p>
           </div>
@@ -44,7 +46,7 @@ export default () => {
           });
         }}
       >
-        Grant permission
+        {t('postInstall_stepPermissions_grant_action')}
       </button>
     </div>
   );

--- a/src/pages/shared/components/AutoKeyAddConsent.tsx
+++ b/src/pages/shared/components/AutoKeyAddConsent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { md } from 'imd/react';
 import { Button } from '@/pages/shared/components/ui/Button';
 import { useTranslation } from '@/popup/lib/context';
 import type { TranslationKeys } from '@/shared/helpers';
@@ -24,16 +25,19 @@ export const AutoKeyAddConsent = ({ onAccept, onDecline, intent }: Props) => {
       data-testid="connect-wallet-auto-key-consent"
     >
       <p className="text-lg leading-snug text-weak">
-        {t(consentMessage[intent])}{' '}
-        <a
-          hidden
-          href="https://webmonetization.org/supporters/get-started/#resolve-a-key-addition-failure"
-          className="text-primary hover:underline"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {t('connectWalletKeyService_consentLearnMore_text')}
-        </a>
+        {md(t(consentMessage[intent]), {
+          link: (children, href) => (
+            <a
+              hidden
+              href={href}
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {children}
+            </a>
+          ),
+        })}
       </p>
 
       <div className="space-y-2 pt-12 text-medium">

--- a/src/pages/shared/components/InputAmount.tsx
+++ b/src/pages/shared/components/InputAmount.tsx
@@ -9,6 +9,7 @@ import {
 } from '../lib/utils';
 import { errorWithKey, type ErrorWithKeyLike } from '@/shared/helpers';
 import { useLongPress, useThrottle } from '@/pages/shared/lib/hooks';
+import { useTranslation } from '@/pages/shared/lib/context';
 
 interface Props {
   id: string;
@@ -51,6 +52,7 @@ export const InputAmount = ({
   controls = false,
   ref,
 }: Props) => {
+  const t = useTranslation();
   const { assetScale } = walletAddress;
   const step = 1 / 10 ** assetScale;
   const currencySymbol = getCurrencySymbol(walletAddress.assetCode);
@@ -149,7 +151,9 @@ export const InputAmount = ({
             walletAddress.assetCode.length !== 3 && 'font-normal font-mono',
           )}
           style={{ maxWidth: '6ch', paddingLeft: '1ch' }}
-          title={`Currency: ${walletAddress.assetCode.toUpperCase()}`}
+          title={t('inputAmount_currency_text', [
+            walletAddress.assetCode.toUpperCase(),
+          ])}
         >
           {currencySymbol}
         </span>

--- a/src/pages/shared/components/ui/Code.tsx
+++ b/src/pages/shared/components/ui/Code.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from './Button';
 import { CheckIcon, ClipboardIcon } from '../Icons';
 import { cn } from '@/pages/shared/lib/utils';
+import { useTranslation } from '@/pages/shared/lib/context';
 
 interface CodeProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
@@ -29,6 +30,7 @@ interface CopyButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
 }
 
 const CopyButton = ({ value, ...props }: CopyButtonProps) => {
+  const t = useTranslation();
   const [hasCopied, setHasCopied] = React.useState(false);
 
   React.useEffect(() => {
@@ -42,7 +44,7 @@ const CopyButton = ({ value, ...props }: CopyButtonProps) => {
   return (
     <Button
       {...props}
-      aria-label="copy"
+      aria-label={t('code_copy_action')}
       variant="ghost"
       size="icon"
       className="rounded-xs text-primary"

--- a/src/pages/shared/components/ui/__tests__/Code.test.tsx
+++ b/src/pages/shared/components/ui/__tests__/Code.test.tsx
@@ -11,7 +11,10 @@ describe('Code', () => {
 
     expect(code).toBeInTheDocument();
     expect(code).toHaveTextContent('test');
-    expect(queryByRole('button')).toHaveAttribute('aria-label', 'copy');
+    expect(queryByRole('button')).toHaveAttribute(
+      'aria-label',
+      'code_copy_action',
+    );
   });
 
   it('calls clipboard.writeText with the correct value', () => {


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1267
Paves way for https://github.com/interledger/web-monetization-extension/issues/979

## Changes proposed in this pull request

- Support basic inline markup in i18n strings, powered by [`imd`](https://github.com/sidvishnoi/imd) package.
- Move many more hard-coded strings from code to `messages.json`

### Example:

Now, the entire string is in one place, and its rendering is handled separately. When we support more languages, placement of parameters might change, but we don't have to update our markup for those.

A good example can be `settings_budget_renewDate_text` - it has a `<time>` element In other language (Hindi for example), we can have something like:

```
 Your budget will renew on <time>$RENEW_DATE$</time>.    // en
 आपका बजट <time>$RENEW_DATE$</time> को रिन्यू होगा।        // hi
 aapka budget <time>$RENEW_DATE$</time> ko renew hoga.   // hi-Latn
```