### PR TITLE
fix(keyAutoAdd/testWallet): use correct `API_ORIGIN`

### DIFF
--- a/src/content/keyAutoAdd/testWallet.ts
+++ b/src/content/keyAutoAdd/testWallet.ts
@@ -35,7 +35,7 @@ const IS_INTERLEDGER_CARDS = location.host === 'wallet.interledger.cards';
 
 const API_ORIGIN = IS_INTERLEDGER_CARDS
   ? 'https://api.interledger.cards'
-  : `https://api.${location.host}`;
+  : `https://api-${location.host}`;
 
 const waitForLogin: Run<void> = async (
   { keyAddUrl },

--- a/tests/e2e/connectAutoKeyTestWallet.spec.ts
+++ b/tests/e2e/connectAutoKeyTestWallet.spec.ts
@@ -54,7 +54,7 @@ for (const testCase of TEST_CASES) {
     const API_URL_ORIGIN =
       origin === 'https://wallet.interledger.cards'
         ? origin.replace('https://wallet.', 'https://api.')
-        : origin.replace('https://wallet.', 'https://api.wallet.');
+        : origin.replace('https://wallet.', 'https://api-wallet.');
 
     test(testCase.name, async ({ page, popup, context, background, i18n }) => {
       if (!username || !password || !walletAddressUrl) return;

--- a/tests/e2e/helpers/testWallet.ts
+++ b/tests/e2e/helpers/testWallet.ts
@@ -10,7 +10,7 @@ import { getContinueWaitTime, waitForWelcomePage } from './common';
 import { revokeKey as revokeKeyApi } from '@/content/keyAutoAdd/lib/helpers/testWallet';
 
 export const TEST_WALLET_ORIGIN = 'https://wallet.interledger-test.dev';
-export const API_URL_ORIGIN = 'https://api.wallet.interledger-test.dev';
+export const API_URL_ORIGIN = 'https://api-wallet.interledger-test.dev';
 export const KEYS_PAGE_URL = `${TEST_WALLET_ORIGIN}/settings/developer-keys`;
 export const LOGIN_PAGE_URL = `${TEST_WALLET_ORIGIN}/auth/login?callbackUrl=${encodeURIComponent('/settings/developer-keys')}`;
 


### PR DESCRIPTION
<!--
Pull request titles should follow conventional commit format.
https://www.conventionalcommits.org/en/v1.0.0/
-->

## Context

E2E tests are failing since few days. The test wallet changed the API origin.

## Changes proposed in this pull request

Use correct API origin so key upload step doesn't fail.