### PR TITLE
perf(background): add minimal `Buffer` polyfill for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "posthog-js": "1.396.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "safe-buffer": "5.2.1",
     "structured-headers": "^2.0.2",
     "tailwind-merge": "^3.6.0",
     "valtio": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      safe-buffer:
-        specifier: 5.2.1
-        version: 5.2.1
       structured-headers:
         specifier: ^2.0.2
         version: 2.0.2

--- a/scripts/esbuild/plugins.ts
+++ b/scripts/esbuild/plugins.ts
@@ -30,7 +30,7 @@ export const getPlugins = ({
     // package, but we need it. We instead use custom crypto layer based on
     // @noble/hashes in for our use case. crypto-browserify and the JSPM crypto
     // package are too large and not tree shakeable, so we don't use them.
-    nodeBuiltin({ exclude: ['crypto'] }),
+    nodeBuiltin({ exclude: ['crypto', 'buffer'] }),
     {
       name: 'crypto-for-extension',
       setup(build) {

--- a/src/background/globalBuffer.ts
+++ b/src/background/globalBuffer.ts
@@ -1,3 +1,56 @@
-import { Buffer } from 'safe-buffer';
-// @ts-expect-error we know
-globalThis.Buffer = Buffer;
+/**
+ * Some dependencies reference the Node.js `Buffer` global, which doesn't exist
+ * in the browser. Adding a full polyfill adds too much to bundle size. We only
+ * need a subset (below), that can be built on top of `Uint8Array`.
+ */
+
+// @ts-expect-error our `from` is narrower than Uint8Array.from (fine here)
+class BufferPolyfill extends Uint8Array {
+  static isBuffer(value: unknown): value is BufferPolyfill {
+    return value instanceof BufferPolyfill;
+  }
+
+  static alloc(size: number): BufferPolyfill {
+    return new BufferPolyfill(size);
+  }
+
+  static from(
+    value: string | ArrayBuffer | ArrayLike<number>,
+    encoding?: string,
+  ): BufferPolyfill {
+    if (typeof value === 'string') {
+      return encodeString(value, encoding);
+    }
+    return new BufferPolyfill(value);
+  }
+
+  write(value: string, offset = 0): number {
+    const bytes = new TextEncoder().encode(value);
+    this.set(bytes, offset);
+    return bytes.length;
+  }
+
+  toString(encoding?: string): string {
+    if (encoding === 'base64') {
+      let binary = '';
+      for (const byte of this) binary += String.fromCharCode(byte);
+      return btoa(binary);
+    }
+    return new TextDecoder().decode(this);
+  }
+}
+
+function encodeString(value: string, encoding?: string): BufferPolyfill {
+  if (encoding === 'base64') {
+    const binary = atob(value);
+    const bytes = new BufferPolyfill(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  return new BufferPolyfill(new TextEncoder().encode(value));
+}
+
+// @ts-expect-error minimal Buffer shim for the browser build, see comment above
+globalThis.Buffer = BufferPolyfill;


### PR DESCRIPTION
## Context

See https://github.com/interledger/open-payments-node/issues/4
We don't need a full Buffer implementation.

## Changes proposed in this pull request

Add a minimal polyfill for Buffer global, remove `safe-buffer` dependency.
`dist/background/background.js` is 22KB smaller now.
