### PR TITLE
perf(pages/progress-connect): remove unused telemetry

### DIFF
--- a/src/pages/app/lib/context.tsx
+++ b/src/pages/app/lib/context.tsx
@@ -5,11 +5,8 @@ import {
   MessageManager,
   type AppToBackgroundMessage,
 } from '@/shared/messages';
-import {
-  TelemetryContextProvider,
-  useBrowser,
-  useTranslation,
-} from '@/pages/shared/lib/context';
+import { useBrowser, useTranslation } from '@/pages/shared/lib/context';
+import { TelemetryContextProvider } from '@/pages/shared/lib/telemetry';
 import { dispatch } from './store';
 
 export {

--- a/src/pages/popup/components/Settings/SettingsDataCollection.tsx
+++ b/src/pages/popup/components/Settings/SettingsDataCollection.tsx
@@ -4,9 +4,9 @@ import { SwitchButton } from '@/pages/shared/components/ui/Switch';
 import {
   useBrowser,
   useBrowserInfo,
-  useTelemetry,
   useTranslation,
 } from '@/pages/shared/lib/context';
+import { useTelemetry } from '@/pages/shared/lib/telemetry';
 import { dispatch, usePopupState } from '@/popup/lib/store';
 import { useMessage } from '@/popup/lib/context';
 import type { Browser } from '@/shared/browser';

--- a/src/pages/popup/lib/context.tsx
+++ b/src/pages/popup/lib/context.tsx
@@ -5,19 +5,16 @@ import {
   type PopupToBackgroundMessage,
   type BackgroundToPopupMessage,
 } from '@/shared/messages';
-import {
-  TelemetryContextProvider,
-  useBrowser,
-  useTranslation,
-} from '@/pages/shared/lib/context';
+import { useBrowser, useTranslation } from '@/pages/shared/lib/context';
+import { TelemetryContextProvider } from '@/pages/shared/lib/telemetry';
 import { dispatch } from './store';
 
 export {
   useBrowser,
   useBrowserInfo,
   useTranslation,
-  useTelemetry,
 } from '@/pages/shared/lib/context';
+export { useTelemetry } from '@/pages/shared/lib/telemetry';
 
 export function WaitForStateLoad({ children }: React.PropsWithChildren) {
   const t = useTranslation();

--- a/src/pages/progress-connect/components/AppFullScreen.tsx
+++ b/src/pages/progress-connect/components/AppFullScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState } from '@/pages/progress-connect/context';
-import { useBrowser } from '@/popup/lib/context';
+import { useBrowser } from '@/pages/shared/lib/context';
 import { Steps } from './Steps';
 
 export function AppFullscreen() {

--- a/src/pages/progress-connect/components/AppNotification.tsx
+++ b/src/pages/progress-connect/components/AppNotification.tsx
@@ -3,7 +3,7 @@ import { HeaderEmpty } from '@/popup/components/layout/HeaderEmpty';
 import { LoadingSpinner } from '@/pages/shared/components/LoadingSpinner';
 import { Countdown } from '@/pages/progress-connect/components/Countdown';
 import { useState } from '@/pages/progress-connect/context';
-import { useBrowser } from '@/popup/lib/context';
+import { useBrowser } from '@/pages/shared/lib/context';
 
 export function AppNotification() {
   const browser = useBrowser();

--- a/src/pages/progress-connect/context.tsx
+++ b/src/pages/progress-connect/context.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Runtime } from 'webextension-polyfill';
-import { useBrowser } from '@/popup/lib/context';
+import { useBrowser } from '@/pages/shared/lib/context';
 import type {
   KeyAutoAddToBackgroundMessage,
   StepWithStatus,

--- a/src/pages/shared/lib/context.tsx
+++ b/src/pages/shared/lib/context.tsx
@@ -1,6 +1,4 @@
 import React, { type PropsWithChildren } from 'react';
-import { PostHog } from 'posthog-js/dist/module.no-external';
-import { POSTHOG_KEY, POSTHOG_HOST } from '@/shared/defines';
 import type { Browser, Runtime } from 'webextension-polyfill';
 import {
   getBrowserName,
@@ -9,7 +7,6 @@ import {
   type ErrorWithKeyLike,
   type Translation,
 } from '@/shared/helpers';
-import type { Storage } from '@/shared/types';
 
 // #region Browser
 const BrowserContext = React.createContext<Browser>({} as Browser);
@@ -75,118 +72,4 @@ export const TranslationContextProvider = ({ children }: PropsWithChildren) => {
     </TranslationContext.Provider>
   );
 };
-// #endregion
-
-// #region Telemetry
-
-// Reduce dependency on full PostHog SDK as we only wish to use a few things.
-type Telemetry = {
-  capture: PostHog['capture'];
-  captureException: PostHog['captureException'];
-  optInOut: (isOptedIn: boolean) => void;
-  register: (
-    properties: Parameters<PostHog['register']>[0],
-  ) => ReturnType<PostHog['register']>;
-};
-
-const mockTelemetry: Telemetry = {
-  capture: () => void 0,
-  captureException: () => void 0,
-  optInOut: () => {},
-  register: () => void 0,
-};
-const TelemetryContext = React.createContext<Telemetry>(mockTelemetry);
-
-const setupPosthog = (distinctId: string, isOptedIn: boolean) => {
-  return new PostHog().init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
-    opt_out_capturing_by_default: !isOptedIn,
-    opt_out_persistence_by_default: true,
-    autocapture: true,
-    capture_pageview: 'history_change',
-    capture_pageleave: 'if_capture_pageview',
-    persistence: 'localStorage',
-    bootstrap: {
-      distinctID: distinctId,
-      // Prevent fetching feature flags.
-      featureFlags: {},
-      featureFlagPayloads: {},
-      // We don't identify users, so marks as identified to avoid API requests.
-      isIdentifiedID: true,
-    },
-    before_send(event) {
-      if (!event) return null;
-      // We use hash-based routing, so ensure hashes are tracked.
-      if (event.properties?.$current_url) {
-        const parsed = new URL(event.properties.$current_url);
-        if (parsed.hash) {
-          event.properties.$pathname = parsed.pathname + parsed.hash;
-        }
-      }
-      return event;
-    },
-    disable_external_dependency_loading: true,
-    disable_session_recording: true,
-    disable_surveys: true,
-    capture_performance: false,
-    capture_heatmaps: false,
-    // Prevent fetching flags and along with it, any remote config.
-    advanced_disable_flags: true,
-  });
-};
-
-export const TelemetryContextProvider = ({
-  uid,
-  continuousPaymentsEnabled,
-  isOptedIn,
-  children,
-}: React.PropsWithChildren<{
-  uid: string;
-  continuousPaymentsEnabled?: Storage['continuousPaymentsEnabled'];
-  isOptedIn?: Storage['consentTelemetry'];
-}>) => {
-  const browser = useBrowser();
-  if (!POSTHOG_KEY) {
-    // biome-ignore lint/suspicious/noConsole: It is always added in production builds, so it's safe. Warning here helps us debug better.
-    console.warn('PostHog key not found. Telemetry will not be enabled.');
-    return (
-      <TelemetryContext.Provider value={mockTelemetry}>
-        {children}
-      </TelemetryContext.Provider>
-    );
-  }
-
-  // While isOptedIn is undefined or false, we won't capture data.
-  const posthog = setupPosthog(uid, isOptedIn === true);
-  const { name, version, version_name } = browser.runtime.getManifest();
-  posthog.register({
-    app_name: name,
-    version,
-    version_name,
-    continuousPaymentsEnabled,
-  });
-
-  const telemetry: Telemetry = {
-    capture: posthog.capture.bind(posthog),
-    captureException: posthog.captureException.bind(posthog),
-    optInOut(isOptedIn) {
-      if (isOptedIn) {
-        posthog.opt_in_capturing();
-      } else {
-        posthog.opt_out_capturing();
-      }
-    },
-    register(properties) {
-      return posthog.register(properties);
-    },
-  };
-
-  return (
-    <TelemetryContext.Provider value={telemetry}>
-      {children}
-    </TelemetryContext.Provider>
-  );
-};
-
-export const useTelemetry = () => React.useContext(TelemetryContext);
 // #endregion

--- a/src/pages/shared/lib/telemetry.tsx
+++ b/src/pages/shared/lib/telemetry.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { PostHog } from 'posthog-js/dist/module.no-external';
+import { POSTHOG_KEY, POSTHOG_HOST } from '@/shared/defines';
+import { useBrowser } from '@/pages/shared/lib/context';
+import type { Storage } from '@/shared/types';
+
+// Reduce dependency on full PostHog SDK as we only wish to use a few things.
+type Telemetry = {
+  capture: PostHog['capture'];
+  captureException: PostHog['captureException'];
+  optInOut: (isOptedIn: boolean) => void;
+  register: (
+    properties: Parameters<PostHog['register']>[0],
+  ) => ReturnType<PostHog['register']>;
+};
+
+const mockTelemetry: Telemetry = {
+  capture: () => void 0,
+  captureException: () => void 0,
+  optInOut: () => {},
+  register: () => void 0,
+};
+const TelemetryContext = React.createContext<Telemetry>(mockTelemetry);
+
+const setupPosthog = (distinctId: string, isOptedIn: boolean) => {
+  return new PostHog().init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    opt_out_capturing_by_default: !isOptedIn,
+    opt_out_persistence_by_default: true,
+    autocapture: true,
+    capture_pageview: 'history_change',
+    capture_pageleave: 'if_capture_pageview',
+    persistence: 'localStorage',
+    bootstrap: {
+      distinctID: distinctId,
+      // Prevent fetching feature flags.
+      featureFlags: {},
+      featureFlagPayloads: {},
+      // We don't identify users, so marks as identified to avoid API requests.
+      isIdentifiedID: true,
+    },
+    before_send(event) {
+      if (!event) return null;
+      // We use hash-based routing, so ensure hashes are tracked.
+      if (event.properties?.$current_url) {
+        const parsed = new URL(event.properties.$current_url);
+        if (parsed.hash) {
+          event.properties.$pathname = parsed.pathname + parsed.hash;
+        }
+      }
+      return event;
+    },
+    disable_external_dependency_loading: true,
+    disable_session_recording: true,
+    disable_surveys: true,
+    capture_performance: false,
+    capture_heatmaps: false,
+    // Prevent fetching flags and along with it, any remote config.
+    advanced_disable_flags: true,
+  });
+};
+
+export const TelemetryContextProvider = ({
+  uid,
+  continuousPaymentsEnabled,
+  isOptedIn,
+  children,
+}: React.PropsWithChildren<{
+  uid: string;
+  continuousPaymentsEnabled?: Storage['continuousPaymentsEnabled'];
+  isOptedIn?: Storage['consentTelemetry'];
+}>) => {
+  const browser = useBrowser();
+  if (!POSTHOG_KEY) {
+    // biome-ignore lint/suspicious/noConsole: It is always added in production builds, so it's safe. Warning here helps us debug better.
+    console.warn('PostHog key not found. Telemetry will not be enabled.');
+    return (
+      <TelemetryContext.Provider value={mockTelemetry}>
+        {children}
+      </TelemetryContext.Provider>
+    );
+  }
+
+  // While isOptedIn is undefined or false, we won't capture data.
+  const posthog = setupPosthog(uid, isOptedIn === true);
+  const { name, version, version_name } = browser.runtime.getManifest();
+  posthog.register({
+    app_name: name,
+    version,
+    version_name,
+    continuousPaymentsEnabled,
+  });
+
+  const telemetry: Telemetry = {
+    capture: posthog.capture.bind(posthog),
+    captureException: posthog.captureException.bind(posthog),
+    optInOut(isOptedIn) {
+      if (isOptedIn) {
+        posthog.opt_in_capturing();
+      } else {
+        posthog.opt_out_capturing();
+      }
+    },
+    register(properties) {
+      return posthog.register(properties);
+    },
+  };
+
+  return (
+    <TelemetryContext.Provider value={telemetry}>
+      {children}
+    </TelemetryContext.Provider>
+  );
+};
+
+export const useTelemetry = () => React.useContext(TelemetryContext);


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

`pages/progress-connect/progress-connect.js` was importing from shared context.tsx, which imported PostHog. Even though, this particular page doesn't include telemetry (as not required, not user interactive). This added around 230KB to bundle size for `progress-connect.js`.

## Changes proposed in this pull request

- Split telemetry context to separate file and import only in pages its used.
- Update some other imports (like progress-connect importing re-exports from popup context instead of directly from shared)
