### PR TITLE
fix(bg/paymentManager): handle zero rate of pay

### DIFF
--- a/src/background/services/__tests__/paymentManager.test.ts
+++ b/src/background/services/__tests__/paymentManager.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it, test } from 'vitest';
 import { distributeAmount, calculateInterval } from '../paymentManager';
 
 describe('continuous payments / calculateInterval', () => {
+  test('handles zero rate', () => {
+    const result = calculateInterval(0n);
+    expect(result.units).toBe(0n);
+    expect(result.period).toBe(Number.POSITIVE_INFINITY);
+  });
+
   test('handles general rate - $0.60/hr', () => {
     const result = calculateInterval(60n);
     expect(result.units).toBe(1n);

--- a/src/background/services/paymentManager.ts
+++ b/src/background/services/paymentManager.ts
@@ -348,7 +348,12 @@ export class PaymentManager {
     // amount by minSendAmount unit to make the interval longer.
 
     if (this.#state === 'active') {
-      this.timer.reset(this.interval.period);
+      if (this.hourlyRate === 0n) {
+        this.logger.debug('Pausing timer. Hourly rate is 0');
+        this.timer.clear();
+      } else {
+        this.timer.reset(this.interval.period);
+      }
     }
   }
 
@@ -369,11 +374,14 @@ export class PaymentManager {
 
     this.#state = 'active';
 
+    if (this.hourlyRate === 0n) {
+      this.logger.debug('Skip payment. Hourly rate is 0');
+      return;
+    }
     await this.preventOverpaying();
     if (this.#state !== 'active') {
       return;
     }
-
     this.#iter ??= this.setupSessionIterator();
     const session = this.consumeSession();
     if (!session) {
@@ -404,6 +412,10 @@ export class PaymentManager {
     }
     if (this.#state === 'paused') {
       this.#state = 'active';
+    }
+    if (this.hourlyRate === 0n) {
+      this.logger.debug('Skip resuming timer. Hourly rate is 0');
+      return;
     }
     this.timer.resume();
   }
@@ -699,6 +711,10 @@ class PeekAbleIterator<T> implements Iterator<T, never, never> {
 }
 
 export function calculateInterval(hourlyRate: bigint): Interval {
+  if (hourlyRate === 0n) {
+    return { units: 0n, period: Number.POSITIVE_INFINITY };
+  }
+
   const period = MS_IN_HOUR / Number(hourlyRate);
 
   // The math below is equivalent to:

--- a/src/background/services/paymentManager.ts
+++ b/src/background/services/paymentManager.ts
@@ -340,6 +340,7 @@ export class PaymentManager {
   #iter: PeekAbleIterator<PaymentSession> | null = null;
 
   setRate(hourlyRate: AmountValue) {
+    const hourlyRateWasZero = this.hourlyRate === 0n;
     this.hourlyRate = BigInt(hourlyRate);
     this.interval = calculateInterval(this.hourlyRate);
 
@@ -351,6 +352,8 @@ export class PaymentManager {
       if (this.hourlyRate === 0n) {
         this.logger.debug('Pausing timer. Hourly rate is 0');
         this.timer.clear();
+      } else if (hourlyRateWasZero) {
+        void this.payNowAndScheduleNext();
       } else {
         this.timer.reset(this.interval.period);
       }
@@ -378,6 +381,10 @@ export class PaymentManager {
       this.logger.debug('Skip payment. Hourly rate is 0');
       return;
     }
+    await this.payNowAndScheduleNext();
+  }
+
+  private async payNowAndScheduleNext() {
     await this.preventOverpaying();
     if (this.#state !== 'active') {
       return;

--- a/tests/e2e/siteRate.spec.ts
+++ b/tests/e2e/siteRate.spec.ts
@@ -2,7 +2,7 @@ import { MIN_PAYMENT_WAIT } from '@/background/config';
 import { hostnameToSiteKey } from '@/background/services/rateList';
 import { getResponseOrThrow, type SiteRateEntry } from '@/shared/messages';
 import { test, expect } from './fixtures/connected';
-import { sendMessageToBackground } from './fixtures/helpers';
+import { type Background, sendMessageToBackground } from './fixtures/helpers';
 import {
   interceptPaymentCreateRequests,
   playgroundUrl,
@@ -79,10 +79,7 @@ test.describe('per-site rate – GET_DATA_POPUP', () => {
 
 test.describe('per-site rate – payment session', () => {
   test.beforeEach(async ({ background }) => {
-    await background.evaluate(
-      (rate) => chrome.storage.local.set({ rateOfPay: rate }),
-      GLOBAL_RATE,
-    );
+    await defineGlobalRate(background, GLOBAL_RATE);
   });
 
   test('site rate is used when a payment session starts', async ({
@@ -180,6 +177,142 @@ test.describe('per-site rate – payment session', () => {
     expect(revertedDebit).toBe(globalDebit);
   });
 });
+
+test.describe('per-site rate – zero rate', () => {
+  test('site rate 0 skips payments despite non-zero global rate', async ({
+    page,
+    context,
+    popup,
+    background,
+  }) => {
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await defineGlobalRate(background, GLOBAL_RATE);
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '0');
+    await setupPlayground(page, walletAddressUrl);
+
+    await context.clock.runFor(MIN_PAYMENT_WAIT * 5);
+    await page.waitForTimeout(2000);
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(0);
+  });
+
+  test('global rate 0 skips payments without a site override', async ({
+    page,
+    context,
+    popup,
+    background,
+  }) => {
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await defineGlobalRate(background, '0');
+    await setupPlayground(page, walletAddressUrl);
+
+    await expect(
+      popup.getByTestId('home-page'),
+      'monetized despite rate being 0',
+    ).toBeVisible();
+
+    await context.clock.runFor(MIN_PAYMENT_WAIT * 5);
+    await page.waitForTimeout(2000);
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(0);
+  });
+
+  test('site rate override keeps paying despite global rate 0', async ({
+    page,
+    context,
+    popup,
+    background,
+  }) => {
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await defineGlobalRate(background, '0');
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await setupPlayground(page, walletAddressUrl);
+
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(1, {
+      timeout: 10_000,
+    });
+  });
+
+  test('site rate 0 pauses active session; reverting resumes it', async ({
+    page,
+    context,
+    popup,
+    background,
+  }) => {
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await defineGlobalRate(background, GLOBAL_RATE);
+    await setupPlayground(page, walletAddressUrl);
+
+    await expect(outgoingPaymentCreatedCallback).toHaveBeenCalledTimes(1);
+
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, '0');
+    await context.clock.runFor(MIN_PAYMENT_WAIT * 5);
+    await page.waitForTimeout(2000);
+    await expect(
+      outgoingPaymentCreatedCallback,
+      'no new payment while rate is 0',
+    ).toHaveBeenCalledTimes(1);
+
+    await setSiteRate(popup, PLAYGROUND_HOSTNAME, SITE_RATE);
+    await context.clock.runFor(MIN_PAYMENT_WAIT);
+    await expect(
+      outgoingPaymentCreatedCallback,
+      'payments resume once rate is non-zero',
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  test('rate 0 to non-zero pays without a page refresh', async ({
+    page,
+    context,
+    popup,
+    background,
+  }) => {
+    const { outgoingPaymentCreatedCallback } =
+      interceptPaymentCreateRequests(context);
+
+    await defineGlobalRate(background, '0');
+    await setupPlayground(page, walletAddressUrl);
+    await expect(
+      popup.getByTestId('home-page'),
+      'monetized (active) despite rate being 0',
+    ).toBeVisible();
+    await context.clock.runFor(MIN_PAYMENT_WAIT * 5);
+    await expect(
+      outgoingPaymentCreatedCallback,
+      'no payment while rate is 0',
+    ).toHaveBeenCalledTimes(0);
+
+    const SLOW_RATE = '1';
+    await setGlobalRate(popup, SLOW_RATE);
+    await context.clock.runFor(MIN_PAYMENT_WAIT * 5);
+
+    await expect(
+      outgoingPaymentCreatedCallback,
+      'pays immediately once rate is non-zero, no refresh needed',
+    ).toHaveBeenCalledTimes(1, { timeout: 6000 });
+  });
+});
+
+async function defineGlobalRate(
+  background: Background,
+  rateOfPay: AmountValue,
+) {
+  await background.evaluate((rateOfPay) => {
+    return chrome.storage.local.set({ rateOfPay });
+  }, rateOfPay);
+}
+
+async function setGlobalRate(popup: Popup, rateOfPay: AmountValue) {
+  await sendMessageToBackground(popup, 'UPDATE_RATE_OF_PAY', {
+    rateOfPay,
+  }).then(getResponseOrThrow);
+}
 
 // TODO: we'll use UI interactions in the future.
 async function setSiteRate(


### PR DESCRIPTION
## Context

Closes https://github.com/interledger/web-monetization-extension/issues/1437

## Changes proposed in this pull request

With https://github.com/interledger/web-monetization-extension/issues/1297, rate of pay can be zero (either global or per-site).

- Handle zero rate for continuous payments.
- Add E2E tests
