### PR TITLE
chore(ci): granular GitHub workflow permissions and routing secrets through env

### DIFF
--- a/.github/workflows/add_to_docs_board.yml
+++ b/.github/workflows/add_to_docs_board.yml
@@ -4,6 +4,8 @@ on:
     types:
       - labeled
 
+permissions: {}
+
 jobs:
   add-to-project:
     if: github.event.label.name == 'user-docs'

--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -7,6 +7,11 @@ on:
     workflows:
       - 'PR Checks'
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
 jobs:
   comment:
     name: Add comment with extension preview builds

--- a/.github/workflows/delete-pr-artifacts.yml
+++ b/.github/workflows/delete-pr-artifacts.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   delete:
     name: Delete artifacts

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -70,8 +70,10 @@ jobs:
         if: always()
         shell: bash
         working-directory: tests/e2e/playwright-report
+        env:
+          ZIP_PASSWORD: ${{ secrets.E2E_PLAYWRIGHT_REPORT_PASSWORD }}
         run: |
-          zip -r -P ${{ secrets.E2E_PLAYWRIGHT_REPORT_PASSWORD }} ../playwright-report.zip *
+          zip -r -P "$ZIP_PASSWORD" ../playwright-report.zip *
 
       - name: Upload report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   check-pr-title:
     name: Check PR Title

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -42,10 +42,11 @@ jobs:
             await script({ github, context, core })
 
       - name: Delete existing release # To keep the workflow idempotent.
-        run: gh release delete v${{ steps.version.outputs.version }}-preview --cleanup-tag --yes
+        run: gh release delete "v${RELEASE_VERSION}-preview" --cleanup-tag --yes
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Release
         uses: softprops/action-gh-release@v3.0.1

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -58,10 +58,11 @@ jobs:
             await script({ github, context, core })
 
       - name: Delete existing release # To keep the workflow idempotent.
-        run: gh release delete v${{ steps.version.outputs.version }} --cleanup-tag --yes
+        run: gh release delete "v${RELEASE_VERSION}" --cleanup-tag --yes
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Release
         uses: softprops/action-gh-release@v3.0.1

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'v[0-9]+.x'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build extension

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main, 'v[0-9]+.x']
 
+permissions:
+  contents: read
+
 jobs:
   filter:
     name: Prepare
@@ -83,8 +86,10 @@ jobs:
         if: always()
         shell: bash
         working-directory: tests/e2e/playwright-report
+        env:
+          ZIP_PASSWORD: ${{ secrets.E2E_PLAYWRIGHT_REPORT_PASSWORD }}
         run: |
-          zip -r -P ${{ secrets.E2E_PLAYWRIGHT_REPORT_PASSWORD }} ../playwright-report.zip *
+          zip -r -P "$ZIP_PASSWORD" ../playwright-report.zip *
 
       - name: Upload report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to the 7 workflows that previously had none. Each is scoped to only what its steps actually use.

Routes `${{ }}` values through `env` instead of interpolating them directly into the shell command. This closes a latent script-injection footgun.