### PR TITLE
fix(polyfill): expose `MonetizationCurrencyAmount` without constructor

### DIFF
--- a/scripts/esbuild/prod.ts
+++ b/scripts/esbuild/prod.ts
@@ -89,35 +89,45 @@ function zipPlugin({
 }
 
 /**
- * Unmangles the MonetizationEvent class
+ * Unmangles the MonetizationEvent and MonetizationCurrencyAmount classes
  */
 function preservePolyfillClassNamesPlugin({
   outDir,
 }: {
   outDir: string;
 }): ESBuildPlugin {
+  const classNames = ['MonetizationEvent', 'MonetizationCurrencyAmount'];
   return {
     name: 'preserve-polyfill-class-names',
     setup(build) {
       build.onEnd(async () => {
         const polyfillPath = path.join(outDir, 'polyfill', 'polyfill.js');
-        const polyfillContent = await fs.readFile(polyfillPath, 'utf8');
-        const definitionRegex = /class\s+([A-Za-z_$][\w$]*)\s+extends\s+Event/;
+        let result = await fs.readFile(polyfillPath, 'utf8');
 
-        const match = polyfillContent.match(definitionRegex);
-        if (!match) {
-          throw new Error('Could not find MonetizationEvent definition');
+        for (const className of classNames) {
+          const assignmentRegex = new RegExp(
+            `window\\.${className}=([A-Za-z_$][\\w$]*)`,
+          );
+          const match = result.match(assignmentRegex);
+          if (!match) {
+            throw new Error(`Could not find ${className} definition`);
+          }
+
+          const minifiedName = match[1];
+          result = result
+            .replace(
+              new RegExp(`\\bclass\\s+${minifiedName}\\b`),
+              `class ${className}`,
+            )
+            .replace(
+              new RegExp(`window\\.${className}=${minifiedName}\\b`),
+              `window.${className}=${className}`,
+            )
+            .replace(
+              new RegExp(`\\bnew ${minifiedName}\\b`, 'g'),
+              `new ${className}`,
+            );
         }
-
-        const minifiedName = match[1];
-
-        const result = polyfillContent
-          .replace(definitionRegex, 'class MonetizationEvent extends Event')
-          .replace(
-            `window.MonetizationEvent=${minifiedName}`,
-            'window.MonetizationEvent=MonetizationEvent',
-          )
-          .replaceAll(`new ${minifiedName}`, 'new MonetizationEvent');
 
         await fs.writeFile(polyfillPath, result);
       });

--- a/src/content/polyfill.ts
+++ b/src/content/polyfill.ts
@@ -66,23 +66,15 @@ import type { MonetizationEventPayload } from '@/shared/messages';
 
   const illegalConstructor = Symbol('illegalConstructor');
   class MonetizationCurrencyAmount {
-    #currency: string;
-    #value: string;
+    public readonly currency: string;
+    public readonly value: string;
 
     constructor(currency: string, value: string, key?: symbol) {
       if (key !== illegalConstructor) {
         throw new TypeError('Illegal constructor');
       }
-      this.#currency = currency;
-      this.#value = value;
-    }
-
-    get currency() {
-      return this.#currency;
-    }
-
-    get value() {
-      return this.#value;
+      this.currency = currency;
+      this.value = value;
     }
 
     get [Symbol.toStringTag]() {

--- a/src/content/polyfill.ts
+++ b/src/content/polyfill.ts
@@ -64,9 +64,41 @@ import type { MonetizationEventPayload } from '@/shared/messages';
   Object.defineProperty(Window.prototype, 'onmonetization', attributes);
   Object.defineProperty(Document.prototype, 'onmonetization', attributes);
 
+  const illegalConstructor = Symbol('illegalConstructor');
+  class MonetizationCurrencyAmount {
+    #currency: string;
+    #value: string;
+
+    constructor(currency: string, value: string, key?: symbol) {
+      if (key !== illegalConstructor) {
+        throw new TypeError('Illegal constructor');
+      }
+      this.#currency = currency;
+      this.#value = value;
+    }
+
+    get currency() {
+      return this.#currency;
+    }
+
+    get value() {
+      return this.#value;
+    }
+
+    get [Symbol.toStringTag]() {
+      return 'MonetizationCurrencyAmount';
+    }
+  }
+
+  const createMonetizationCurrencyAmount = (currency: string, value: string) =>
+    new MonetizationCurrencyAmount(currency, value, illegalConstructor);
+
+  // @ts-expect-error: we're defining this now
+  window.MonetizationCurrencyAmount = MonetizationCurrencyAmount;
+
   let eventDetailDeprecationEmitted = false;
   class MonetizationEvent extends Event {
-    public readonly amountSent: PaymentCurrencyAmount;
+    public readonly amountSent: MonetizationCurrencyAmount;
     public readonly incomingPayment: string;
     public readonly paymentPointer: string;
 
@@ -76,7 +108,10 @@ import type { MonetizationEventPayload } from '@/shared/messages';
     ) {
       super(type, { bubbles: true });
       const { amountSent, incomingPayment, paymentPointer } = eventInitDict;
-      this.amountSent = amountSent;
+      this.amountSent = createMonetizationCurrencyAmount(
+        amountSent.currency,
+        amountSent.value,
+      );
       this.incomingPayment = incomingPayment;
       this.paymentPointer = paymentPointer;
     }


### PR DESCRIPTION
## Context

Closes #501.

## Changes proposed in this pull request

This exposes `MonetizationCurrencyAmount` to `window`. We could use [LegacyNoInterfaceObject](https://webidl.spec.whatwg.org/#LegacyNoInterfaceObject), however it [should not be used for new APIs](https://webidl.spec.whatwg.org/#js-legacy-extended-attributes). Therefore we expose it, but do not allow construction.
