### PR TITLE
docs(develop): add `GrantBalanceService` to documentation

### DIFF
--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -202,7 +202,7 @@ mindmap
 - **`GrantBalanceService`**:
   - Responsible for grant balance updates
   - Listens to created/completed payments and adjusts the balance
-  - Regularly queries "grant spent" endpoint and adjusts the balance
+  - Regularly queries the grant spent amounts endpoint and adjusts the balance
 
 #### Content scripts
 

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -199,6 +199,10 @@ mindmap
   - The backend part is for orchestration only.
 - **`EventsService`**:
   - A simple EventEmitter/pub-sub service
+- **`GrantBalanceService`**:
+  - Responsible for grant balance updates
+  - Listens to created/completed payments and adjusts the balance
+  - Regularly queries "grant spent" endpoint and adjusts the balance
 
 #### Content scripts
 


### PR DESCRIPTION
## Changes proposed in this pull request

This adds the `GrantBalanceService` to the list of services in the `DEVELOP.md` documentation.
